### PR TITLE
HAL-1717 correct Oracle connection URL in template

### DIFF
--- a/app/src/main/java/org/jboss/hal/client/configuration/subsystem/datasource/DataSourceTemplates.java
+++ b/app/src/main/java/org/jboss/hal/client/configuration/subsystem/datasource/DataSourceTemplates.java
@@ -220,7 +220,7 @@ public class DataSourceTemplates implements Iterable<DataSourceTemplate> {
                     return dataSource;
                 },
                 oracleDriver,
-                properties("URL", "jdbc:oracle:oci8:@tc")));
+                properties("URL", "jdbc:oracle:thin:@SERVER_NAME:PORT:ORACLE_SID")));
 
 
         // ------------------------------------------------------ Microsoft SQL Server


### PR DESCRIPTION
https://issues.redhat.com/browse/HAL-1717

HAL-1717 correct Oracle connection URL in template based on https://access.redhat.com/documentation/en-us/red_hat_jboss_enterprise_application_platform/7.3/html-single/configuration_guide/index#datasource_connection_urls