### PR TITLE
HAL-1602: do not show empty form state when nothing is selected

### DIFF
--- a/core/src/main/java/org/jboss/hal/core/mbui/form/ModelNodeForm.java
+++ b/core/src/main/java/org/jboss/hal/core/mbui/form/ModelNodeForm.java
@@ -276,7 +276,7 @@ public class ModelNodeForm<T extends ModelNode> extends AbstractForm<T> {
                         } else {
                             flip(READONLY);
                         }
-                    }, (op, failure) -> flip(EMPTY));
+                    }, (op, failure) -> flip(READONLY));
         }
     }
 


### PR DESCRIPTION
Issue: [HAL-1602](https://issues.jboss.org/browse/HAL-1602)

changed the failure outcome to show READONLY instead, in cases without a table the EMPTY gets shown because of `form.view(model)`