### PR TITLE
HAL-1454 Unable to edit Transaction's Process ID Socket Max Ports

### DIFF
--- a/app/src/main/java/org/jboss/hal/client/configuration/subsystem/transaction/TransactionPresenter.java
+++ b/app/src/main/java/org/jboss/hal/client/configuration/subsystem/transaction/TransactionPresenter.java
@@ -15,20 +15,12 @@
  */
 package org.jboss.hal.client.configuration.subsystem.transaction;
 
-import java.util.Map;
-
 import javax.inject.Inject;
 
-import com.google.common.base.Strings;
 import com.google.web.bindery.event.shared.EventBus;
 import com.gwtplatform.mvp.client.annotations.NameToken;
 import com.gwtplatform.mvp.client.annotations.ProxyCodeSplit;
 import com.gwtplatform.mvp.client.proxy.ProxyPlace;
-import org.jboss.hal.ballroom.form.Form;
-import org.jboss.hal.ballroom.form.Form.FinishReset;
-import org.jboss.hal.ballroom.form.FormItem;
-import org.jboss.hal.ballroom.form.FormValidation;
-import org.jboss.hal.ballroom.form.ValidationResult;
 import org.jboss.hal.core.CrudOperations;
 import org.jboss.hal.core.finder.Finder;
 import org.jboss.hal.core.finder.FinderPath;
@@ -36,46 +28,23 @@ import org.jboss.hal.core.finder.FinderPathFactory;
 import org.jboss.hal.core.mbui.MbuiPresenter;
 import org.jboss.hal.core.mbui.MbuiView;
 import org.jboss.hal.core.mvp.SupportsExpertMode;
-import org.jboss.hal.dmr.Composite;
-import org.jboss.hal.dmr.CompositeResult;
 import org.jboss.hal.dmr.ModelDescriptionConstants;
 import org.jboss.hal.dmr.ModelNode;
-import org.jboss.hal.dmr.Operation;
 import org.jboss.hal.dmr.ResourceAddress;
-import org.jboss.hal.dmr.dispatch.Dispatcher;
-import org.jboss.hal.meta.Metadata;
-import org.jboss.hal.meta.MetadataRegistry;
 import org.jboss.hal.meta.StatementContext;
 import org.jboss.hal.meta.token.NameTokens;
-import org.jboss.hal.resources.Resources;
-import org.jboss.hal.spi.Message;
-import org.jboss.hal.spi.MessageEvent;
 import org.jboss.hal.spi.Requires;
 
 import static org.jboss.hal.client.configuration.subsystem.transaction.AddressTemplates.TRANSACTIONS_SUBSYSTEM_ADDRESS;
 import static org.jboss.hal.client.configuration.subsystem.transaction.AddressTemplates.TRANSACTIONS_SUBSYSTEM_TEMPLATE;
-import static org.jboss.hal.dmr.ModelDescriptionConstants.NAME;
-import static org.jboss.hal.dmr.ModelDescriptionConstants.UNDEFINE_ATTRIBUTE_OPERATION;
-import static org.jboss.hal.dmr.ModelDescriptionConstants.VALUE;
-import static org.jboss.hal.dmr.ModelDescriptionConstants.WRITE_ATTRIBUTE_OPERATION;
 
