### PR TITLE
Replace 'list-log-files' with using the 'log-file' resource and other fixes

### DIFF
--- a/app/src/main/java/org/jboss/hal/client/deployment/ServerGroupDeploymentColumn.java
+++ b/app/src/main/java/org/jboss/hal/client/deployment/ServerGroupDeploymentColumn.java
@@ -40,6 +40,7 @@ import org.jboss.hal.client.deployment.wizard.UploadContext;
 import org.jboss.hal.client.deployment.wizard.UploadDeploymentStep;
 import org.jboss.hal.client.deployment.wizard.UploadState;
 import org.jboss.hal.config.Environment;
+import org.jboss.hal.core.CrudOperations;
 import org.jboss.hal.core.SuccessfulOutcome;
 import org.jboss.hal.core.deployment.Content;
 import org.jboss.hal.core.deployment.Deployment.Status;
@@ -89,6 +90,7 @@ import static org.jboss.hal.client.deployment.ServerGroupDeploymentColumn.SERVER
 import static org.jboss.hal.client.deployment.wizard.UploadState.NAMES;
 import static org.jboss.hal.client.deployment.wizard.UploadState.UPLOAD;
 import static org.jboss.hal.core.deployment.Deployment.Status.OK;
+import static org.jboss.hal.core.finder.FinderColumn.RefreshMode.CLEAR_SELECTION;
 import static org.jboss.hal.core.finder.FinderColumn.RefreshMode.RESTORE_SELECTION;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.*;
 import static org.jboss.hal.flow.Flow.series;
@@ -119,6 +121,7 @@ public class ServerGroupDeploymentColumn extends FinderColumn<ServerGroupDeploym
             EventBus eventBus,
             Dispatcher dispatcher,
             Places places,
+            CrudOperations crud,
             ServerActions serverActions,
             StatementContext statementContext,
             MetadataRegistry metadataRegistry,
@@ -274,8 +277,12 @@ public class ServerGroupDeploymentColumn extends FinderColumn<ServerGroupDeploym
                 }
                 AddressTemplate template = SERVER_GROUP_DEPLOYMENT_TEMPLATE
                         .replaceWildcards(statementContext.selectedServerGroup());
-                actions.add(itemActionFactory.remove(Names.DEPLOYMENT, item.getName(),
-                        template, SERVER_GROUP_DEPLOYMENT_TEMPLATE, ServerGroupDeploymentColumn.this));
+                actions.add(new ItemAction.Builder<ServerGroupDeployment>()
+                        .title(resources.constants().undeploy())
+                        .handler(item -> crud.remove(Names.DEPLOYMENT, item.getName(), template,
+                                () -> refresh(CLEAR_SELECTION)))
+                        .constraint(Constraint.executable(SERVER_GROUP_DEPLOYMENT_TEMPLATE, REMOVE))
+                        .build());
                 return actions;
             }
         });

--- a/app/src/main/java/org/jboss/hal/client/deployment/StandaloneDeploymentColumn.java
+++ b/app/src/main/java/org/jboss/hal/client/deployment/StandaloneDeploymentColumn.java
@@ -37,6 +37,7 @@ import org.jboss.hal.client.deployment.wizard.UploadDeploymentStep;
 import org.jboss.hal.client.deployment.wizard.UploadElement;
 import org.jboss.hal.client.deployment.wizard.UploadState;
 import org.jboss.hal.config.Environment;
+import org.jboss.hal.core.CrudOperations;
 import org.jboss.hal.core.SuccessfulOutcome;
 import org.jboss.hal.core.deployment.Deployment;
 import org.jboss.hal.core.deployment.Deployment.Status;
@@ -80,6 +81,7 @@ import static org.jboss.gwt.elemento.core.Elements.span;
 import static org.jboss.hal.client.deployment.StandaloneDeploymentColumn.DEPLOYMENT_ADDRESS;
 import static org.jboss.hal.client.deployment.wizard.UploadState.NAMES;
 import static org.jboss.hal.client.deployment.wizard.UploadState.UPLOAD;
+import static org.jboss.hal.core.finder.FinderColumn.RefreshMode.CLEAR_SELECTION;
 import static org.jboss.hal.core.finder.FinderColumn.RefreshMode.RESTORE_SELECTION;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.*;
 import static org.jboss.hal.flow.Flow.series;
