### PR TITLE
Fix logging profile form, add-identity with attributes

### DIFF
--- a/app/src/main/java/org/jboss/hal/client/runtime/subsystem/elytron/ElytronColumn.java
+++ b/app/src/main/java/org/jboss/hal/client/runtime/subsystem/elytron/ElytronColumn.java
@@ -51,17 +51,17 @@ public class ElytronColumn extends FinderColumn<StaticItem> {
                 new StaticItem.Builder(Names.SECURITY_REALMS)
                         .onPreview(new PreviewContent<>(Names.SECURITY_REALMS, resources.previews().runtimeElytronSecurityRealms()))
                         .action(itemActionFactory.viewAndMonitor(Ids.ELYTRON_SECURITY_REALMS,
-                                places.selectedProfile(NameTokens.ELYTRON_RUNTIME_SECURITY_REALMS).build()))
+                                places.selectedServer(NameTokens.ELYTRON_RUNTIME_SECURITY_REALMS).build()))
                         .build(),
                 new StaticItem.Builder(Names.STORES)
                         .onPreview(new PreviewContent<>(Names.STORES, resources.previews().runtimeElytronStores()))
                         .action(itemActionFactory.viewAndMonitor(Ids.ELYTRON_STORES,
-                                places.selectedProfile(NameTokens.ELYTRON_RUNTIME_STORES).build()))
+                                places.selectedServer(NameTokens.ELYTRON_RUNTIME_STORES).build()))
                         .build(),
                 new StaticItem.Builder(Names.SSL)
                         .onPreview(new PreviewContent<>(Names.SSL, resources.previews().runtimeElytronSSL()))
                         .action(itemActionFactory.viewAndMonitor(Ids.ELYTRON_SSL,
-                                places.selectedProfile(NameTokens.ELYTRON_RUNTIME_SSL).build()))
+                                places.selectedServer(NameTokens.ELYTRON_RUNTIME_SSL).build()))
                         .build()
 
         );

