### PR TITLE
HAL-1745: Make autosuggestions HTML safe

### DIFF
--- a/ballroom/src/main/java/org/jboss/hal/ballroom/autocomplete/StringRenderer.java
+++ b/ballroom/src/main/java/org/jboss/hal/ballroom/autocomplete/StringRenderer.java
@@ -18,6 +18,7 @@ package org.jboss.hal.ballroom.autocomplete;
 import java.util.function.Function;
 
 import com.google.gwt.safehtml.shared.SafeHtmlBuilder;
+import com.google.gwt.safehtml.shared.SafeHtmlUtils;
 
 import static org.jboss.hal.ballroom.autocomplete.ItemRenderer.highlight;
 import static org.jboss.hal.resources.CSS.autocompleteSuggestion;
@@ -32,7 +33,7 @@ public final class StringRenderer<T> implements ItemRenderer<T> {
 
     @Override
     public String render(T item, String query) {
-        String itm = toString.apply(item);
+        String itm = SafeHtmlUtils.fromString(toString.apply(item)).asString();
         SafeHtmlBuilder builder = new SafeHtmlBuilder();
         builder.appendHtmlConstant(
                 "<div class=\"" + autocompleteSuggestion + "\" data-val=\"" + itm + "\">")


### PR DESCRIPTION
(cherry picked from commit a801828b25f8394b5facdeee137ea4bc01bb4e0e)

backport upstream fix to 3.2.x branch.

Issue: https://issues.redhat.com/browse/JBEAP-21483
Upstream issue: https://issues.redhat.com/browse/HAL-1745
Upstream PR: https://github.com/hal/console/pull/461