### PR TITLE
HAL-1482 Broken CSS for steps in wizard header

### DIFF
--- a/app/src/less/wizard.less
+++ b/app/src/less/wizard.less
@@ -20,3 +20,7 @@
 .wizard-pf-step-title {
   .text-overflow();
 }
+
+.wizard-pf-step {
+    line-height: 19px !important;
+}

--- a/ballroom/src/main/java/org/jboss/hal/ballroom/wizard/Wizard.java
+++ b/ballroom/src/main/java/org/jboss/hal/ballroom/wizard/Wizard.java
@@ -456,7 +456,7 @@ public class Wizard<C, S extends Enum<S>> {
             S status = entry.getKey();
             WizardStep<C, S> step = entry.getValue();
 
-            HTMLLIElement li = li()
+            HTMLLIElement li = li().css(wizardPfStep)
                     .add(a()
                             .add(span().css(wizardPfStepNumber).textContent(String.valueOf(index)))
                             .add(span().css(wizardPfStepTitle).textContent(step.title)))

--- a/resources/src/main/java/org/jboss/hal/resources/CSS.java
+++ b/resources/src/main/java/org/jboss/hal/resources/CSS.java
@@ -412,6 +412,7 @@ public interface CSS {
     String wizardPfRow = "wizard-pf-row";
     String wizardPfStepNumber = "wizard-pf-step-number";
     String wizardPfStepTitle = "wizard-pf-step-title";
+    String wizardPfStep = "wizard-pf-step";
     String wizardPfSteps = "wizard-pf-steps";
     String wizardPfStepsIndicator = "wizard-pf-steps-indicator";
     String wizardPfSuccessIcon = "wizard-pf-success-icon";


### PR DESCRIPTION
https://issues.jboss.org/browse/HAL-1482
* patternfly introduced a change in its wizard.less file
* Also increased the line-height of the wizard steps, as some letters had the lower part hidden