### PR TITLE
HAL-1721 remove STALE_CONNECTION_CHECKER_CLASS_NAME for DB2XADS

### DIFF
--- a/app/src/main/java/org/jboss/hal/client/configuration/subsystem/datasource/DataSourceTemplates.java
+++ b/app/src/main/java/org/jboss/hal/client/configuration/subsystem/datasource/DataSourceTemplates.java
@@ -363,8 +363,6 @@ public class DataSourceTemplates implements Iterable<DataSourceTemplate> {
                             .set("org.jboss.jca.adapters.jdbc.extensions.db2.DB2ValidConnectionChecker");
                     dataSource.get(EXCEPTION_SORTER_CLASS_NAME)
                             .set("org.jboss.jca.adapters.jdbc.extensions.db2.DB2ExceptionSorter");
-                    dataSource.get(STALE_CONNECTION_CHECKER_CLASS_NAME)
-                            .set("org.jboss.jca.adapters.jdbc.extensions.db2.DB2StaleConnectionChecker");
                     dataSource.get(RECOVERY_PLUGIN_CLASS_NAME)
                             .set("org.jboss.jca.core.recovery.ConfigurableRecoveryPlugin");
                     // TODO Add missing recovery plugin properties


### PR DESCRIPTION
https://issues.redhat.com/browse/HAL-1721
remove STALE_CONNECTION_CHECKER_CLASS_NAME for DB2XADS

It was previously removed for DB2DS in https://github.com/hal/console/pull/440, but it hasn't been done for DB2XADS