### PR TITLE
HAL-1646 Navigation doesn't remember chosen profile in some subsystems

### DIFF
--- a/app/src/main/java/org/jboss/hal/client/configuration/subsystem/elytron/ElytronColumn.java
+++ b/app/src/main/java/org/jboss/hal/client/configuration/subsystem/elytron/ElytronColumn.java
@@ -16,6 +16,7 @@
 package org.jboss.hal.client.configuration.subsystem.elytron;
 
 import java.util.List;
+import java.util.function.Supplier;
 
 import javax.inject.Inject;
 
@@ -56,7 +57,7 @@ public class ElytronColumn
                 .useFirstActionAsBreadcrumbHandler()
                 .withFilter());
 
-        List<StaticItem> items = asList(
+        Supplier<List<StaticItem>> itemsSupplier = () -> asList(
                 new StaticItem.Builder(resources.constants().globalSettings())
                         .id(Ids.ELYTRON)
                         .action(itemActionFactory.viewAndMonitor(Ids.ELYTRON,
@@ -98,12 +99,11 @@ public class ElytronColumn
                                 resources.previews().configurationElytronSecurityRealms()))
                         .keywords("realm")
                         .build()
-
-
         );
-        setItemsProvider((context, callback) -> callback.onSuccess(items));
+
+        setItemsProvider((context, callback) -> callback.onSuccess(itemsSupplier.get()));
         setBreadcrumbItemsProvider(
                 (context, callback) -> callback.onSuccess(
-                        items.stream().filter(item -> item.getNextColumn() == null).collect(toList())));
+                        itemsSupplier.get().stream().filter(item -> item.getNextColumn() == null).collect(toList())));
     }
 }

--- a/app/src/main/java/org/jboss/hal/client/configuration/subsystem/messaging/MessagingCategoryColumn.java
+++ b/app/src/main/java/org/jboss/hal/client/configuration/subsystem/messaging/MessagingCategoryColumn.java
@@ -43,29 +43,31 @@ public class MessagingCategoryColumn extends StaticItemColumn {
             Places places,
             Resources resources) {
 
-        super(finder, Ids.MESSAGING_CATEGORY, resources.constants().category(), asList(
-                new StaticItem.Builder(resources.constants().globalSettings())
-                        .id(Ids.MESSAGING_GLOBAL_SETTINGS)
-                        .action(itemActionFactory.view(places.selectedProfile(NameTokens.MESSAGING).build()))
-                        .onPreview(new MessagingSubsystemPreview(crud, resources))
-                        .build(),
-                new StaticItem.Builder(resources.constants().remoteActiveMQServer())
-                        .id(Ids.MESSAGING_REMOTE_ACTIVEMQ)
-                        .action(itemActionFactory.view(places.selectedProfile(NameTokens.MESSAGING_REMOTE_ACTIVEMQ).build()))
-                        .onPreview(new PreviewContent<>(Names.MESSAGING_REMOTE_ACTIVEMQ,
-                                resources.previews().configurationMessagingRemoteActiveMQ()))
-                        .build(),
-                new StaticItem.Builder(Names.SERVER)
-                        .nextColumn(Ids.MESSAGING_SERVER_CONFIGURATION)
-                        .onPreview(new PreviewContent<>(Names.SERVER,
-                                resources.previews().configurationMessagingServer()))
-                        .build(),
-                new StaticItem.Builder(Names.JMS_BRIDGE)
-                        .id(JMS_BRIDGE_ITEM)
-                        .nextColumn(Ids.JMS_BRIDGE)
-                        .onPreview(new PreviewContent<>(Names.JMS_BRIDGE,
-                                resources.previews().configurationMessagingJmsBridge()))
-                        .build()
-        ));
+        super(finder, Ids.MESSAGING_CATEGORY, resources.constants().category(), (context, callback) ->
+                callback.onSuccess(asList(
+                        new StaticItem.Builder(resources.constants().globalSettings())
+                                .id(Ids.MESSAGING_GLOBAL_SETTINGS)
+                                .action(itemActionFactory.view(places.selectedProfile(NameTokens.MESSAGING).build()))
+                                .onPreview(new MessagingSubsystemPreview(crud, resources))
+                                .build(),
+                        new StaticItem.Builder(resources.constants().remoteActiveMQServer())
+                                .id(Ids.MESSAGING_REMOTE_ACTIVEMQ)
+                                .action(itemActionFactory.view(places.selectedProfile(NameTokens.MESSAGING_REMOTE_ACTIVEMQ).build()))
+                                .onPreview(new PreviewContent<>(Names.MESSAGING_REMOTE_ACTIVEMQ,
+                                        resources.previews().configurationMessagingRemoteActiveMQ()))
+                                .build(),
+                        new StaticItem.Builder(Names.SERVER)
+                                .nextColumn(Ids.MESSAGING_SERVER_CONFIGURATION)
+                                .onPreview(new PreviewContent<>(Names.SERVER,
+                                        resources.previews().configurationMessagingServer()))
+                                .build(),
+                        new StaticItem.Builder(Names.JMS_BRIDGE)
+                                .id(JMS_BRIDGE_ITEM)
+                                .nextColumn(Ids.JMS_BRIDGE)
+                                .onPreview(new PreviewContent<>(Names.JMS_BRIDGE,
+                                        resources.previews().configurationMessagingJmsBridge()))
+                                .build()
+                ))
+        );
     }
 }

