### PR TITLE
HAL-1669: add object attribute support to model browser

### DIFF
--- a/core/src/main/java/org/jboss/hal/core/mbui/form/ModelNodeForm.java
+++ b/core/src/main/java/org/jboss/hal/core/mbui/form/ModelNodeForm.java
@@ -294,10 +294,15 @@ public class ModelNodeForm<T extends ModelNode> extends AbstractForm<T> {
             case EDITING:
                 // change restricted and enabled state
                 for (FormItem formItem : getBoundFormItems()) {
-                    formItem.setRestricted(!securityContext.isReadable(formItem.getName()));
+                    String name = formItem.getName();
+                    int pos = name.indexOf('.');
+                    if (pos > 0) {
+                        name = name.substring(0,pos);
+                    }
+                    formItem.setRestricted(!securityContext.isReadable(name));
                     // don't touch disabled form items
                     if (formItem.isEnabled()) {
-                        formItem.setEnabled(securityContext.isWritable(formItem.getName()));
+                        formItem.setEnabled(securityContext.isWritable(name));
                     }
                 }
                 break;

--- a/core/src/main/java/org/jboss/hal/core/modelbrowser/ModelBrowser.java
+++ b/core/src/main/java/org/jboss/hal/core/modelbrowser/ModelBrowser.java
@@ -46,6 +46,7 @@ import org.jboss.hal.core.mbui.form.ModelNodeForm;
 import org.jboss.hal.dmr.ModelNode;
 import org.jboss.hal.dmr.ModelNodeHelper;
 import org.jboss.hal.dmr.Operation;
+import org.jboss.hal.dmr.Property;
 import org.jboss.hal.dmr.ResourceAddress;
 import org.jboss.hal.dmr.dispatch.Dispatcher;
 import org.jboss.hal.flow.FlowContext;
@@ -82,10 +83,7 @@ import static org.jboss.hal.ballroom.Skeleton.MARGIN_SMALL;
 import static org.jboss.hal.ballroom.Skeleton.applicationOffset;
 import static org.jboss.hal.core.modelbrowser.SingletonState.CHOOSE;
 import static org.jboss.hal.core.modelbrowser.SingletonState.CREATE;
-import static org.jboss.hal.dmr.ModelDescriptionConstants.ADD;
-import static org.jboss.hal.dmr.ModelDescriptionConstants.PROFILE;
-import static org.jboss.hal.dmr.ModelDescriptionConstants.READ_RESOURCE_OPERATION;
-import static org.jboss.hal.dmr.ModelDescriptionConstants.SERVER_GROUP;
+import static org.jboss.hal.dmr.ModelDescriptionConstants.*;
 import static org.jboss.hal.flow.Flow.series;
 import static org.jboss.hal.meta.StatementContext.Expression.SELECTED_GROUP;
 import static org.jboss.hal.meta.StatementContext.Expression.SELECTED_PROFILE;
@@ -401,6 +399,7 @@ public class ModelBrowser implements IsElement<HTMLElement> {
             metadataProcessor.lookup(template, progress.get(), new SuccessfulMetadataCallback(eventBus, resources) {
                 @Override
                 public void onMetadata(Metadata metadata) {
+                    flattenDescription(metadata.getDescription().get(OPERATIONS).get(ADD).get(REQUEST_PROPERTIES));
                     String title = new LabelBuilder().label(parent.text);
                     NameItem nameItem = new NameItem();
                     String id = Ids.build(parent.id, "add");
@@ -412,12 +411,43 @@ public class ModelBrowser implements IsElement<HTMLElement> {
 
                     AddResourceDialog dialog = new AddResourceDialog(
                             resources.messages().addResourceTitle(title),
-                            form, (name1, model) ->
-                            crud.add(title, nameItem.getValue(), fqAddress(parent, nameItem.getValue()),
-                                    model, (n, a) -> refresh(parent)));
+                            form, (name1, model) -> {
+                                unflattenModel(model);
+                                crud.add(title, nameItem.getValue(), fqAddress(parent, nameItem.getValue()),
+                                    model, (n, a) -> refresh(parent));
+                            });
                     dialog.show();
                 }
             });
+        }
+    }
+
+    private void flattenDescription(ModelNode model) {
+        for (Property p : model.asPropertyList()) {
+            if (p.getValue().get(TYPE).asString().equalsIgnoreCase(OBJECT) && !p.getValue().get(VALUE_TYPE).asString().equalsIgnoreCase(STRING)) {
+
+                model.remove(p.getName());
+
+                for (Property nested : p.getValue().get(VALUE_TYPE).asPropertyList()) {
+                    model.get(p.getName() + "." + nested.getName()).set(nested.getValue());
+                }
+            }
+        }
+    }
+
+    private void unflattenModel(ModelNode model) {
+        if (!model.isDefined()) {
+            return;
+        }
+        for (Property p : model.asPropertyList()) {
+            if (p.getName().indexOf('.') < 0) {
+                continue;
+            }
+
+            String[] split = p.getName().split("\\.");
+
+            model.remove(p.getName());
+            model.get(split[0]).get(split[1]).set(p.getValue());
         }
     }
 


### PR DESCRIPTION
Issue: [HAL-1669](https://issues.redhat.com/browse/HAL-1669)
Related: [JBEAP-18368](https://issues.redhat.com/browse/JBEAP-18368)

The idea is this:
When adding a new resource:
 - if there are required Object attributes (in OPERATIONS / ADD / REQUEST_PROPERTIES) take their nested attributes and put them on the same level as the primary attributes, change their name to "parent.attribute" (unfortunately in the case of Keycloak they'll still be hidden under Optional attributes)
 - when retrieving the form create the object based on those names

When editing a resource
 - same thing, put nested attributes on the same level as other attributes
 - when the form is saved we don't have to do anything because CLI `write-attribute` supports the "parent.attribute" format