### PR TITLE
[HAL-1716] HAL doesn't permit creation of working XA datasource

### DIFF
--- a/app/src/main/java/org/jboss/hal/client/configuration/subsystem/datasource/wizard/DataSourceWizard.java
+++ b/app/src/main/java/org/jboss/hal/client/configuration/subsystem/datasource/wizard/DataSourceWizard.java
@@ -210,7 +210,7 @@ public class DataSourceWizard {
 
         builder.addStep(CHOOSE_TEMPLATE, new ChooseTemplateStep(templates, resources, xa));
         builder.addStep(NAMES, new NamesStep(dataSources, dataSourceMetadata, resources, xa));
-        builder.addStep(DRIVER, new DriverStep(drivers, driverMetadata, resources));
+        builder.addStep(DRIVER, new DriverStep(drivers, driverMetadata, resources, xa));
         if (xa) {
             builder.addStep(XA_PROPERTIES, new PropertiesStep(dispatcher, statementContext, environment, progress,
                     xaDataSourcePropertiesMetadata, resources));

--- a/core/src/main/java/org/jboss/hal/core/datasource/DataSource.java
+++ b/core/src/main/java/org/jboss/hal/core/datasource/DataSource.java
@@ -83,7 +83,11 @@ public class DataSource extends NamedNode {
 
     public void setDriver(JdbcDriver driver) {
         get(DRIVER_NAME).set(driver.getName());
-        get(DRIVER_CLASS).set(driver.get(DRIVER_CLASS_NAME));
+        if (isXa()) {
+            get(XA_DATASOURCE_CLASS).set(driver.get(DRIVER_XA_DATASOURCE_CLASS_NAME));
+        } else {
+            get(DRIVER_CLASS).set(driver.get(DRIVER_CLASS_NAME));
+        }
     }
 
     public boolean fromDeployment() {


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/HAL-1716

Three main changes done here:

1. Now the `DriverStep` manages `DRIVER_CLASS_NAME` or `DRIVER_XA_DATASOURCE_CLASS_NAME` depending if it is an xa data-source or not.
2. The `DRIVER_XA_DATASOURCE_CLASS_NAME` is now a compulsory attribute (this is a bit strange, because it is compulsory only if the driver has not defined this property, I have added it as compulsory always but we can change this if you prefer).
3. A value change handler has been added to modify that attribute when the driver is changed. The handler first try to add the driver xa data-source class first and, if it's not defined there, the value in the template.

PR for develop branch.