### PR TITLE
HAL-1740: fix security handling in Model Browser

### DIFF
--- a/ballroom/src/main/java/org/jboss/hal/ballroom/table/DataTable.java
+++ b/ballroom/src/main/java/org/jboss/hal/ballroom/table/DataTable.java
@@ -19,14 +19,19 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 
+import elemental2.dom.Element;
 import elemental2.dom.HTMLElement;
 import elemental2.dom.HTMLTableElement;
+import elemental2.dom.NodeList;
 import org.jboss.gwt.elemento.core.Elements;
 import org.jboss.hal.ballroom.JQuery;
 import org.jboss.hal.ballroom.form.Form;
 import org.jboss.hal.ballroom.table.Api.CallbackUnionType;
 import org.jboss.hal.ballroom.table.Api.DrawCallback;
 import org.jboss.hal.ballroom.table.Api.SelectCallback;
+import org.jboss.hal.meta.security.AuthorisationDecision;
+import org.jboss.hal.meta.security.ElementGuard;
+import org.jboss.hal.resources.UIConstants;
 
 import static elemental2.dom.DomGlobal.document;
 import static java.util.Arrays.asList;
@@ -43,6 +48,7 @@ import static org.jboss.hal.resources.CSS.tableBordered;
 import static org.jboss.hal.resources.CSS.tableHover;
 import static org.jboss.hal.resources.CSS.tableStriped;
 import static org.jboss.hal.resources.UIConstants.HASH;
+import static org.jboss.hal.resources.UIConstants.data;
 
 /**
  * Table element which implements the DataTables plugin for jQuery. Using the data table consists of these steps:
@@ -329,5 +335,13 @@ public class DataTable<T> implements Table<T> {
                 api().rows(rows).select();
             }
         }
+    }
+
+    public void applySecurity(Map<Integer, String> buttonConstraints, AuthorisationDecision authorisationDecision) {
+        buttonConstraints.forEach((index, constraint) -> {
+            buttonElement(index).attr(data(UIConstants.CONSTRAINT), constraint);
+        });
+        NodeList<Element> elements = element().querySelectorAll("[" + data(UIConstants.CONSTRAINT + "]"));
+        Elements.stream(elements).forEach(new ElementGuard.Toggle(authorisationDecision));
     }
 }

--- a/core/src/main/java/org/jboss/hal/core/modelbrowser/ChildrenPanel.java
+++ b/core/src/main/java/org/jboss/hal/core/modelbrowser/ChildrenPanel.java
@@ -15,8 +15,10 @@
  */
 package org.jboss.hal.core.modelbrowser;
 
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import com.google.gwt.safehtml.shared.SafeHtmlBuilder;
@@ -135,12 +137,12 @@ class ChildrenPanel implements Iterable<HTMLElement>, Attachable {
                         new MetadataProcessor.MetadataCallback() {
                             @Override
                             public void onMetadata(Metadata metadata) {
-                                table.enableButton(0, AuthorisationDecision.from(environment,
-                                        constraint -> Optional.of(metadata.getSecurityContext()))
-                                        .isAllowed(Constraint.executable(template, ADD)));
-                                table.enableButton(1, AuthorisationDecision.from(environment,
-                                        constraint -> Optional.of(metadata.getSecurityContext()))
-                                        .isAllowed(Constraint.executable(template, REMOVE)));
+                                Map<Integer, String> buttonConstraints = new HashMap<>();
+                                buttonConstraints.put(0, Constraint.executable(template, ADD).data());
+                                buttonConstraints.put(1, Constraint.executable(template, REMOVE).data());
+
+                                ((DataTable) table).applySecurity(buttonConstraints,
+                                        AuthorisationDecision.from(environment, constraint -> Optional.of(metadata.getSecurityContext())));
                             }
 
                             @Override


### PR DESCRIPTION
Issue: [HAL-1740](https://issues.redhat.com/browse/HAL-1740)

Changed the table buttons in Model Browser tables to properly work with RBAC, the buttons will now be hidden instead of disabled. The disabling wasn't working anyway, since they would get enabled by the default datatable behavior.