### PR TITLE
HAL-1647 JVM option is saved multiple times

### DIFF
--- a/ballroom/src/main/java/org/jboss/hal/ballroom/form/TagsItem.java
+++ b/ballroom/src/main/java/org/jboss/hal/ballroom/form/TagsItem.java
@@ -118,16 +118,7 @@ public abstract class TagsItem<T> extends AbstractFormItem<T> {
             inputContainer.appendChild(tagsContainer);
             inputContainer.appendChild(helpBlock);
             inputGroup.classList.add(properties);
-        }
 
-        @Override
-        protected String name() {
-            return "TagsEditingAppearance";
-        }
-
-        @Override
-        public void attach() {
-            super.attach();
             Options options = Defaults.get();
             options.tagsContainer = HASH + tagsContainer.id;
             options.validator = mapping.validator();
@@ -152,6 +143,11 @@ public abstract class TagsItem<T> extends AbstractFormItem<T> {
                 removeTag(mapping.parseTag(tag));
                 clearError();
             });
+        }
+
+        @Override
+        protected String name() {
+            return "TagsEditingAppearance";
         }
 
         @Override


### PR DESCRIPTION
Component issue: https://issues.jboss.org/browse/HAL-1647

TagsItem registers it's api.onAdded() callback inside the attach() method, which leads to the callback being registered multiple times (every time the component is attached). As a result, the JVM options field value is saved multiple times.