### PR TITLE
HAL-1639: Console does not display destination list, if the messaging server name is in caps

### DIFF
--- a/app/src/main/java/org/jboss/hal/client/configuration/subsystem/messaging/ServerSettingsColumn.java
+++ b/app/src/main/java/org/jboss/hal/client/configuration/subsystem/messaging/ServerSettingsColumn.java
@@ -93,7 +93,7 @@ public class ServerSettingsColumn
             List<StaticItem> items = new ArrayList<>();
             FinderSegment segment = context.getPath().findColumn(Ids.MESSAGING_SERVER_CONFIGURATION);
             if (segment != null) {
-                String server = Ids.extractMessagingServer(segment.getItemId());
+                String server = segment.getItemTitle();
                 StatementContext serverStatementContext = new SelectionAwareStatementContext(statementContext,
                         () -> server);
                 ResourceAddress address = SELECTED_SERVER_TEMPLATE.resolve(serverStatementContext);

--- a/app/src/main/java/org/jboss/hal/client/runtime/subsystem/messaging/DestinationColumn.java
+++ b/app/src/main/java/org/jboss/hal/client/runtime/subsystem/messaging/DestinationColumn.java
@@ -106,7 +106,7 @@ public class DestinationColumn extends FinderColumn<Destination> {
             // extract server name from the finder path
             FinderSegment segment = context.getPath().findColumn(Ids.MESSAGING_SERVER_RUNTIME);
             if (segment != null) {
-                String server = Ids.extractMessagingServer(segment.getItemId());
+                String server = segment.getItemTitle();
                 List<Operation> operations = new ArrayList<>();
                 for (Type type : SUBSYSTEM_RESOURCES) {
                     ResourceAddress address = MESSAGING_SERVER_TEMPLATE.append(type.resource + "=*")


### PR DESCRIPTION
https://issues.jboss.org/browse/HAL-1639

Id is converted to the lowercase, due to which the server name was set incorrectly. 