--- a/app/src/main/java/org/jboss/hal/client/runtime/subsystem/elytron/IdentityAttributeItem.java
+++ b/app/src/main/java/org/jboss/hal/client/runtime/subsystem/elytron/IdentityAttributeItem.java
@@ -52,7 +52,7 @@ public class IdentityAttributeItem extends TagsItem<Map<String, List<String>>> {
     private static class MapMapping implements TagsMapping<Map<String, List<String>>> {
 
         private static final String VALUE_SEPARATOR = ";";
-        private static final RegExp REGEX = RegExp.compile("^([\\w\\-\\.\\/]+)=([\\w\\-\\.\\/:\\,]+)$"); //NON-NLS
+        private static final RegExp REGEX = RegExp.compile("^([\\w\\-\\.\\/]+)=([\\w\\-\\.\\/:\\;]+)$"); //NON-NLS
 
         @Override
         public TagsManager.Validator validator() {
@@ -63,7 +63,7 @@ public class IdentityAttributeItem extends TagsItem<Map<String, List<String>>> {
         public Map<String, List<String>> parse(final String cst) {
             Map<String, List<String>> result = new HashMap<>();
             if (cst != null) {
-                Splitter.on(VALUE_SEPARATOR)
+                Splitter.on(",")
                         .trimResults()
                         .omitEmptyStrings()
                         .withKeyValueSeparator('=')
@@ -82,7 +82,7 @@ public class IdentityAttributeItem extends TagsItem<Map<String, List<String>>> {
             }
             List<String> tags = new ArrayList<>();
             sourceValue.forEach((key, values) -> {
-                String tag = key + "=" + Joiner.on(",").join(values) + VALUE_SEPARATOR;
+                String tag = key + "=" + Joiner.on(VALUE_SEPARATOR).join(values);
                 tags.add(tag);
             });
             return tags;
@@ -95,10 +95,9 @@ public class IdentityAttributeItem extends TagsItem<Map<String, List<String>>> {
             }
             StringBuilder result = new StringBuilder();
             sourceValue.forEach((key, values) -> {
-                String tag = key + " \u21D2 " + Joiner.on(",").join(values) + " \n ";
+                String tag = key + " \u21D2 " + Joiner.on(VALUE_SEPARATOR).join(values) + " \n ";
                 result.append(tag);
             });
-            result.append("\n");
             return result.toString();
         }
     }

--- a/app/src/main/java/org/jboss/hal/client/runtime/subsystem/elytron/RealmsPresenter.java
+++ b/app/src/main/java/org/jboss/hal/client/runtime/subsystem/elytron/RealmsPresenter.java
@@ -15,11 +15,13 @@
  */
 package org.jboss.hal.client.runtime.subsystem.elytron;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
 
 import javax.inject.Inject;
+import javax.inject.Provider;
 
 import com.google.gwt.safehtml.shared.SafeHtml;
 import com.google.web.bindery.event.shared.EventBus;
@@ -31,6 +33,7 @@ import org.jboss.hal.ballroom.dialog.Dialog;
 import org.jboss.hal.ballroom.dialog.DialogFactory;
 import org.jboss.hal.ballroom.form.Form;
 import org.jboss.hal.client.runtime.subsystem.elytron.wizardpassword.PasswordWizard;
+import org.jboss.hal.core.SuccessfulOutcome;
 import org.jboss.hal.core.finder.Finder;
 import org.jboss.hal.core.finder.FinderPath;
 import org.jboss.hal.core.finder.FinderPathFactory;
@@ -47,6 +50,9 @@ import org.jboss.hal.dmr.NamedNode;
 import org.jboss.hal.dmr.Operation;
 import org.jboss.hal.dmr.ResourceAddress;
 import org.jboss.hal.dmr.dispatch.Dispatcher;
+import org.jboss.hal.flow.FlowContext;
+import org.jboss.hal.flow.Progress;
+import org.jboss.hal.flow.Task;
 import org.jboss.hal.meta.AddressTemplate;
 import org.jboss.hal.meta.Metadata;
 import org.jboss.hal.meta.StatementContext;
@@ -54,6 +60,7 @@ import org.jboss.hal.meta.token.NameTokens;
 import org.jboss.hal.resources.Ids;
 import org.jboss.hal.resources.Names;
 import org.jboss.hal.resources.Resources;
+import org.jboss.hal.spi.Footer;
 import org.jboss.hal.spi.Message;
 import org.jboss.hal.spi.MessageEvent;
 import org.jboss.hal.spi.Requires;
@@ -61,6 +68,7 @@ import org.jboss.hal.spi.Requires;
 import static org.jboss.hal.client.runtime.subsystem.elytron.AddressTemplates.*;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.*;
 import static org.jboss.hal.dmr.ModelNodeHelper.asNamedNodes;
+import static org.jboss.hal.flow.Flow.series;
 import static org.jboss.hal.resources.Names.IDENTITY_ATTRIBUTE_MAPPING;
 
 public class RealmsPresenter extends ApplicationFinderPresenter<RealmsPresenter.MyView, RealmsPresenter.MyProxy>
@@ -71,6 +79,7 @@ public class RealmsPresenter extends ApplicationFinderPresenter<RealmsPresenter.
     private final FinderPathFactory finderPathFactory;
     private final StatementContext statementContext;
     private Resources resources;
+    private Provider<Progress> progress;
     private Dispatcher dispatcher;
 
     @Inject
@@ -79,11 +88,13 @@ public class RealmsPresenter extends ApplicationFinderPresenter<RealmsPresenter.
             MyProxy proxy,
             Resources resources,
             Finder finder,
+            @Footer Provider<Progress> progress,
             Dispatcher dispatcher,
             FinderPathFactory finderPathFactory,
             StatementContext statementContext) {
         super(eventBus, view, proxy, finder);
         this.resources = resources;
+        this.progress = progress;
         this.dispatcher = dispatcher;
         this.finderPathFactory = finderPathFactory;
         this.statementContext = statementContext;
@@ -169,40 +180,72 @@ public class RealmsPresenter extends ApplicationFinderPresenter<RealmsPresenter.
                 .build();
         form.attach();
         AddResourceDialog dialog = new AddResourceDialog(resources.constants().addIdentity(), form, (name1, model) -> {
-            Composite composite = new Composite();
-            ResourceAddress address = template.resolve(statementContext, name);
+
+            LabelBuilder labelBuilder = new LabelBuilder();
+            String resourceName = labelBuilder.label(template.lastName()) + SPACE + name;
             String identity = model.get(IDENTITY).asString();
-            Operation addOp = new Operation.Builder(address, ADD_IDENTITY)
-                    .param(IDENTITY, identity)
-                    .build();
-            composite.add(addOp);
+            ResourceAddress address = template.resolve(statementContext, name);
+            List<Task<FlowContext>> tasks = new ArrayList<>();
+            Task<FlowContext> addTask = flowContext -> {
+                Operation addOp = new Operation.Builder(address, ADD_IDENTITY)
+                        .param(IDENTITY, identity)
+                        .build();
+
+                return dispatcher.execute(addOp)
+                        .doOnError(ex -> MessageEvent.fire(getEventBus(),
+                                Message.error(resources.messages()
+                                        .addError(resources.constants().identity(), identity, resourceName,
+                                                ex.getMessage()))))
+                        .toCompletable();
+            };
+            tasks.add(addTask);
 
             if (identityAttribute.getValue() != null) {
                 identityAttribute.getValue().forEach((key, values) -> {
-                    ModelNode modelValues = new ModelNode();
-                    values.forEach(modelValues::add);
-                    Operation addIdentAttributeOp = new Operation.Builder(address, ADD_IDENTITY_ATTRIBUTE)
-                            .param(IDENTITY, identity)
-                            .param(NAME, key)
-                            .param(VALUE, modelValues)
-                            .build();
-                    composite.add(addIdentAttributeOp);
+                    Task<FlowContext> addAttribute = flowContext -> {
+                        ModelNode modelValues = new ModelNode();
+                        values.forEach(modelValues::add);
+                        Operation addIdentAttributeOp = new Operation.Builder(address, ADD_IDENTITY_ATTRIBUTE)
+                                .param(IDENTITY, identity)
+                                .param(NAME, key)
+                                .param(VALUE, modelValues)
+                                .build();
+
+                        return dispatcher.execute(addIdentAttributeOp)
+                                .doOnError(ex -> MessageEvent.fire(getEventBus(),
+                                        Message.error(resources.messages()
+                                                .addError(resources.constants().identity(), identity, resourceName,
+                                                        ex.getMessage()))))
+                                .toCompletable();
+
+
+                    };
+                    tasks.add(addAttribute);
                 });
             }
-            LabelBuilder labelBuilder = new LabelBuilder();
-            String resourceName = labelBuilder.label(template.lastName()) + SPACE + name;
-            dispatcher.execute(composite, (CompositeResult compositeResult) -> MessageEvent.fire(getEventBus(),
-                                    Message.success(resources.messages().addSuccess(resources.constants().identity(), identity, resourceName))),
-                    (operation, failure) -> MessageEvent.fire(getEventBus(),
-                            Message.error(resources.messages().addError(resources.constants().identity(), identity, resourceName, failure))),
-                    (operation, exception) -> MessageEvent.fire(getEventBus(),
-                            Message.error(resources.messages().addError(resources.constants().identity(), identity, resourceName, exception.getMessage()))));
 
+            series(new FlowContext(progress.get()), tasks)
+                    .subscribe(new SuccessfulOutcome<FlowContext>(getEventBus(), resources) {
+                        @Override
+                        public void onSuccess(FlowContext flowContext) {
+                            MessageEvent.fire(getEventBus(),
+                                    Message.success(resources.messages()
+                                            .addSuccess(resources.constants().identity(), identity, resourceName)));
+                        }
+
+                        @Override
+                        public void onError(FlowContext context, Throwable throwable) {
+                            MessageEvent.fire(getEventBus(),
+                                    Message.error(resources.messages()
+                                            .addError(resources.constants().identity(), identity, resourceName,
+                                                    throwable.getMessage())));
+                        }
+                    });
         });
         dialog.show();
     }
 
-    void editIdentity(Metadata metadata, String resource, String title, Consumer<ModelNode> viewCallback) {
+    void editIdentity(Metadata metadata, String resource, String title, Consumer<ModelNode> callback) {
         AddressTemplate template = metadata.getTemplate();
         Metadata opMetadata = metadata.forOperation(READ_IDENTITY);
         Form<ModelNode> form = new ModelNodeForm.Builder<>(Ids.build(template.lastName(), READ_IDENTITY), opMetadata)
@@ -224,7 +267,7 @@ public class RealmsPresenter extends ApplicationFinderPresenter<RealmsPresenter.
                     .build();
             LabelBuilder labelBuilder = new LabelBuilder();
             String resourceName = labelBuilder.label(template.lastName()) + SPACE + resource;
-            dispatcher.execute(operation, viewCallback::accept,
+            dispatcher.execute(operation,  callback::accept,
                     (operation1, failure) -> MessageEvent.fire(getEventBus(),
                             Message.error(resources.messages().readIdentityError(identity, resourceName, failure))),
                     (operation1, exception) -> MessageEvent.fire(getEventBus(),
@@ -236,49 +279,72 @@ public class RealmsPresenter extends ApplicationFinderPresenter<RealmsPresenter.
 
     void saveIdentity(Metadata metadata, String resource, String identity, Map<String, List<String>> originalAttributes,
             Map<String, List<String>> attributes, Consumer<Boolean> viewCallback) {
+        LabelBuilder labelBuilder = new LabelBuilder();
+        String resourceName = labelBuilder.label(metadata.getTemplate().lastName()) + SPACE + resource;
         ResourceAddress address = metadata.getTemplate().resolve(statementContext, resource);
         // remove the old attributes and add the attribute list
-        Composite composite = new Composite();
+        List<Task<FlowContext>> tasks = new ArrayList<>();
         // compare the original values to the new values, to see which one to remove or add
         originalAttributes.forEach((key, originalValues) -> {
             List<String> newValues = attributes.get(key);
             if (!originalValues.equals(newValues)) {
                 // remove the key tag if it is not present, the user deleted it
-                Operation operation = new Operation.Builder(address, REMOVE_IDENTITY_ATTRIBUTE)
-                        .param(IDENTITY, identity)
-                        .param(NAME, key)
-                        .build();
-                composite.add(operation);
+
+                Task<FlowContext> addTask = flowContext -> {
+                    Operation operation = new Operation.Builder(address, REMOVE_IDENTITY_ATTRIBUTE)
+                            .param(IDENTITY, identity)
+                            .param(NAME, key)
+                            .build();
+
+                    return dispatcher.execute(operation)
+                            .doOnError(ex -> MessageEvent.fire(getEventBus(), Message.error(
+                                    resources.messages().saveIdentityError(identity, resourceName, ex.getMessage()))))
+                            .toCompletable();
+                };
+                tasks.add(addTask);
             }
         });
         attributes.forEach((name, newValues) -> {
             List<String> originalValues = originalAttributes.get(name);
             if (!newValues.equals(originalValues)) {
-                ModelNode modelValues = new ModelNode();
-                newValues.forEach(modelValues::add);
-                Operation addIdentAttributeOp = new Operation.Builder(address, ADD_IDENTITY_ATTRIBUTE)
-                        .param(IDENTITY, identity)
-                        .param(NAME, name)
-                        .param(VALUE, modelValues)
-                        .build();
-                composite.add(addIdentAttributeOp);
+
+                Task<FlowContext> addTask = flowContext -> {
+                    ModelNode modelValues = new ModelNode();
+                    newValues.forEach(modelValues::add);
+                    Operation operation = new Operation.Builder(address, ADD_IDENTITY_ATTRIBUTE)
+                            .param(IDENTITY, identity)
+                            .param(NAME, name)
+                            .param(VALUE, modelValues)
+                            .build();
+
+                    return dispatcher.execute(operation)
+                            .doOnError(ex -> MessageEvent.fire(getEventBus(), Message.error(
+                                    resources.messages().saveIdentityError(identity, resourceName, ex.getMessage()))))
+                            .toCompletable();
+                };
+                tasks.add(addTask);
             }
         });
-        if (composite.isEmpty()) {
+        if (tasks.isEmpty()) {
             MessageEvent.fire(getEventBus(), Message.warning(resources.messages().noChanges()));
         } else {
-            LabelBuilder labelBuilder = new LabelBuilder();
-            String resourceName = labelBuilder.label(metadata.getTemplate().lastName()) + SPACE + resource;
-            dispatcher.execute(composite, (CompositeResult compositeResult) -> {
-                    viewCallback.accept(true);
-                    MessageEvent.fire(getEventBus(),
-                            Message.success(resources.messages().saveIdentitySuccess(identity, resourceName)));
-                },
-                (operation1, failure) -> MessageEvent.fire(getEventBus(),
-                        Message.error(resources.messages().saveIdentityError(identity, resourceName, failure))),
-                (operation1, exception) -> MessageEvent.fire(getEventBus(),
-                        Message.error(resources.messages().saveIdentityError(identity, resourceName, exception.getMessage()))));
 
+            series(new FlowContext(progress.get()), tasks)
+                    .subscribe(new SuccessfulOutcome<FlowContext>(getEventBus(), resources) {
+                        @Override
+                        public void onSuccess(FlowContext flowContext) {
+                            viewCallback.accept(true);
+                            MessageEvent.fire(getEventBus(),
+                                    Message.success(resources.messages().saveIdentitySuccess(identity, resourceName)));
+                        }
+
+                        @Override
+                        public void onError(FlowContext context, Throwable throwable) {
+                            MessageEvent.fire(getEventBus(),
+                                    Message.error(resources.messages()
+                                            .saveIdentityError(identity, resourceName, throwable.getMessage())));
+                        }
+                    });
         }
     }
 

--- a/app/src/main/java/org/jboss/hal/client/shared/sslwizard/EnableSSLWizard.java
+++ b/app/src/main/java/org/jboss/hal/client/shared/sslwizard/EnableSSLWizard.java
@@ -39,6 +39,7 @@ import org.jboss.hal.meta.AddressTemplate;
 import org.jboss.hal.meta.StatementContext;
 import org.jboss.hal.resources.Constants;
 import org.jboss.hal.resources.Resources;
+import org.jboss.hal.spi.Footer;
 import org.jboss.hal.spi.Message;
 import org.jboss.hal.spi.MessageEvent;
 
@@ -68,7 +69,7 @@ public class EnableSSLWizard {
 
     private EnableSSLWizard(Map<String, List<String>> existingResources, Resources resources, Environment environment,
             StatementContext statementContext, Dispatcher dispatcher, Host host, EnableSSLPresenter presenter,
-            Provider<Progress> progress, EventBus eventBus) {
+            @Footer Provider<Progress> progress, EventBus eventBus) {
         this.existingResources = existingResources;
         this.resources = resources;
         this.environment = environment;

--- a/app/src/main/resources/org/jboss/hal/client/configuration/subsystem/logging/LoggingProfileView.mbui.xml
+++ b/app/src/main/resources/org/jboss/hal/client/configuration/subsystem/logging/LoggingProfileView.mbui.xml
@@ -44,7 +44,7 @@
                 <h1>Categories</h1>
                 <p>${metadata.getDescription().getDescription()}</p>
                 <table id="logging-profile-category-table" title="Category"
-                       form-ref="logging-profile-categories-form">
+                       form-ref="logging-profile-category-form">
                     <actions>
                         <action title="${mbuiContext.resources().constants().add()}" handler="${addLogger()}"
                                 constraint="add"/>

--- a/ballroom/src/main/java/org/jboss/hal/ballroom/form/TagsManager.java
+++ b/ballroom/src/main/java/org/jboss/hal/ballroom/form/TagsManager.java
@@ -78,10 +78,7 @@ public class TagsManager {
 
         public static Options get() {
             Options options = new Options();
-            // use the first delimiter character instead of comma, there are some multivalues that are separated by comma
-            // then, use an alternative delimiter to separate the tags
-            // https://github.com/max-favilli/tagmanager/blob/v3.0.2/tagmanager.js#L369
-            options.delimiters = new int[]{59, 13}; // semicolon, enter
+            options.delimiters = new int[]{13}; // 13=enter
             options.tagClass = tagManagerTag;
             options.validator = null;
             return options;

--- a/resources/src/main/resources/org/jboss/hal/resources/Messages.properties
+++ b/resources/src/main/resources/org/jboss/hal/resources/Messages.properties
@@ -197,7 +197,7 @@ identityPasswordScramDigest=A password using the SCRAM digest algorithm.
 identityPasswordSimpleDigest=A simple digest password.
 identityDescription=Identity name and attributes.
 identityAttributeHelp=The list of attributes of an identity.
-identityAttributeHint=Add new attributes as <em>key=value1,value2</em> pairs. Press <abbr class="key" title="RETURN">&crarr;</abbr> to add and <abbr class="key" title="BACKSPACE">&#x232B</abbr> to remove them.
+identityAttributeHint=Add new attributes as <em>key=value1;value2</em> pairs. Press <abbr class="key" title="RETURN">&crarr;</abbr> to add and <abbr class="key" title="BACKSPACE">&#x232B</abbr> to remove them.
 importCertificateError=Failed to import the certificate with alias <strong>{0}</strong> from path <strong>{1}</strong> for <strong>{2}</strong>. Cause: {3}.
 importCertificateSuccess=The certificate with alias <strong>{0}</strong> was successfully imported from path <strong>{1}</strong> for resource <strong>{2}</strong>.
 includeAllHelpText=Configure if all authenticated users should be automatically assigned this role.

--- a/resources/src/main/resources/org/jboss/hal/resources/Messages_pt_BR.properties
+++ b/resources/src/main/resources/org/jboss/hal/resources/Messages_pt_BR.properties
@@ -51,7 +51,7 @@ hostColumnFilterDescription=Filtrar por: nome do host, dc/hc (tipo do controlado
 hostPatchesColumnFilterDescription=Filtrar por: nome do host, dc/hc (tipo do controlador) e o estado de execu\u00e7\u00e3o
 identityDescription=Nome da identidade e atributos.
 identityAttributeHelp=A lista de atributos de uma identidade.
-identityAttributeHint=Adicione novos atributos em pares como <em>chave=valor1,valor2</em>. Pressione <abbr class="key" title="ENTER">&crarr;</abbr> para adicionar e <abbr class="key" title="REMOVER">&#x232B</abbr> para remover.
+identityAttributeHint=Adicione novos atributos em pares como <em>chave=valor1;valor2</em>. Pressione <abbr class="key" title="ENTER">&crarr;</abbr> para adicionar e <abbr class="key" title="REMOVER">&#x232B</abbr> para remover.
 identityPasswordBcrypt=Uma senha que usa o algoritmo BCRYPT.
 identityPasswordClear=Uma senha em texto limpo.
 identityPasswordDigest=Uma senha digest.


### PR DESCRIPTION
HAL-1469 Unable to read or edit categories in logging profile
https://issues.jboss.org/browse/HAL-1469
HAL-1470 add-identity in filesystem-realm with no notification
https://issues.jboss.org/browse/HAL-1470
* Due to ListItem having problems to use the semicolon as delimiter, reverted the tags delimiter to comma and replace the value delimiter of IdentityAttributeItem from colon to semicolon
* Fixed the ElytronColumn finder selector