### PR TITLE
Fix action Undeploy in Server Group Deployment

### DIFF
--- a/app/src/main/java/org/jboss/hal/client/deployment/ServerGroupDeploymentColumn.java
+++ b/app/src/main/java/org/jboss/hal/client/deployment/ServerGroupDeploymentColumn.java
@@ -280,7 +280,7 @@ public class ServerGroupDeploymentColumn extends FinderColumn<ServerGroupDeploym
                             .build());
                 }
                 AddressTemplate template = SERVER_GROUP_DEPLOYMENT_TEMPLATE
-                        .replaceWildcards(statementContext.selectedServerGroup());
+                        .replaceWildcards(item.getName());
                 actions.add(new ItemAction.Builder<ServerGroupDeployment>()
                         .title(resources.constants().undeploy())
                         .handler(item -> crud.remove(Names.DEPLOYMENT, item.getName(), template,


### PR DESCRIPTION
Action _Undeploy_ failed with a message  *{"domain-failure-description" => "WFLYCTL0216: Management resource '[(\"deployment\" => \"**server-group-name**\")]' not found"}*.