### PR TITLE
HAL-1682 fix wrong op name for message moving

### DIFF
--- a/app/src/main/java/org/jboss/hal/client/runtime/subsystem/messaging/JmsQueuePresenter.java
+++ b/app/src/main/java/org/jboss/hal/client/runtime/subsystem/messaging/JmsQueuePresenter.java
@@ -300,13 +300,13 @@ public class JmsQueuePresenter extends ApplicationFinderPresenter<JmsQueuePresen
                             String destination = form.getModel().get(OTHER_QUEUE_NAME).asString();
                             boolean rejectDuplicates = failSafeBoolean(form.getModel(), REJECT_DUPLICATES);
                             if (messages.size() == 1) {
-                                operation = new Operation.Builder(queueAddress(), CHANGE_MESSAGE_PRIORITY)
+                                operation = new Operation.Builder(queueAddress(), MOVE_MESSAGE)
                                         .param(MESSAGE_ID, messages.get(0).getMessageId())
                                         .param(OTHER_QUEUE_NAME, destination)
                                         .param(REJECT_DUPLICATES, rejectDuplicates)
                                         .build();
                             } else {
-                                operation = new Operation.Builder(queueAddress(), CHANGE_MESSAGES_PRIORITY)
+                                operation = new Operation.Builder(queueAddress(), MOVE_MESSAGES)
                                         .param(FILTER, filter(messages))
                                         .param(OTHER_QUEUE_NAME, destination)
                                         .param(REJECT_DUPLICATES, rejectDuplicates)


### PR DESCRIPTION
(cherry picked from commit 0ec5ecef18620d5e649917dab6c7227503865caa)

issue: https://issues.redhat.com/browse/HAL-1682

JBEAP issue: https://issues.redhat.com/browse/JBEAP-19236

The op name for move-message and move-messages are wrong.

upstream PR: https://github.com/hal/console/pull/396