### PR TITLE
[JBEAP-21565] [HAL-1742] [HAL-1749] Fix address parsing when address contains duplicate parts

### DIFF
--- a/dmr/src/main/java/org/jboss/hal/dmr/ResourceAddress.java
+++ b/dmr/src/main/java/org/jboss/hal/dmr/ResourceAddress.java
@@ -15,7 +15,6 @@
  */
 package org.jboss.hal.dmr;
 
-import com.google.common.base.Strings;
 import jsinterop.annotations.JsIgnore;
 import jsinterop.annotations.JsMethod;
 import jsinterop.annotations.JsProperty;
@@ -40,21 +39,38 @@ public class ResourceAddress extends ModelNode {
 
     /** Creates a new resource address from the specified string. */
     public static ResourceAddress from(String address) {
-        if (Strings.isNullOrEmpty(address)) {
-            throw new IllegalArgumentException("Address must not be null or empty");
+        if (address == null) {
+            throw new IllegalArgumentException("Address must not be null");
         }
-        String safeAddress = address.startsWith("/") ? address.substring(1) : address;
-        ResourceAddress ra = new ResourceAddress();
-        String[] parts = safeAddress.split("/");
-        if (parts.length == 0) {
-            throw new IllegalArgumentException("Malformed address: " + address);
-        }
-        for (String part : parts) {
-            String[] kv = part.split("=");
-            if (kv.length != 2) {
-                throw new IllegalArgumentException("Malformed part '" + part + "' in address: " + address);
+
+        ResourceAddress ra;
+        if (address.trim().length() == 0) {
+            ra = ResourceAddress.root();
+        } else {
+            String safeAddress = address.startsWith("/") ? address.substring(1) : address;
+            if (safeAddress.length() == 0) {
+                ra = ResourceAddress.root();
+            } else if (!safeAddress.contains("/")) {
+                ra = new ResourceAddress();
+                String[] parts = safeAddress.split("=");
+                if (parts.length != 2) {
+                    throw new IllegalArgumentException("Malformed address: " + address);
+                }
+                ra.add(parts[0], parts[1]);
+            } else {
+                ra = new ResourceAddress();
+                String[] parts = safeAddress.split("/");
+                if (parts.length == 0) {
+                    throw new IllegalArgumentException("Malformed address: " + address);
+                }
+                for (String part : parts) {
+                    String[] kv = part.split("=");
+                    if (kv.length != 2) {
+                        throw new IllegalArgumentException("Malformed part '" + part + "' in address: " + address);
+                    }
+                    ra.add(kv[0], kv[1]);
+                }
             }
-            ra.add(kv[0], kv[1]);
         }
         return ra;
     }

--- a/dmr/src/main/java/org/jboss/hal/dmr/ResourceAddress.java
+++ b/dmr/src/main/java/org/jboss/hal/dmr/ResourceAddress.java
@@ -47,12 +47,16 @@ public class ResourceAddress extends ModelNode {
         }
         String safeAddress = address.startsWith("/") ? address.substring(1) : address;
         ResourceAddress ra = new ResourceAddress();
-        Map<String, String> segments = Splitter.on('/')
-                .omitEmptyStrings()
-                .withKeyValueSeparator('=')
-                .split(safeAddress);
-        for (Map.Entry<String, String> entry : segments.entrySet()) {
-            ra.add(entry.getKey(), entry.getValue());
+        String[] parts = safeAddress.split("/");
+        if (parts.length == 0) {
+            throw new IllegalArgumentException("Malformed address: " + address);
+        }
+        for (String part : parts) {
+            String[] kv = part.split("=");
+            if (kv.length != 2) {
+                throw new IllegalArgumentException("Malformed part '" + part + "' in address: " + address);
+            }
+            ra.add(kv[0], kv[1]);
         }
         return ra;
     }

--- a/dmr/src/main/java/org/jboss/hal/dmr/ResourceAddress.java
+++ b/dmr/src/main/java/org/jboss/hal/dmr/ResourceAddress.java
@@ -15,17 +15,15 @@
  */
 package org.jboss.hal.dmr;
 
-import java.util.ArrayList;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-
-import com.google.common.base.Splitter;
 import com.google.common.base.Strings;
 import jsinterop.annotations.JsIgnore;
 import jsinterop.annotations.JsMethod;
 import jsinterop.annotations.JsProperty;
 import jsinterop.annotations.JsType;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
 
 /**
  * Represents a fully qualified DMR address ready to be put into a DMR operation. The address consists of 0-n segments

--- a/dmr/src/test/java/org/jboss/hal/dmr/ResourceAddressTest.java
+++ b/dmr/src/test/java/org/jboss/hal/dmr/ResourceAddressTest.java
@@ -1,0 +1,61 @@
+package org.jboss.hal.dmr;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.*;
+
+public class ResourceAddressTest {
+
+    @Test(expected = IllegalArgumentException.class)
+    public void fromNull() {
+        ResourceAddress.from(null);
+    }
+
+    @Test
+    public void fromEmpty() {
+        ResourceAddress address = ResourceAddress.from("");
+        assertEquals(ResourceAddress.root(), address);
+    }
+
+    @Test
+    public void fromRoot() {
+        ResourceAddress address = ResourceAddress.from("/");
+        assertEquals(ResourceAddress.root(), address);
+    }
+
+    @Test
+    public void fromAddressWithSlash() {
+        ResourceAddress address = ResourceAddress.from("/subsystem=ee");
+        assertFalse(address.isEmpty());
+        assertEquals(1, address.size());
+        assertArrayEquals(new String[]{"subsystem", "ee"}, segments(address));
+    }
+
+    @Test
+    public void fromAddressWithoutSlash() {
+        ResourceAddress address = ResourceAddress.from("subsystem=ee");
+        assertFalse(address.isEmpty());
+        assertEquals(1, address.size());
+        assertArrayEquals(new String[]{"subsystem", "ee"}, segments(address));
+    }
+
+    @Test
+    public void fromAddress() {
+        ResourceAddress address = ResourceAddress.from("subsystem=ee/context-service=default");
+        assertFalse(address.isEmpty());
+        assertEquals(2, address.size());
+        assertArrayEquals(new String[]{"subsystem", "ee", "context-service", "default"}, segments(address));
+    }
+
+    private String[] segments(ResourceAddress address) {
+        List<String> segments = new ArrayList<>();
+        for (Property property : address.asPropertyList()) {
+            segments.add(property.getName());
+            segments.add(property.getValue().asString());
+        }
+        return segments.toArray(new String[0]);
+    }
+}


### PR DESCRIPTION
Upstream Issue: https://issues.redhat.com/browse/HAL-1742
Upstream PR: https://github.com/hal/console/pull/462
Issue: https://issues.redhat.com/browse/JBEAP-21565

Adding the commit in the related upstream PR and the one that removed the unneeded imports in the class (it was merged later).