--- a/app/src/main/java/org/jboss/hal/client/configuration/subsystem/undertow/UndertowSettingsColumn.java
+++ b/app/src/main/java/org/jboss/hal/client/configuration/subsystem/undertow/UndertowSettingsColumn.java
@@ -16,6 +16,7 @@
 package org.jboss.hal.client.configuration.subsystem.undertow;
 
 import java.util.List;
+import java.util.function.Supplier;
 
 import javax.inject.Inject;
 
@@ -53,7 +54,7 @@ public class UndertowSettingsColumn
                 .onPreview(StaticItem::getPreviewContent)
                 .useFirstActionAsBreadcrumbHandler());
 
-        List<StaticItem> items = asList(
+        Supplier<List<StaticItem>> itemsSupplier = () -> asList(
                 new StaticItem.Builder(resources.constants().globalSettings())
                         .id(Ids.UNDERTOW_GLOBAL_SETTINGS)
                         .action(itemActionFactory.view(places.selectedProfile(NameTokens.UNDERTOW).build()))
@@ -97,9 +98,9 @@ public class UndertowSettingsColumn
                                 resources.previews().configurationUndertowHandlers()))
                         .build()
         );
-        setItemsProvider((context, callback) -> callback.onSuccess(items));
+        setItemsProvider((context, callback) -> callback.onSuccess(itemsSupplier.get()));
         setBreadcrumbItemsProvider(
                 (context, callback) -> callback.onSuccess(
-                        items.stream().filter(item -> item.getNextColumn() == null).collect(toList())));
+                        itemsSupplier.get().stream().filter(item -> item.getNextColumn() == null).collect(toList())));
     }
 }

--- a/app/src/main/java/org/jboss/hal/client/runtime/subsystem/elytron/ElytronColumn.java
+++ b/app/src/main/java/org/jboss/hal/client/runtime/subsystem/elytron/ElytronColumn.java
@@ -16,6 +16,7 @@
 package org.jboss.hal.client.runtime.subsystem.elytron;
 
 import java.util.List;
+import java.util.function.Supplier;
 
 import javax.inject.Inject;
 
@@ -47,7 +48,7 @@ public class ElytronColumn extends FinderColumn<StaticItem> {
                 .onPreview(StaticItem::getPreviewContent)
                 .useFirstActionAsBreadcrumbHandler());
 
-        List<StaticItem> items = asList(
+        Supplier<List<StaticItem>> itemsSupplier = () -> asList(
                 new StaticItem.Builder(Names.SECURITY_REALMS)
                         .onPreview(new PreviewContent<>(Names.SECURITY_REALMS, resources.previews().runtimeElytronSecurityRealms()))
                         .action(itemActionFactory.viewAndMonitor(Ids.ELYTRON_SECURITY_REALMS,
@@ -65,10 +66,10 @@ public class ElytronColumn extends FinderColumn<StaticItem> {
                         .build()
 
         );
-        setItemsProvider((context, callback) -> callback.onSuccess(items));
+        setItemsProvider((context, callback) -> callback.onSuccess(itemsSupplier.get()));
         setBreadcrumbItemsProvider(
                 (context, callback) -> callback.onSuccess(
-                        items.stream().filter(item -> item.getNextColumn() == null).collect(toList())));
+                        itemsSupplier.get().stream().filter(item -> item.getNextColumn() == null).collect(toList())));
 
     }
 }


### PR DESCRIPTION
Component issue: https://issues.jboss.org/browse/HAL-1646
EAP 7.3 issue: https://issues.jboss.org/browse/JBEAP-18157

Upstream PR: https://github.com/hal/console/pull/351

In certain ConfigurationColumns, list of menu items was created in a wrong scope - directly in a column constructor. Those menu items were then permanently linked to the profile selected when the column was created, even when user later selected different profile.

The items should rather be generated by an ItemsProvider, which will cause the items to be regenerated every time the column is displayed, so they will always link to a currently selected profile.