### PR TITLE
HAL & WildFly nightly Docker image

### DIFF
--- a/docker/pom.xml
+++ b/docker/pom.xml
@@ -99,9 +99,11 @@
                 </executions>
             </plugin>
             <!--
-             Produce two docker images:
+             Produce three docker images:
                 1. halconsole/hal-standalone: Contains HAL standalone
-                2. halconsole/hal-wildfly: Contains latest WildFly and and HAL
+                2. halconsole/hal-wildfly: Contains latest WildFly and HAL
+                3. halconsole/hal-wildfly-nightly: Contains latest nightly
+                   build of WildFly with HAL 
             -->
             <plugin>
                 <groupId>io.fabric8</groupId>

--- a/docker/pom.xml
+++ b/docker/pom.xml
@@ -152,6 +152,27 @@
                                 </assembly>
                             </build>
                         </image>
+                        <image>
+                            <alias>hal-wildfly-nightly</alias>
+                            <name>halconsole/hal-wildfly-nightly</name>
+                            <build>
+                                <dockerFileDir>hal-wildfly-nightly</dockerFileDir>
+                                <assembly>
+                                    <mode>dir</mode>
+                                    <inline>
+                                        <fileSets>
+                                            <fileSet>
+                                                <directory>${project.build.directory}</directory>
+                                                <includes>
+                                                    <include>hal-console.jar</include>
+                                                </includes>
+                                                <outputDirectory>.</outputDirectory>
+                                            </fileSet>
+                                        </fileSets>
+                                    </inline>
+                                </assembly>
+                            </build>
+                        </image>
                     </images>
                 </configuration>
             </plugin>

--- a/docker/src/main/docker/hal-wildfly-nightly/Dockerfile
+++ b/docker/src/main/docker/hal-wildfly-nightly/Dockerfile
@@ -1,0 +1,35 @@
+FROM jboss/base-jdk:8
+
+ARG wildfly_version=''
+
+ENV JBOSS_HOME /opt/jboss/wildfly
+ENV LAUNCH_JBOSS_IN_BACKGROUND true
+
+COPY setup.sh /opt/jboss/setup/
+
+USER root
+
+RUN yum install libxml2 -y \
+    && chmod +x /opt/jboss/setup/setup.sh \
+    && sh /opt/jboss/setup/setup.sh
+
+COPY --chown=jboss /module.xml $JBOSS_HOME/modules/system/layers/base/org/jboss/as/console/main/
+COPY --chown=jboss /maven/hal-console.jar $JBOSS_HOME/modules/system/layers/base/org/jboss/as/console/main/
+
+USER jboss
+
+RUN sed "s/<http-interface security-realm=\"ManagementRealm\">/<http-interface>/" $JBOSS_HOME/standalone/configuration/standalone.xml > $JBOSS_HOME/standalone/configuration/standalone-insecure.xml \
+    && sed "s/<http-interface security-realm=\"ManagementRealm\">/<http-interface>/" $JBOSS_HOME/standalone/configuration/standalone-full.xml > $JBOSS_HOME/standalone/configuration/standalone-full-insecure.xml \
+    && sed "s/<http-interface security-realm=\"ManagementRealm\">/<http-interface>/" $JBOSS_HOME/standalone/configuration/standalone-ha.xml > $JBOSS_HOME/standalone/configuration/standalone-ha-insecure.xml \
+    && sed "s/<http-interface security-realm=\"ManagementRealm\">/ <http-interface>/" $JBOSS_HOME/standalone/configuration/standalone-full-ha.xml > $JBOSS_HOME/standalone/configuration/standalone-full-ha-insecure.xml \
+    && $JBOSS_HOME/bin/add-user.sh -u admin -p admin --silent
+
+# Expose the ports we're interested in
+EXPOSE 8080
+
+EXPOSE 9090
+
+# Set the default command to run on boot
+# This will boot WildFly in the standalone mode and bind to all interface
+
+CMD ["/opt/jboss/wildfly/bin/standalone.sh", "-b", "0.0.0.0", "-bmanagement", "0.0.0.0"]

