### PR TITLE
HAL-1723 update url in template for MS SQLServer datasource

### DIFF
--- a/app/src/main/java/org/jboss/hal/client/configuration/subsystem/datasource/DataSourceTemplates.java
+++ b/app/src/main/java/org/jboss/hal/client/configuration/subsystem/datasource/DataSourceTemplates.java
@@ -238,7 +238,7 @@ public class DataSourceTemplates implements Iterable<DataSourceTemplate> {
                     dataSource.get(JNDI_NAME).set("java:/MSSQLDS");
                     dataSource.get(DRIVER_NAME).set(SQLSERVER);
                     dataSource.get(CONNECTION_URL)
-                            .set("jdbc:microsoft:sqlserver://localhost:1433;DatabaseName=MyDatabase");
+                            .set("jdbc:sqlserver://localhost:1433;DatabaseName=MyDatabase");
                     dataSource.get(USER_NAME).set(ADMIN);
                     dataSource.get(PASSWORD).set(ADMIN);
                     dataSource.get(BACKGROUND_VALIDATION).set(true);


### PR DESCRIPTION
(cherry picked from commit 63a689c4154ed44a77a0b80b55fd51a1006712af)

Issue: https://issues.redhat.com/browse/HAL-1723

This was actually fixed in HAL 2.8.26 with https://issues.redhat.com/browse/HAL-1098, in repository https://github.com/hal/core
Old PR https://github.com/hal/core/pull/210, but it seems the fix was not included when migrating HAL code to https://github.com/hal/console in HAL 3 development.

Downstream PR: https://github.com/hal/console/pull/434