-/** TODO I18n for error / validation messages */
 public class TransactionPresenter
         extends MbuiPresenter<TransactionPresenter.MyView, TransactionPresenter.MyProxy>
         implements SupportsExpertMode {
 
-    private static final String PROCESS_ID_UUID = "process-id-uuid";
-    private static final String PROCESS_ID_SOCKET_BINDING = "process-id-socket-binding";
-    private static final String PROCESS_ID_SOCKET_MAX_PORTS = "process-id-socket-max-ports";
-    private static final ValidationResult invalid = ValidationResult
-            .invalid("Validation error, see error messages below.");
-
     private final CrudOperations crud;
     private final FinderPathFactory finderPathFactory;
     private final StatementContext statementContext;
-    private final Dispatcher dispatcher;
-    private final MetadataRegistry metadataRegistry;
-    private final Resources resources;
 
     @Inject
     public TransactionPresenter(EventBus eventBus,
@@ -84,17 +53,11 @@ public class TransactionPresenter
             Finder finder,
             CrudOperations crud,
             FinderPathFactory finderPathFactory,
-            StatementContext statementContext,
-            Dispatcher dispatcher,
-            MetadataRegistry metadataRegistry,
-            Resources resources) {
+            StatementContext statementContext) {
         super(eventBus, view, proxy, finder);
         this.crud = crud;
         this.finderPathFactory = finderPathFactory;
         this.statementContext = statementContext;
-        this.dispatcher = dispatcher;
-        this.metadataRegistry = metadataRegistry;
-        this.resources = resources;
     }
 
     @Override
@@ -117,200 +80,6 @@ public class TransactionPresenter
     protected void reload() {
         crud.read(TRANSACTIONS_SUBSYSTEM_TEMPLATE, 1, result -> getView().updateConfiguration(result));
     }
-
-    // The process form, contains attributes that must have some special treatment before save operation
-    // the process-uuid and process-id-socket-binding are mutually exclusive
-    // this is called from process-form in TransactionView.mbui.xml
-    void saveProcessForm(Form<ModelNode> form, Map<String, Object> changeSet) {
-        if (!changeSet.isEmpty()) {
-            Boolean uuid;
-            String socketBinding;
-            Integer maxPorts;
-
-            if (changeSet.containsKey(PROCESS_ID_UUID)) {
-                uuid = (Boolean) changeSet.get(PROCESS_ID_UUID);
-            } else {
-                // if not in changeSet, get current value from edited entity
-                uuid = form.getModel().get(PROCESS_ID_UUID).asBoolean();
-            }
-
-            if (changeSet.containsKey(PROCESS_ID_SOCKET_BINDING)) {
-                socketBinding = (String) changeSet.get(PROCESS_ID_SOCKET_BINDING);
-            } else {
-                socketBinding = form.getModel().get(PROCESS_ID_SOCKET_BINDING).isDefined() ?
-                        form.getModel().get(PROCESS_ID_SOCKET_BINDING).asString() : null;
-            }
-
-            if (changeSet.containsKey(PROCESS_ID_SOCKET_MAX_PORTS)) {
-                maxPorts = (Integer) changeSet.get(PROCESS_ID_SOCKET_MAX_PORTS);
-            } else {
-                maxPorts = form.getModel().get(PROCESS_ID_SOCKET_MAX_PORTS).isDefined() ?
-                        form.getModel().get(PROCESS_ID_SOCKET_MAX_PORTS).asInt() : null;
-            }
-
-            boolean socketBindingEmpty = socketBinding == null || socketBinding.trim().length() == 0;
-
-            if (uuid != null && socketBindingEmpty) {
-                switchToUuid();
-            } else if (!socketBindingEmpty && (uuid == null || !uuid)) {
-                switchToSocketBinding(socketBinding, maxPorts);
-            } else {
-                MessageEvent.fire(getEventBus(),
-                        Message.error(resources.messages().transactionSetUuidOrSocket()));
-            }
-        }
-    }
-
-    void resetProcessForm(Form<ModelNode> form) {
-        Metadata metadata = metadataRegistry.lookup(TRANSACTIONS_SUBSYSTEM_TEMPLATE);
-        ResourceAddress address = TRANSACTIONS_SUBSYSTEM_TEMPLATE.resolve(statementContext);
-        crud.resetSingleton("Process", address, form, metadata, new FinishReset<ModelNode>(form) {
-            @Override
-            public void afterReset(Form<ModelNode> form) {
-                reload();
-            }
-        });
-    }
-
-    private void switchToUuid() {
-        ResourceAddress address = TRANSACTIONS_SUBSYSTEM_TEMPLATE.resolve(statementContext);
-        Operation op = new Operation.Builder(address, WRITE_ATTRIBUTE_OPERATION)
-                .param(NAME, PROCESS_ID_UUID)
-                .param(VALUE, true)
-                .build();
-        dispatcher.execute(op, result -> {
-            if (result.isFailure()) {
-                MessageEvent.fire(getEventBus(),
-                        Message.error(resources.messages().transactionUnableSetProcessId(),
-                                result.getFailureDescription()));
-            } else {
-                MessageEvent.fire(getEventBus(),
-                        Message.success(resources.messages().modifySingleResourceSuccess("Process")));
-                reload();
-            }
-        });
-    }
-
-    private void switchToSocketBinding(String socketBinding, Integer maxPorts) {
-        Composite composite;
-        ResourceAddress address = TRANSACTIONS_SUBSYSTEM_TEMPLATE.resolve(statementContext);
-
-        Operation writeSocketBinding = new Operation.Builder(address, WRITE_ATTRIBUTE_OPERATION)
-                .param(NAME, PROCESS_ID_SOCKET_BINDING)
-                .param(VALUE, socketBinding)
-                .build();
-
-        Operation undefineUuid = new Operation.Builder(address, UNDEFINE_ATTRIBUTE_OPERATION)
-                .param(NAME, PROCESS_ID_UUID)
-                .build();
-
-        if (maxPorts != null) {
-            Operation writeMaxPorts = new Operation.Builder(address, WRITE_ATTRIBUTE_OPERATION)
-                    .param(NAME, PROCESS_ID_SOCKET_MAX_PORTS)
-                    .param(VALUE, maxPorts)
-                    .build();
-            composite = new Composite(undefineUuid, writeSocketBinding, writeMaxPorts);
-        } else {
-            composite = new Composite(undefineUuid, writeSocketBinding);
-        }
-
-        dispatcher.execute(composite, (CompositeResult result) -> {
-
-            ModelNode writeSocketResult = result.step(0);
-            ModelNode undefineUuidResult = result.step(1);
-
-            boolean failed = writeSocketResult.isFailure() || undefineUuidResult.isFailure();
-            if (failed) {
-                String failMessage = writeSocketBinding.isFailure() ? writeSocketBinding.getFailureDescription()
-                        : undefineUuidResult.getFailureDescription();
-                MessageEvent.fire(getEventBus(),
-                        Message.error(resources.messages().transactionUnableSetProcessId(), failMessage));
-            } else {
-                MessageEvent.fire(getEventBus(),
-                        Message.success(resources.messages().modifySingleResourceSuccess("Process")));
-                reload();
-            }
-        });
-    }
-
-    private FormValidation<ModelNode> attributesFormValidation = form -> {
-
-        final FormItem<Boolean> journalStoreEnableAsyncIoItem = form
-                .getFormItem("journal-store-enable-async-io");
-        final FormItem<Boolean> useJournalStoreItem = form.getFormItem("use-journal-store");
-
-        ValidationResult validationResult = ValidationResult.OK;
-
-        if (journalStoreEnableAsyncIoItem != null) {
-            final boolean journalStoreEnableAsyncIo = journalStoreEnableAsyncIoItem
-                    .getValue() != null && journalStoreEnableAsyncIoItem.getValue();
-            final boolean useJournalStore = useJournalStoreItem != null && useJournalStoreItem
-                    .getValue() != null && useJournalStoreItem.getValue();
-
-            if (journalStoreEnableAsyncIo && !useJournalStore) {
-                useJournalStoreItem
-                        .showError("Journal store needs to be enabled before enabling asynchronous IO.");
-                validationResult = invalid;
-            }
-        }
-        return validationResult;
-    };
-
-    private FormValidation<ModelNode> processFormValidation = form -> {
-
-        ValidationResult validationResult = ValidationResult.OK;
-        FormItem<Boolean> uuidItem = form.getFormItem(PROCESS_ID_UUID);
-        FormItem<String> socketBindingItem = form.getFormItem(PROCESS_ID_SOCKET_BINDING);
-        FormItem<Number> socketMaxPortsItem = form.getFormItem(PROCESS_ID_SOCKET_MAX_PORTS);
-        if (uuidItem != null && socketBindingItem != null) {
-            boolean uuidGiven = uuidItem.getValue() != null && uuidItem.getValue();
-            String socketBinding = Strings.emptyToNull(socketBindingItem.getValue());
-
-            if ((uuidGiven && socketBinding != null) || (!uuidGiven && socketBinding == null)) {
-                socketBindingItem.showError("Please set either UUID or socket binding");
-                validationResult = ValidationResult.invalid("Validation error, see error messages below.");
-            }
-        }
-        if (socketBindingItem != null && socketMaxPortsItem != null) {
-            String socketBinding = Strings.emptyToNull(socketBindingItem.getValue());
-            Number socketMaxPorts = socketMaxPortsItem.getValue();
-
-            if (socketBinding == null && socketMaxPorts != null && socketMaxPortsItem.isModified()) {
-                socketMaxPortsItem.showError("Can't be set if socket binding is not set");
-                validationResult = invalid;
-            }
-        }
-        return validationResult;
-    };
-
-    private FormValidation<ModelNode> jdbcFormValidation = form -> {
-
-        ValidationResult validationResult = ValidationResult.OK;
-
-        final FormItem<Boolean> useJdbc = form.getFormItem("use-jdbc-store");
-        final FormItem<String> datasource = form.getFormItem("jdbc-store-datasource");
-
-        if (useJdbc != null && useJdbc.getValue()) {
-            if (datasource == null || datasource.getValue() == null || datasource.getValue().isEmpty()) {
-                datasource.showError("Please provide datasource JNDI name if using jdbc store.");
-                validationResult = invalid;
-            }
-        }
-        return validationResult;
-    };
-
-    FormValidation<ModelNode> getAttributesFormValidation() {
-        return attributesFormValidation;
-    }
-
-    FormValidation<ModelNode> getProcessFormValidation() {
-        return processFormValidation;
-    }
-
-    FormValidation<ModelNode> getJdbcFormValidation() {
-        return jdbcFormValidation;
-    }
-
 
     // @formatter:off
     @ProxyCodeSplit

--- a/app/src/main/java/org/jboss/hal/client/configuration/subsystem/transaction/TransactionView.java
+++ b/app/src/main/java/org/jboss/hal/client/configuration/subsystem/transaction/TransactionView.java
@@ -15,13 +15,21 @@
  */
 package org.jboss.hal.client.configuration.subsystem.transaction;
 
+import java.util.Collections;
+
 import org.jboss.hal.ballroom.VerticalNavigation;
 import org.jboss.hal.ballroom.form.Form;
+import org.jboss.hal.ballroom.form.FormItem;
 import org.jboss.hal.core.mbui.MbuiContext;
 import org.jboss.hal.core.mbui.MbuiViewImpl;
+import org.jboss.hal.core.mbui.form.ModelNodeForm;
+import org.jboss.hal.core.mbui.form.RequiredByValidation;
 import org.jboss.hal.dmr.ModelNode;
 import org.jboss.hal.spi.MbuiElement;
 import org.jboss.hal.spi.MbuiView;
+
+import static org.jboss.hal.dmr.ModelDescriptionConstants.PROCESS_ID_SOCKET_BINDING;
+import static org.jboss.hal.dmr.ModelDescriptionConstants.PROCESS_ID_SOCKET_MAX_PORTS;
 
 @MbuiView
 @SuppressWarnings({"DuplicateStringLiteralInspection", "HardCodedStringLiteral", "WeakerAccess"})
@@ -49,17 +57,14 @@ public abstract class TransactionView extends MbuiViewImpl<TransactionPresenter>
     public void setPresenter(final TransactionPresenter presenter) {
         super.setPresenter(presenter);
 
-        // set the process fields as not required, because uuid and socket-binding are mutually exclusive.
-        processForm.getBoundFormItems().forEach(formItem -> formItem.setRequired(false));
-
-        // --------------- form validation for the general attributes
-        attributesForm.addFormValidation(presenter.getAttributesFormValidation());
-
-        // --------------- form validation for the process attributes
-        processForm.addFormValidation(presenter.getProcessFormValidation());
-
-        // --------------- form validation for the jdbc attributes
-        jdbcForm.addFormValidation(presenter.getJdbcFormValidation());
+        // process-id-socket-max-ports requires process-id-socket-binding, but as process-id-socket-binding is a required
+        // attribute, the "requires" validation handler in ModelNodeForm only elects them for validation if it is
+        // a non-required attribute
+        FormItem<String> socketBindingItem = processForm.getFormItem(PROCESS_ID_SOCKET_BINDING);
+        socketBindingItem.addValidationHandler(
+                new RequiredByValidation<>(socketBindingItem, Collections.singletonList(PROCESS_ID_SOCKET_MAX_PORTS),
+                        ((ModelNodeForm) processForm), mbuiContext.resources().constants(),
+                        mbuiContext.resources().messages()));
     }
 
     @Override

--- a/app/src/main/resources/org/jboss/hal/client/configuration/subsystem/transaction/TransactionView.mbui.xml
+++ b/app/src/main/resources/org/jboss/hal/client/configuration/subsystem/transaction/TransactionView.mbui.xml
@@ -40,9 +40,7 @@
             <metadata address="/{selected.profile}/subsystem=transactions">
                 <h1>Process ID</h1>
                 <p>${metadata.getDescription().getDescription()}</p>
-                <form id="tx-process-form" title="Process ID"
-                      on-save="${presenter.saveProcessForm(form, changedValues)}"
-                      prepare-reset="${presenter.resetProcessForm(form)}">
+                <form id="tx-process-form" title="Process ID" auto-save="true" reset="true">
                     <attributes>
                         <attribute name="process-id-uuid"/>
                         <attribute name="process-id-socket-binding">

--- a/core/src/main/java/org/jboss/hal/core/OperationFactory.java
+++ b/core/src/main/java/org/jboss/hal/core/OperationFactory.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.TreeSet;
 import java.util.function.Function;
 
 import com.google.common.base.Strings;
@@ -46,6 +47,7 @@ import static java.util.stream.Collectors.groupingBy;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toMap;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.*;
+import static org.jboss.hal.dmr.ModelNodeHelper.failSafeList;
 
 public class OperationFactory {
 
@@ -198,6 +200,21 @@ public class OperationFactory {
         List<Operation> operations = new ArrayList<>();
         ResourceDescription description = metadata.getDescription();
 
+        // collect all attributes from the 'requires' list of this attribute
+        // HashMultimap<String, String> requires = HashMultimap.create();
+        final TreeSet<String> requires = new TreeSet<>();
+        ModelNode attributesDescription = description.get(ATTRIBUTES);
+        attributes.forEach(attribute -> {
+            ModelNode attributeDescription = attributesDescription.get(attribute);
+            if (attributeDescription != null && attributeDescription.hasDefined(REQUIRES)) {
+                failSafeList(attributeDescription, REQUIRES).forEach(node -> requires.add(node.asString()));
+                        /*.map(ModelNode::asString)
+                        .forEach(requiresName -> {
+                            requires.add(requiresName);
+                        });*/
+            }
+        });
+
         attributes.stream()
                 .map(attribute -> description.findAttribute(ATTRIBUTES, attribute))
                 .filter(Objects::nonNull)
@@ -209,8 +226,9 @@ public class OperationFactory {
                             READ_ONLY.equals(attributeDescription.get(ACCESS_TYPE).asString());
                     boolean alternatives = attributeDescription.hasDefined(ALTERNATIVES) &&
                             !attributeDescription.get(ALTERNATIVES).asList().isEmpty();
+                    boolean requiredBy = requires.contains(property.getName());
 
-                    if (nillable && !readOnly && !alternatives) {
+                    if (nillable && !readOnly && !alternatives && !requiredBy) {
                         boolean hasDefault = attributeDescription.hasDefined(DEFAULT);
                         ModelType type = attributeDescription.get(TYPE).asType();
                         switch (type) {
@@ -222,10 +240,7 @@ public class OperationFactory {
                             case INT:
                             case LONG:
                                 if (hasDefault) {
-                                    operations.add(new Operation.Builder(address, WRITE_ATTRIBUTE_OPERATION)
-                                            .param(NAME, attributeName(property.getName()))
-                                            .param(VALUE, attributeDescription.get(DEFAULT))
-                                            .build());
+                                    operations.add(undefineAttribute(address, attributeName(property.getName())));
                                 }
                                 break;
                             case EXPRESSION:
@@ -233,9 +248,7 @@ public class OperationFactory {
                             case OBJECT:
                             case PROPERTY:
                             case STRING:
-                                operations.add(new Operation.Builder(address, UNDEFINE_ATTRIBUTE_OPERATION)
-                                        .param(NAME, attributeName(property.getName()))
-                                        .build());
+                                operations.add(undefineAttribute(address, attributeName(property.getName())));
                                 break;
                             case TYPE:
                             case UNDEFINED:

--- a/core/src/main/java/org/jboss/hal/core/mbui/form/RequiredByValidation.java
+++ b/core/src/main/java/org/jboss/hal/core/mbui/form/RequiredByValidation.java
@@ -21,6 +21,7 @@ import java.util.List;
 import org.jboss.hal.ballroom.LabelBuilder;
 import org.jboss.hal.ballroom.form.FormItem;
 import org.jboss.hal.ballroom.form.FormItemValidation;
+import org.jboss.hal.ballroom.form.SwitchItem;
 import org.jboss.hal.ballroom.form.ValidationResult;
 import org.jboss.hal.resources.Constants;
 import org.jboss.hal.resources.Messages;
@@ -28,7 +29,7 @@ import org.jboss.hal.resources.Messages;
 import static java.util.stream.Collectors.toList;
 import static org.jboss.hal.ballroom.form.FormItemValidation.ValidationRule.ALWAYS;
 
-class RequiredByValidation<T> implements FormItemValidation<T> {
+public class RequiredByValidation<T> implements FormItemValidation<T> {
 
     private final FormItem<T> formItem;
     private final Collection<String> requiredBy;
@@ -37,7 +38,7 @@ class RequiredByValidation<T> implements FormItemValidation<T> {
     private final Messages messages;
     private final LabelBuilder labelBuilder;
 
-    RequiredByValidation(final FormItem<T> formItem, final Collection<String> requiredBy, final ModelNodeForm form,
+    public RequiredByValidation(final FormItem<T> formItem, final Collection<String> requiredBy, final ModelNodeForm form,
             final Constants constants, final Messages messages) {
         this.formItem = formItem;
         this.requiredBy = requiredBy;
@@ -66,8 +67,14 @@ class RequiredByValidation<T> implements FormItemValidation<T> {
             // if all required-by fields are empty, everything is fine
             return ValidationResult.OK;
         } else {
+            // there is a special case for SwitchItem of Boolean type, the SwitchItem.isEmpty() tests if the value is
+            // null, but for this validation case we must ensure the value is false
+            boolean switchItemFalse = false;
+            if (formItem instanceof SwitchItem) {
+                switchItemFalse = !((SwitchItem) formItem).getValue();
+            }
             // but as soon as there's one non-empty required-by field, this form item must be non-empty as well!
-            if (formItem.isEmpty()) {
+            if (formItem.isEmpty() || switchItemFalse) {
                 return ValidationResult.invalid(
                         messages.nonEmptyRequires(labelBuilder.enumeration(nonEmptyRequiredBy, constants.or())));
             } else {

--- a/dmr/src/main/java/org/jboss/hal/dmr/ModelDescriptionConstants.java
+++ b/dmr/src/main/java/org/jboss/hal/dmr/ModelDescriptionConstants.java
@@ -549,6 +549,9 @@ public interface ModelDescriptionConstants {
     String PRIORITY = "priority";
     String PROBE_OPERATION = "probe";
     String PROCESSING_TIME = "processing-time";
+    String PROCESS_ID_SOCKET_BINDING = "process-id-socket-binding";
+    String PROCESS_ID_SOCKET_MAX_PORTS = "process-id-socket-max-ports";
+    String PROCESS_ID_UUID = "process-id-uuid";
     String PROCESS_STATE = "process-state";
     String PRODUCES = "produces";
     String PRODUCT_NAME = "product-name";


### PR DESCRIPTION
https://issues.jboss.org/browse/HAL-1454
* Removed the custom validation and save operations in TransactionPresenter, to use the default validation and save of ModelNodeForm, as the resource description contains the alternatives and requires metadata.
* Enhanced the validation code to consider the SwitchItem false value.
* Enhanced the OperationFactory.reset operation to consider the "requires" metadata