### PR TITLE
HAL-1640: fix the scope of host-related meatadata requirements

### DIFF
--- a/app/src/main/java/org/jboss/hal/client/runtime/BrowseByColumn.java
+++ b/app/src/main/java/org/jboss/hal/client/runtime/BrowseByColumn.java
@@ -45,18 +45,18 @@ import org.jboss.hal.spi.Column;
 import org.jboss.hal.spi.Footer;
 import org.jboss.hal.spi.Requires;
 
-import static org.jboss.hal.client.runtime.BrowseByColumn.DC_ADDRESS;
+import static org.jboss.hal.client.runtime.BrowseByColumn.ANY_HOST;
 import static org.jboss.hal.client.runtime.BrowseByColumn.SERVER_CONFIG_ADDRESS;
 import static org.jboss.hal.client.runtime.BrowseByColumn.SERVER_GROUP_ADDRESS;
 
 @Column(Ids.DOMAIN_BROWSE_BY)
-@Requires(value = {DC_ADDRESS, SERVER_GROUP_ADDRESS, SERVER_CONFIG_ADDRESS}, recursive = false)
+@Requires(value = {ANY_HOST, SERVER_GROUP_ADDRESS, SERVER_CONFIG_ADDRESS}, recursive = false)
 public class BrowseByColumn extends StaticItemColumn {
 
     // necessary for the constraints in topology preview
-    static final String DC_ADDRESS = "/{domain.controller}";
+    static final String ANY_HOST = "/host=*";
     static final String SERVER_GROUP_ADDRESS = "/server-group=*";
-    static final String SERVER_CONFIG_ADDRESS = "/{domain.controller}/server-config=*";
+    static final String SERVER_CONFIG_ADDRESS = ANY_HOST + "/server-config=*";
 
     public static boolean browseByHosts(FinderContext context) {
         FinderSegment firstSegment = context.getPath().iterator().next();

--- a/app/src/main/java/org/jboss/hal/client/runtime/configurationchanges/ConfigurationChangesPresenter.java
+++ b/app/src/main/java/org/jboss/hal/client/runtime/configurationchanges/ConfigurationChangesPresenter.java
@@ -72,10 +72,11 @@ import static org.jboss.hal.resources.Ids.ADD;
 public class ConfigurationChangesPresenter extends
         ApplicationFinderPresenter<ConfigurationChangesPresenter.MyView, ConfigurationChangesPresenter.MyProxy> {
 
-    public static final String HOST_CONFIGURATION_CHANGES_ADDRESS = "{selected.host}/subsystem=core-management/service=configuration-changes";
+    public static final String CONFIGURATION_CHANGES_ADDRESS = "/subsystem=core-management/service=configuration-changes";
+    public static final String HOST_CONFIGURATION_CHANGES_ADDRESS = "{selected.host}" + CONFIGURATION_CHANGES_ADDRESS;
     public static final AddressTemplate HOST_CONFIGURATION_CHANGES_TEMPLATE = AddressTemplate.of(
             HOST_CONFIGURATION_CHANGES_ADDRESS);
-    private static final String SERVER_CONFIGURATION_CHANGES_ADDRESS = "/{selected.host}/{selected.server}/subsystem=core-management/service=configuration-changes";
+    private static final String SERVER_CONFIGURATION_CHANGES_ADDRESS = "/{selected.host}/{selected.server}" + CONFIGURATION_CHANGES_ADDRESS;
     public static final AddressTemplate SERVER_CONFIGURATION_CHANGES_TEMPLATE = AddressTemplate.of(
             SERVER_CONFIGURATION_CHANGES_ADDRESS);
     private static final String PROFILE_CONFIGURATION_CHANGES_ADDRESS = "/profile=*/subsystem=core-management/service=configuration-changes";

--- a/app/src/main/java/org/jboss/hal/client/runtime/host/AddressTemplates.java
+++ b/app/src/main/java/org/jboss/hal/client/runtime/host/AddressTemplates.java
@@ -17,22 +17,24 @@ package org.jboss.hal.client.runtime.host;
 
 import org.jboss.hal.meta.AddressTemplate;
 
+import static org.jboss.hal.client.runtime.configurationchanges.ConfigurationChangesPresenter.CONFIGURATION_CHANGES_ADDRESS;
+
 interface AddressTemplates {
 
     String DOMAIN_CONTROLLER = "{domain.controller}";
-    String SELECTED_HOST = "{selected.host}";
+    String ANY_HOST = "host=*";
 
     String ELYTRON_ADDRESS = DOMAIN_CONTROLLER + "/subsystem=elytron";
-    String HTTP_INTERFACE_ADDRESS = SELECTED_HOST + "/core-service=management/management-interface=http-interface";
+    String HTTP_INTERFACE_ADDRESS = ANY_HOST + "/core-service=management/management-interface=http-interface";
     String HOST_CONNECTION_ADDRESS = "/core-service=management/host-connection=*";
-    String HOST_CONFIGURATION_CHANGES_ADDRESS = DOMAIN_CONTROLLER + "/subsystem=core-management/service=configuration-changes";
-    String HOST_MANAGEMENT_OPERATIONS_ADDRESS = DOMAIN_CONTROLLER + "/core-service=management/service=management-operations";
-    String INTERFACE_ADDRESS = SELECTED_HOST + "/interface=*";
-    String JVM_ADDRESS = SELECTED_HOST + "/jvm=*";
-    String NATIVE_INTERFACE_ADDRESS = SELECTED_HOST + "/core-service=management/management-interface=native-interface";
-    String PATH_ADDRESS = SELECTED_HOST + "/path=*";
-    String SOCKET_BINDING_GROUP_ADDRESS = SELECTED_HOST + "/socket-binding-group=*";
-    String SYSTEM_PROPERTY_ADDRESS = SELECTED_HOST + "/system-property=*";
+    String HOST_CONFIGURATION_CHANGES_ADDRESS = ANY_HOST + CONFIGURATION_CHANGES_ADDRESS;
+    String HOST_MANAGEMENT_OPERATIONS_ADDRESS = ANY_HOST + "/core-service=management/service=management-operations";
+    String INTERFACE_ADDRESS = ANY_HOST + "/interface=*";
+    String JVM_ADDRESS = ANY_HOST + "/jvm=*";
+    String NATIVE_INTERFACE_ADDRESS = ANY_HOST + "/core-service=management/management-interface=native-interface";
+    String PATH_ADDRESS = ANY_HOST + "/path=*";
+    String SOCKET_BINDING_GROUP_ADDRESS = ANY_HOST + "/socket-binding-group=*";
+    String SYSTEM_PROPERTY_ADDRESS = ANY_HOST + "/system-property=*";
 
     AddressTemplate HTTP_INTERFACE_TEMPLATE = AddressTemplate.of(HTTP_INTERFACE_ADDRESS);
     AddressTemplate NATIVE_INTERFACE_TEMPLATE = AddressTemplate.of(NATIVE_INTERFACE_ADDRESS);

--- a/app/src/main/java/org/jboss/hal/client/runtime/host/HostColumn.java
+++ b/app/src/main/java/org/jboss/hal/client/runtime/host/HostColumn.java
@@ -67,7 +67,7 @@ import org.jboss.hal.spi.Requires;
 
 import static java.util.Collections.emptyList;
 import static java.util.stream.Collectors.toList;
-import static org.jboss.hal.client.runtime.configurationchanges.ConfigurationChangesPresenter.HOST_CONFIGURATION_CHANGES_TEMPLATE;
+import static org.jboss.hal.client.runtime.configurationchanges.ConfigurationChangesPresenter.CONFIGURATION_CHANGES_ADDRESS;
 import static org.jboss.hal.client.runtime.host.AddressTemplates.HOST_CONFIGURATION_CHANGES_ADDRESS;
 import static org.jboss.hal.client.runtime.host.AddressTemplates.HOST_CONNECTION_ADDRESS;
 import static org.jboss.hal.client.runtime.host.AddressTemplates.HOST_CONNECTION_TEMPLATE;
@@ -196,7 +196,7 @@ public class HostColumn extends FinderColumn<Host> implements HostActionHandler,
                                     .with(HOST, item.getAddressName())
                                     .build();
                             actions.add(itemActionFactory.placeRequest(resources.constants().configurationChanges(),
-                                    ccPlaceRequest, Constraint.executable(HOST_CONFIGURATION_CHANGES_TEMPLATE, ADD)));
+                                    ccPlaceRequest, Constraint.executable(hostTemplate(item).append(CONFIGURATION_CHANGES_ADDRESS), ADD)));
                         }
                         // TODO Add additional operations like :reload(admin-mode=true), :clean-obsolete-content or :take-snapshot
                         actions.add(ItemAction.separator());

--- a/app/src/main/java/org/jboss/hal/client/runtime/host/HostPresenter.java
+++ b/app/src/main/java/org/jboss/hal/client/runtime/host/HostPresenter.java
@@ -186,7 +186,7 @@ public class HostPresenter
 
     void saveHost(Form<Host> form, Map<String, Object> changedValues) {
         boolean hostNameChanged = changedValues.containsKey(NAME);
-        crud.save(Names.HOST, form.getModel().getName(), AddressTemplate.of(SELECTED_HOST), changedValues, () -> {
+        crud.save(Names.HOST, form.getModel().getName(), AddressTemplate.of("/{selected.host}"), changedValues, () -> {
             reload();
             if (hostNameChanged) {
                 DialogFactory.showConfirmation(resources.constants().hostNameChanged(),
@@ -406,7 +406,7 @@ public class HostPresenter
     // @formatter:off
     @ProxyCodeSplit
     @NameToken(NameTokens.HOST_CONFIGURATION)
-    @Requires(value = {SELECTED_HOST, INTERFACE_ADDRESS, JVM_ADDRESS, PATH_ADDRESS, SOCKET_BINDING_GROUP_ADDRESS,
+    @Requires(value = {ANY_HOST, INTERFACE_ADDRESS, JVM_ADDRESS, PATH_ADDRESS, SOCKET_BINDING_GROUP_ADDRESS,
             SYSTEM_PROPERTY_ADDRESS, HTTP_INTERFACE_ADDRESS, NATIVE_INTERFACE_ADDRESS}, recursive = false)
     public interface MyProxy extends ProxyPlace<HostPresenter> {
     }


### PR DESCRIPTION
Issue: [HAL-1640](https://issues.redhat.com/browse/HAL-1640)

I have replaced most instances of `{domain.controller}` with `{host=*}`, since that only worked for master host controller. I have also replaced some instances of `{selected.host}` with `{host=*}` since they were used in places where no host has been selected yet (and so the wildcard was resolving to nothing).