--- a/docker/src/main/docker/hal-wildfly-nightly/Dockerfile
+++ b/docker/src/main/docker/hal-wildfly-nightly/Dockerfile
@@ -22,7 +22,7 @@ RUN sed "s/<http-interface security-realm=\"ManagementRealm\">/<http-interface>/
     && sed "s/<http-interface security-realm=\"ManagementRealm\">/<http-interface>/" $JBOSS_HOME/standalone/configuration/standalone-full.xml > $JBOSS_HOME/standalone/configuration/standalone-full-insecure.xml \
     && sed "s/<http-interface security-realm=\"ManagementRealm\">/<http-interface>/" $JBOSS_HOME/standalone/configuration/standalone-ha.xml > $JBOSS_HOME/standalone/configuration/standalone-ha-insecure.xml \
     && sed "s/<http-interface security-realm=\"ManagementRealm\">/<http-interface>/" $JBOSS_HOME/standalone/configuration/standalone-full-ha.xml > $JBOSS_HOME/standalone/configuration/standalone-full-ha-insecure.xml \
-    && sed -i "s/<http-interface security-realm=\"ManagementRealm\">/<http-interface>/" $JBOSS_HOME/domain/configuration/host.xml \
+    && sed "s/<http-interface security-realm=\"ManagementRealm\">/<http-interface>/" $JBOSS_HOME/domain/configuration/host.xml > $JBOSS_HOME/domain/configuration/host-insecure.xml \
     && $JBOSS_HOME/bin/add-user.sh -u admin -p admin --silent
 
 # Expose the ports we're interested in

--- a/docker/src/main/docker/hal-wildfly-nightly/Dockerfile
+++ b/docker/src/main/docker/hal-wildfly-nightly/Dockerfile
@@ -21,7 +21,8 @@ USER jboss
 RUN sed "s/<http-interface security-realm=\"ManagementRealm\">/<http-interface>/" $JBOSS_HOME/standalone/configuration/standalone.xml > $JBOSS_HOME/standalone/configuration/standalone-insecure.xml \
     && sed "s/<http-interface security-realm=\"ManagementRealm\">/<http-interface>/" $JBOSS_HOME/standalone/configuration/standalone-full.xml > $JBOSS_HOME/standalone/configuration/standalone-full-insecure.xml \
     && sed "s/<http-interface security-realm=\"ManagementRealm\">/<http-interface>/" $JBOSS_HOME/standalone/configuration/standalone-ha.xml > $JBOSS_HOME/standalone/configuration/standalone-ha-insecure.xml \
-    && sed "s/<http-interface security-realm=\"ManagementRealm\">/ <http-interface>/" $JBOSS_HOME/standalone/configuration/standalone-full-ha.xml > $JBOSS_HOME/standalone/configuration/standalone-full-ha-insecure.xml \
+    && sed "s/<http-interface security-realm=\"ManagementRealm\">/<http-interface>/" $JBOSS_HOME/standalone/configuration/standalone-full-ha.xml > $JBOSS_HOME/standalone/configuration/standalone-full-ha-insecure.xml \
+    && sed -i "s/<http-interface security-realm=\"ManagementRealm\">/<http-interface>/" $JBOSS_HOME/domain/configuration/host.xml \
     && $JBOSS_HOME/bin/add-user.sh -u admin -p admin --silent
 
 # Expose the ports we're interested in

--- a/docker/src/main/docker/hal-wildfly-nightly/module.xml
+++ b/docker/src/main/docker/hal-wildfly-nightly/module.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2015-2016 Red Hat, Inc, and individual contributors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<module xmlns="urn:jboss:module:1.5" name="org.jboss.as.console">
+    <properties>
+        <property name="jboss.api" value="private"/>
+    </properties>
+
+    <resources>
+        <resource-root path="hal-console.jar"/>
+    </resources>
+
+    <dependencies>
+        <!-- Do not add dependencies to the console as resources in any
+             dependencies could be served up through the HTTP interface. -->
+    </dependencies>
+</module>

