### PR TITLE
HAL-1634: implement subdeployment exploding

### DIFF
--- a/resources/src/main/java/org/jboss/hal/resources/Constants.java
+++ b/resources/src/main/java/org/jboss/hal/resources/Constants.java
@@ -174,6 +174,7 @@ public interface Constants extends com.google.gwt.i18n.client.Constants {
     String expire();
     String expiredSessions();
     String explode();
+    String explodeSubdeployments();
     String exploded();
     String export();
     String exportCertificate();

--- a/resources/src/main/java/org/jboss/hal/resources/Messages.java
+++ b/resources/src/main/java/org/jboss/hal/resources/Messages.java
@@ -113,6 +113,7 @@ public interface Messages extends com.google.gwt.i18n.client.Messages {
     SafeHtml deploymentReadError(String deployment);
     SafeHtml deploymentReplaced(@PluralCount int count);
     SafeHtml deploymentStopped(String name);
+    SafeHtml deploymentSubAlreadyExploded();
     SafeHtml deploymentSuccessful(String name);
     SafeHtml deploymentUnknownState(String name);
     SafeHtml destroyServerError(String name);

--- a/resources/src/main/resources/org/jboss/hal/resources/Constants.properties
+++ b/resources/src/main/resources/org/jboss/hal/resources/Constants.properties
@@ -155,6 +155,7 @@ expertMode=Switch to expert mode (model browser)
 expire=Expire
 expiredSessions=Expired Sessions
 explode=Explode
+explodeSubdeployments=Explode subdeployments
 exploded=exploded
 export=Export
 exportCertificate=Export Certificate

--- a/resources/src/main/resources/org/jboss/hal/resources/Messages.properties
+++ b/resources/src/main/resources/org/jboss/hal/resources/Messages.properties
@@ -124,6 +124,7 @@ deploymentReplaced=<strong>{0}</strong> deployments have been replaced.
 deploymentReplaced[\=1]=The deployment has been replaced.
 deploymentStandaloneColumnFilterDescription=Filter by: name or deployment status
 deploymentStopped=The deployment <strong>{0}</strong> is stopped.
+deploymentSubAlreadyExploded=Subdeployments are already exploded.
 deploymentSuccessful=<strong>{0}</strong> has been successfully deployed.
 deploymentUnknownState=The state of deployment <strong>{0}</strong> is unknown.
 deprecated=Deprecated since {0}, reason: {1}


### PR DESCRIPTION
It's a bit convoluted but this works.

Added a button to explode all subdeployments (this can only be done while the deployment is enabled and exploded), I don't know if there's a use case to explode each them separately. The only problem is that there's no way to tell if the subdeployments are exploded, so if the user tries the operation again we'll show an error - added a custom message since the default isn't very clear.