### PR TITLE
On datasource creation wizard, use the friendly names on labels. Also…

### DIFF
--- a/app/src/main/java/org/jboss/hal/client/configuration/subsystem/datasource/DataSourceTemplate.java
+++ b/app/src/main/java/org/jboss/hal/client/configuration/subsystem/datasource/DataSourceTemplate.java
@@ -27,7 +27,7 @@ import static java.util.Collections.emptyMap;
 public class DataSourceTemplate {
 
     @SuppressWarnings("HardCodedStringLiteral")
-    enum Vendor {
+    public enum Vendor {
         H2("H2"),
         POSTGRE_SQL("PostgreSQL"),
         MYSQL("MySQL"),
@@ -36,7 +36,7 @@ public class DataSourceTemplate {
         DB2("IBM DB2"),
         SYBASE("Sybase");
 
-        private final String label;
+        public final String label;
 
         Vendor(String label) {
             this.label = label;

--- a/app/src/main/java/org/jboss/hal/client/configuration/subsystem/datasource/DataSourceTemplates.java
+++ b/app/src/main/java/org/jboss/hal/client/configuration/subsystem/datasource/DataSourceTemplates.java
@@ -104,6 +104,7 @@ public class DataSourceTemplates implements Iterable<DataSourceTemplate> {
                     dataSource.get(JNDI_NAME).set("java:/PostgresDS");
                     dataSource.get(DRIVER_NAME).set(POSTGRESQL);
                     dataSource.get(CONNECTION_URL).set("jdbc:postgresql://localhost:5432/postgresdb");
+                    dataSource.get(DATASOURCE_CLASS).set("org.postgresql.ds.PGSimpleDataSource");
                     dataSource.get(USER_NAME).set(ADMIN);
                     dataSource.get(PASSWORD).set(ADMIN);
                     dataSource.get(BACKGROUND_VALIDATION).set(true);
@@ -192,6 +193,7 @@ public class DataSourceTemplates implements Iterable<DataSourceTemplate> {
                     dataSource.get(JNDI_NAME).set("java:/OracleDS");
                     dataSource.get(DRIVER_NAME).set(ORACLE);
                     dataSource.get(CONNECTION_URL).set("jdbc:oracle:thin:@localhost:1521:orcalesid");
+                    dataSource.get(DATASOURCE_CLASS).set("oracle.jdbc.pool.OracleDataSource");
                     dataSource.get(USER_NAME).set(ADMIN);
                     dataSource.get(PASSWORD).set(ADMIN);
                     dataSource.get(BACKGROUND_VALIDATION).set(true);
@@ -243,6 +245,7 @@ public class DataSourceTemplates implements Iterable<DataSourceTemplate> {
                     dataSource.get(DRIVER_NAME).set(SQLSERVER);
                     dataSource.get(CONNECTION_URL)
                             .set("jdbc:microsoft:sqlserver://localhost:1433;DatabaseName=MyDatabase");
+                    dataSource.get(DATASOURCE_CLASS).set("com.microsoft.sqlserver.jdbc.SQLServerDataSource");
                     dataSource.get(USER_NAME).set(ADMIN);
                     dataSource.get(PASSWORD).set(ADMIN);
                     dataSource.get(BACKGROUND_VALIDATION).set(true);

--- a/app/src/main/java/org/jboss/hal/client/configuration/subsystem/datasource/wizard/ChooseTemplateStep.java
+++ b/app/src/main/java/org/jboss/hal/client/configuration/subsystem/datasource/wizard/ChooseTemplateStep.java
@@ -63,7 +63,7 @@ class ChooseTemplateStep extends WizardStep<Context, State> {
                                         String id = ((HTMLInputElement) event.target).value;
                                         wizard().getContext().template = templates.getTemplate(id);
                                     }))
-                            .add(span().textContent(template.getId())))
+                            .add(span().textContent(template.getVendor().label)))
                     .asElement());
         }
 


### PR DESCRIPTION
…, set the datasource-class attribute on the templates.