--- a/docker/src/main/docker/hal-wildfly-nightly/setup.sh
+++ b/docker/src/main/docker/hal-wildfly-nightly/setup.sh
@@ -2,7 +2,7 @@
 
 WF_ARTIFACT_VERSION=wildfly-$wildfly_version
 
-function downloadLatestWildflyOrSpecified() {
+function downloadSpecifiedOrLatestWildfly() {
     if [ -z "$wildfly_version" ]
     then
         echo "Version of Wildfly has not been specified, resolving latest one"
@@ -11,11 +11,10 @@ function downloadLatestWildflyOrSpecified() {
         echo "Latest version of Wildfly is $WF_ARTIFACT_VERSION"
     fi
     curl -O https://ci.wildfly.org/guestAuth/repository/download/WF_Nightly/latest.lastFinished/${WF_ARTIFACT_VERSION}.zip
-    unzip ${WF_ARTIFACT_VERSION}.zip
-    mv ${WF_ARTIFACT_VERSION} ${JBOSS_HOME}
-    rm ${WF_ARTIFACT_VERSION}.zip
-    chown -R jboss:0 ${JBOSS_HOME}
-    chmod -R g+rw ${JBOSS_HOME}
 }
-
-downloadLatestWildflyOrSpecified
+downloadSpecifiedOrLatestWildfly
+unzip ${WF_ARTIFACT_VERSION}.zip
+mv ${WF_ARTIFACT_VERSION} ${JBOSS_HOME}
+rm ${WF_ARTIFACT_VERSION}.zip
+chown -R jboss:0 ${JBOSS_HOME}
+chmod -R g+rw ${JBOSS_HOME}

--- a/docker/src/main/docker/hal-wildfly-nightly/setup.sh
+++ b/docker/src/main/docker/hal-wildfly-nightly/setup.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+WF_ARTIFACT_VERSION=wildfly-$wildfly_version
+
+function downloadLatestWildflyOrSpecified() {
+    if [ -z "$wildfly_version" ]
+    then
+        echo "Version of Wildfly has not been specified, resolving latest one"
+        curl https://ci.wildfly.org/guestAuth/repository/download/WF_Nightly/latest.lastFinished/teamcity-ivy.xml > /tmp/teamcity-ivy.xml
+        WF_ARTIFACT_VERSION=`xmllint --xpath 'string(ivy-module/publications/artifact[not(contains(@name,"src"))]/@name)' /tmp/teamcity-ivy.xml` 
+        echo "Latest version of Wildfly is $WF_ARTIFACT_VERSION"
+    fi
+    curl -O https://ci.wildfly.org/guestAuth/repository/download/WF_Nightly/latest.lastFinished/${WF_ARTIFACT_VERSION}.zip
+    unzip ${WF_ARTIFACT_VERSION}.zip
+    mv ${WF_ARTIFACT_VERSION} ${JBOSS_HOME}
+    rm ${WF_ARTIFACT_VERSION}.zip
+    chown -R jboss:0 ${JBOSS_HOME}
+    chmod -R g+rw ${JBOSS_HOME}
+}
+
+downloadLatestWildflyOrSpecified


### PR DESCRIPTION
# Summary
This PR automizes creation of a WF with the latest HAL in a form of Docker image. This image additionally to the [``hal-wildfly``](https://hub.docker.com/r/halconsole/hal-wildfly/) image brings insecure domain configuration ``host-insecure.xml`` for testing purposes. To boot WF in domain mode without administration simply issue following command:
``docker run -p 8080:8080 -p 9990:9990 halconsole/hal-wildfly-nightly /opt/jboss/wildfly/bin/domain.sh --host-config host-insecure.xml -b 0.0.0.0 -bmanagement 0.0.0.0``. 
# Drawbacks
When building the Docker image, the [latest WF nightly build](https://ci.wildfly.org/viewType.html?buildTypeId=WF_Nightly) is being pulled and processed furthemore. The download of this artifact is slowing down the build process. To reduce this speedbump a build hook could be an option. Any thoughts @claudio4j @hpehl ?