### PR TITLE
HAL-1704: adjust donut charts 

### DIFF
--- a/app/src/less/hal.less
+++ b/app/src/less/hal.less
@@ -109,7 +109,6 @@
 @import "../../node_modules/patternfly/dist/less/bootstrap-treeview.less";
 @import "../../node_modules/patternfly/dist/less/cards.less";
 @import "../../node_modules/patternfly/dist/less/card-view.less";
-@import "../../node_modules/patternfly/dist/less/charts.less";
 @import "../../node_modules/patternfly/dist/less/close.less";
 @import "../../node_modules/patternfly/dist/less/datatables.less";
 @import "../../node_modules/patternfly/dist/less/experimental-features.less";
@@ -146,6 +145,9 @@
 // Misc
 @import (less) "../../node_modules/c3/c3.css";
 @import (less) "../../node_modules/google-code-prettify/src/prettify.css";
+
+// has to be imported after c3, do not move
+@import "../../node_modules/patternfly/dist/less/charts.less";
 
 // HAL
 @import "variables";

--- a/app/src/main/java/org/jboss/hal/client/runtime/subsystem/undertow/DeploymentPreview.java
+++ b/app/src/main/java/org/jboss/hal/client/runtime/subsystem/undertow/DeploymentPreview.java
@@ -126,7 +126,7 @@ class DeploymentPreview extends PreviewContent<DeploymentResource> {
                 .add(ACTIVE_SESSIONS, resources.constants().activeSessions(), PatternFly.colors.green)
                 .add(EXPIRED_SESSIONS, resources.constants().expiredSessions(), PatternFly.colors.orange)
                 .add(REJECTED_SESSIONS, resources.constants().rejectedSessions(), PatternFly.colors.red)
-                .legend(Donut.Legend.BOTTOM)
+                .legend(Donut.Legend.RIGHT)
                 .responsive(true)
                 .build();
         registerAttachable(sessions);

--- a/ballroom/src/main/java/org/jboss/hal/ballroom/chart/Donut.java
+++ b/ballroom/src/main/java/org/jboss/hal/ballroom/chart/Donut.java
@@ -29,6 +29,7 @@ import org.jboss.hal.resources.UIConstants;
 import static elemental2.dom.DomGlobal.window;
 import static org.jboss.gwt.elemento.core.Elements.div;
 import static org.jboss.hal.ballroom.JQuery.$;
+import static org.jboss.hal.ballroom.chart.Donut.Legend.BOTTOM;
 import static org.jboss.hal.ballroom.chart.Donut.Legend.NONE;
 import static org.jboss.hal.resources.UIConstants.HASH;
 
@@ -57,6 +58,7 @@ public class Donut implements IsElement<HTMLElement>, Attachable {
         options.data.type = "donut";
         options.donut.title = builder.unit;
         options.legend.show = builder.legend != NONE;
+        options.legend.position = builder.legend == BOTTOM ? "bottom" : "right";
         options.size.width = builder.width != -1 ? builder.width : builder.legend.width;
         options.size.height = builder.width != -1 ? (int) (builder.width / builder.legend.ratio) : builder.legend.height;
         options.tooltip.show = true;
@@ -134,7 +136,7 @@ public class Donut implements IsElement<HTMLElement>, Attachable {
 
 
     public enum Legend {
-        NONE(200, 171), RIGHT(251, 161), BOTTOM(271, 191);
+        NONE(200, 171), RIGHT(291, 161), BOTTOM(271, 191);
 
         final int width;
         final int height;

--- a/ballroom/src/main/java/org/jboss/hal/ballroom/chart/Donut.java
+++ b/ballroom/src/main/java/org/jboss/hal/ballroom/chart/Donut.java
@@ -15,8 +15,10 @@
  */
 package org.jboss.hal.ballroom.chart;
 
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import elemental2.core.JsArray;
 import elemental2.dom.HTMLElement;
@@ -24,6 +26,7 @@ import jsinterop.base.JsPropertyMap;
 import org.jboss.gwt.elemento.core.IsElement;
 import org.jboss.hal.ballroom.Attachable;
 import org.jboss.hal.js.JsHelper;
+import org.jboss.hal.resources.Strings;
 import org.jboss.hal.resources.UIConstants;
 
 import static elemental2.dom.DomGlobal.window;
@@ -107,6 +110,7 @@ public class Donut implements IsElement<HTMLElement>, Attachable {
         long total = 0;
         JsPropertyMap<Object> dataMap = JsPropertyMap.of();
         JsArray<JsArray<Object>> columns = new JsArray<>();
+        JsPropertyMap<Object> names = JsPropertyMap.of();
 
         for (Map.Entry<String, Long> entry : data.entrySet()) {
             String key = entry.getKey();
@@ -114,11 +118,13 @@ public class Donut implements IsElement<HTMLElement>, Attachable {
             total += value;
             JsArray<Object> column = new JsArray<>();
             column.push(key, value);
+            names.set(key, nameAndCount(key, value));
             columns.push(column);
         }
 
         Charts.setDonutChartTitle(HASH + root.id, String.valueOf(total), builder.unit);
         dataMap.set("columns", columns); //NON-NLS
+        dataMap.set("names", names); //NON-NLS
         api().load(dataMap);
     }
 
@@ -132,6 +138,11 @@ public class Donut implements IsElement<HTMLElement>, Attachable {
     private void resizeInParent() {
         HTMLElement parent = (HTMLElement) root.parentNode;
         resize((int) $(parent).width());
+    }
+
+    private String nameAndCount(String name, long count) {
+        String[] parts = name.split("[-_]");
+        return Arrays.stream(parts).map(String::toLowerCase).map(Strings::capitalize).collect(Collectors.joining(" ")) + ": " + count;
     }
 
 


### PR DESCRIPTION
Issue: [HAL-1704](https://issues.redhat.com/browse/HAL-1704)

Adjusted donut charts, the legend position was not being used and the styles were not applies properly.
Added subtotals to the legend, in case of web sessions moved the legend right since there's more space (otherwise the donut ends up being even smaller)