### PR TITLE
HAL-1633: enable JAXRS subsystem

### DIFF
--- a/app/src/main/java/org/jboss/hal/client/configuration/subsystem/SubsystemColumn.java
+++ b/app/src/main/java/org/jboss/hal/client/configuration/subsystem/SubsystemColumn.java
@@ -61,7 +61,7 @@ public class SubsystemColumn extends FinderColumn<SubsystemMetadata> {
 
     private static final AddressTemplate SUBSYSTEM_TEMPLATE = AddressTemplate.of(SELECTED_PROFILE, "subsystem=*");
     private static final boolean DISABLE_EMPTY_SUBSYSTEM = true;
-    private static final List<String> EMPTY_SUBSYSTEMS = asList("bean-validation", "ee-security", "jaxrs", "jdr",
+    private static final List<String> EMPTY_SUBSYSTEMS = asList("bean-validation", "ee-security", "jdr",
             "jsr77", "microprofile-opentracing-smallrye", "pojo", "sar");
 
     @Inject


### PR DESCRIPTION
Issue: [HAL-1633](https://issues.redhat.com/browse/HAL-1633)

Since the subsystem doesn't contain any children or complex attributes I didn't add a dedicated view, the model browser can handle it.