@@ -109,6 +111,7 @@ public class StandaloneDeploymentColumn extends FinderColumn<Deployment> {
             Environment environment,
             ServerActions serverActions,
             Dispatcher dispatcher,
+            CrudOperations crud,
             StatementContext statementContext,
             EventBus eventBus,
             MetadataRegistry metadataRegistry,
@@ -234,8 +237,12 @@ public class StandaloneDeploymentColumn extends FinderColumn<Deployment> {
                             .constraint(Constraint.executable(DEPLOYMENT_TEMPLATE, EXPLODE))
                             .build());
                 }
-                actions.add(itemActionFactory.remove(Names.DEPLOYMENT, item.getName(), DEPLOYMENT_TEMPLATE,
-                        StandaloneDeploymentColumn.this));
+                actions.add(new ItemAction.Builder<Deployment>()
+                        .title(resources.constants().undeploy())
+                        .handler(item -> crud.remove(Names.DEPLOYMENT, item.getName(), DEPLOYMENT_TEMPLATE,
+                                () -> refresh(CLEAR_SELECTION)))
+                        .constraint(Constraint.executable(DEPLOYMENT_TEMPLATE, REMOVE))
+                        .build());
                 return actions;
             }
         });

--- a/app/src/main/java/org/jboss/hal/client/runtime/subsystem/logging/LogFile.java
+++ b/app/src/main/java/org/jboss/hal/client/runtime/subsystem/logging/LogFile.java
@@ -27,7 +27,6 @@ class LogFile extends ModelNode {
     // TODO Move to ModelDescriptionConstants
     private static final String FILE_NAME = "file-name";
     private static final String FILE_SIZE = "file-size";
-    private static final String LAST_MODIFIED_DATE = "last-modified-date";
     private static final String LAST_MODIFIED_TIMESTAMP = "last-modified-timestamp";
 
     LogFile(ModelNode node) {
@@ -44,12 +43,7 @@ class LogFile extends ModelNode {
     }
 
     public Date getLastModifiedDate() {
-        // first try LAST_MODIFIED_DATE then LAST_MODIFIED_TIMESTAMP
-        Date date = failSafeDate(this, LAST_MODIFIED_DATE);
-        if (date == null) {
-            date = failSafeDate(this, LAST_MODIFIED_TIMESTAMP);
-        }
-        return date;
+        return failSafeDate(this, LAST_MODIFIED_TIMESTAMP);
     }
 
     public String getFormattedLastModifiedDate() {

--- a/ballroom/src/main/java/org/jboss/hal/ballroom/LabelBuilder.java
+++ b/ballroom/src/main/java/org/jboss/hal/ballroom/LabelBuilder.java
@@ -53,6 +53,7 @@ public class LabelBuilder {
             .put("io", "IO")
             .put("jaas", "JAAS")
             .put("jacc", "JACC")
+            .put("jaspi", "JASPI")
             .put("jaxrs", "JAX-RS")
             .put("jboss", "JBoss")
             .put("jdbc", "JDBC")

--- a/ballroom/src/main/java/org/jboss/hal/ballroom/table/ColumnBuilder.java
+++ b/ballroom/src/main/java/org/jboss/hal/ballroom/table/ColumnBuilder.java
@@ -83,8 +83,10 @@ public class ColumnBuilder<T> {
             // make sure the render escapes HTML
             effectiveRender = (cell, type, row, meta) -> {
                 String value = ColumnBuilder.this.render.render(cell, type, row, meta);
-                String safeHtmlValue = SafeHtmlUtils.fromString(value).asString();
-                return safeHtmlValue;
+                if (value != null) {
+                    value = SafeHtmlUtils.htmlEscape(value);
+                }
+                return value;
             };
         }
 


### PR DESCRIPTION
* HAL-1485 Replace 'list-log-files' with using the 'log-file' resource
https://issues.jboss.org/browse/HAL-1485
* HAL-1519 Undeploy operation wording is not unified
https://issues.jboss.org/browse/HAL-1519
* Only escapes html in the Datatable column if the value is not null
