### PR TITLE
HAL-1580: implement a form item for simple lists of objects

### DIFF
--- a/ballroom/src/main/java/org/jboss/hal/ballroom/form/TagsItem.java
+++ b/ballroom/src/main/java/org/jboss/hal/ballroom/form/TagsItem.java
@@ -28,6 +28,7 @@ import org.jboss.hal.resources.Ids;
 
 import static org.jboss.gwt.elemento.core.Elements.div;
 import static org.jboss.gwt.elemento.core.Elements.input;
+import static org.jboss.gwt.elemento.core.Elements.span;
 import static org.jboss.gwt.elemento.core.InputType.text;
 import static org.jboss.hal.ballroom.form.Decoration.DEFAULT;
 import static org.jboss.hal.ballroom.form.Decoration.DEPRECATED;
@@ -45,6 +46,11 @@ public abstract class TagsItem<T> extends AbstractFormItem<T> {
 
     protected TagsItem(String name, String label, SafeHtml inputHelp,
             Set<Decoration> editingDecorations, TagsMapping<T> mapping) {
+        this(name, label, inputHelp, editingDecorations, mapping, null);
+    }
+
+    protected TagsItem(String name, String label, SafeHtml inputHelp,
+                       Set<Decoration> editingDecorations, TagsMapping<T> mapping, HTMLElement button) {
         super(name, label, null);
 
         this.editingDecorations = editingDecorations;
@@ -55,7 +61,7 @@ public abstract class TagsItem<T> extends AbstractFormItem<T> {
 
         // editing appearance
         editingAppearance = new TagsEditingAppearance(input(text).css(formControl, tags).element(), inputHelp,
-                editingDecorations, mapping);
+                editingDecorations, mapping, button);
         addAppearance(Form.State.EDITING, editingAppearance);
     }
 
@@ -100,13 +106,15 @@ public abstract class TagsItem<T> extends AbstractFormItem<T> {
 
         private final HTMLElement tagsContainer;
         private final TagsMapping<T> mapping;
+        private final SafeHtml inputHelp;
 
         private boolean skipAdding;
 
         TagsEditingAppearance(HTMLInputElement inputElement, SafeHtml inputHelp,
-                Set<Decoration> supportedDecorations, TagsMapping<T> mapping) {
+                Set<Decoration> supportedDecorations, TagsMapping<T> mapping, HTMLElement button) {
             super(supportedDecorations, inputElement);
             this.mapping = mapping;
+            this.inputHelp = inputHelp;
 
             tagsContainer = div().css(tagManagerContainer)
                     .id(Ids.build("tags", "container", uniqueId())).element();
@@ -115,6 +123,13 @@ public abstract class TagsItem<T> extends AbstractFormItem<T> {
             helpBlock.innerHTML = inputHelp.asString();
 
             inputContainer.appendChild(tagsContainer);
+
+            if (button != null) {
+                wrapInputElement();
+                HTMLElement buttonContainer = span().css(inputGroupBtn)
+                        .add(button).element();
+                inputGroup.appendChild(buttonContainer);
+            }
             inputContainer.appendChild(helpBlock);
             inputGroup.classList.add(properties);
 
@@ -193,7 +208,7 @@ public abstract class TagsItem<T> extends AbstractFormItem<T> {
         void unapplyInvalid() {
             root.classList.remove(hasError);
             helpBlock.classList.add(CSS.hint);
-            helpBlock.innerHTML = MESSAGES.propertiesHint().asString();
+            helpBlock.innerHTML = inputHelp.asString();
         }
     }
 }

--- a/core/src/main/java/org/jboss/hal/core/ui/TuplesListItem.java
+++ b/core/src/main/java/org/jboss/hal/core/ui/TuplesListItem.java
@@ -1,0 +1,207 @@
+/*
+ * Copyright 2021 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.hal.core.ui;
+
+import com.google.gwt.core.client.GWT;
+import elemental2.dom.HTMLElement;
+import elemental2.dom.HTMLInputElement;
+import org.jboss.hal.ballroom.dialog.Dialog;
+import org.jboss.hal.ballroom.form.ModelNodeItem;
+import org.jboss.hal.ballroom.form.TagsItem;
+import org.jboss.hal.ballroom.form.TagsManager;
+import org.jboss.hal.ballroom.form.TagsMapping;
+import org.jboss.hal.core.mbui.form.ModelNodeForm;
+import org.jboss.hal.dmr.ModelNode;
+import org.jboss.hal.meta.Metadata;
+import org.jboss.hal.resources.Constants;
+import org.jboss.hal.resources.Ids;
+import org.jboss.hal.resources.Messages;
+
+import static java.util.Collections.emptyList;
+import static org.jboss.gwt.elemento.core.Elements.*;
+import static org.jboss.gwt.elemento.core.EventType.bind;
+import static org.jboss.gwt.elemento.core.EventType.click;
+import static org.jboss.gwt.elemento.core.InputType.checkbox;
+import static org.jboss.hal.ballroom.form.Decoration.*;
+import static org.jboss.hal.dmr.ModelDescriptionConstants.ATTRIBUTES;
+import static org.jboss.hal.dmr.ModelDescriptionConstants.NILLABLE;
+import static org.jboss.hal.resources.CSS.*;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Form item which is used for some attributes which are defined as
+ * <pre>
+ * "attribute-name" => {
+ *     "type" => LIST,
+ *     "value-type" => {
+ *         "subattribute1" => {
+ *             "type" => BIG_INTEGER | BOOLEAN | DOUBLE | INT | LONG | STRING
+ *         },
+ *         "subattribute2" => {}, …
+ *     }
+ * }
+ * </pre>
+ */
+public class TuplesListItem extends TagsItem<ModelNode> implements ModelNodeItem {
+    private static final Constants CONSTANTS = GWT.create(Constants.class);
+    private static final Messages MESSAGES = GWT.create(Messages.class);
+
+    public TuplesListItem(String name, String label, Metadata metadata) {
+        this(name, label, metadata, createButton(), new TuplesListMapping(metadata));
+    }
+
+    private TuplesListItem(String name, String label, Metadata metadata, HTMLElement addButton, TuplesListMapping mapping) {
+        super(name, label, MESSAGES.tuplesHint(String.join(",", getAttributeNames(metadata, true))),
+                EnumSet.of(DEFAULT, DEPRECATED, ENABLED, INVALID, REQUIRED, RESTRICTED, SUGGESTIONS),
+                mapping, addButton);
+
+        Dialog addTupleDialog;
+        ModelNodeForm dialogForm;
+        HTMLInputElement checkBox;
+
+        ModelNodeForm.Builder<ModelNode> builder = new ModelNodeForm.Builder<>(Ids.RESOLVE_EXPRESSION_FORM, metadata)
+                .addOnly()
+                .onSave((f, changedValues) -> {
+                    onSuggest(mapping.tupleToString(f.getModel())); // add item from dialog form to the tags
+                });
+        dialogForm = builder.build();
+
+        addTupleDialog = new Dialog.Builder(MESSAGES.addResourceTitle(getLabel()))
+                .add(dialogForm.element())
+                .add(div().css(formGroup)
+                        .add(label(MESSAGES.keepDialogOpen()).css(controlLabel, halFormLabel).element())
+                        .add(div().css(halFormInput)
+                                .add(checkBox = input(checkbox).element())
+                                .element())
+                        .element())
+                .primary(CONSTANTS.add(), () -> {
+                    if (dialogForm.save()) {
+                        dialogForm.edit(new ModelNode());
+                        return !checkBox.checked;
+                    }
+                    return false;
+                })
+                .secondary(CONSTANTS.close(), () -> true)
+                .size(Dialog.Size.MEDIUM)
+                .build();
+        addTupleDialog.registerAttachable(dialogForm);
+
+        bind(addButton, click, event -> {
+            addTupleDialog.show();
+            dialogForm.edit(new ModelNode());
+        });
+    }
+
+    public static String[] getAttributeNames(Metadata metadata, boolean markRequired) {
+        return metadata.getDescription().get(ATTRIBUTES).asPropertyList().stream()
+                .map(prop -> prop.getName()
+                        + (markRequired && prop.getValue().hasDefined(NILLABLE) && !prop.getValue().get(NILLABLE).asBoolean() ? "*" : ""))
+                .toArray(String[]::new);
+    }
+
+    public static HTMLElement createButton() {
+        return button()
+                .css(btn, btnDefault)
+                .title(CONSTANTS.add())
+                .add(i().css(fontAwesome("plus"))).element();
+    }
+
+    @Override
+    public void addTag(ModelNode tag) {
+        ModelNode value = getValue();
+        ModelNode newValue = value != null ? value.clone() : new ModelNode();
+        newValue.add(tag);
+        modifyValue(newValue);
+    }
+
+    @Override
+    public void removeTag(ModelNode tag) {
+        List<ModelNode> list = new ArrayList<>(getValue().asList());
+        list.remove(tag);
+        ModelNode newValue = new ModelNode();
+        newValue.set(list);
+        modifyValue(newValue);
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return getValue() == null || getValue().asInt() == 0;
+    }
+
+    private static class TuplesListMapping implements TagsMapping<ModelNode> {
+        private final String[] attributeNames;
+        private static final String TUPLE_SEPARATOR = "; ";
+        private static final String SEPARATOR = ",";
+        private static final String BLANK = "—";
+
+        public TuplesListMapping(Metadata metadata) {
+            this.attributeNames = getAttributeNames(metadata, false);
+        }
+
+        @Override
+        public TagsManager.Validator validator() {
+            return (value) -> {
+                String[] attrs = value.split(SEPARATOR, -1);
+                return attrs.length == attributeNames.length && !Arrays.stream(attrs).allMatch(String::isEmpty);
+            };
+        }
+
+        @Override
+        public ModelNode parseTag(final String tag) {
+            ModelNode tuple = stringToTuple(tag);
+            return tuple;
+        }
+
+        @Override
+        public List<String> tags(ModelNode value) {
+            if (!value.isDefined()) {
+                return emptyList();
+            }
+            return value.asList().stream()
+                    .map(this::tupleToString)
+                    .collect(Collectors.toList());
+        }
+
+        @Override
+        public String asString(ModelNode value) {
+            return String.join(TUPLE_SEPARATOR, tags(value));
+        }
+
+        private ModelNode stringToTuple(String tag) {
+            ModelNode tuple = new ModelNode();
+            String[] attrValues = tag.split(SEPARATOR,-1);
+            for (int i = 0; i < attributeNames.length; i++) {
+                if (!attrValues[i].isEmpty()) {
+                    tuple.get(attributeNames[i]).set(attrValues[i]);
+                }
+            }
+            return tuple;
+        }
+
+        private String tupleToString(ModelNode value) {
+            String[] attrValues = new String[attributeNames.length];
+            for (int i = 0; i < attributeNames.length; i++) {
+                attrValues[i] = value.hasDefined(attributeNames[i]) ? value.get(attributeNames[i]).asString() : BLANK;
+            }
+            return String.join(SEPARATOR, attrValues);
+        }
+    }
+}

--- a/resources/src/main/java/org/jboss/hal/resources/Messages.java
+++ b/resources/src/main/java/org/jboss/hal/resources/Messages.java
@@ -487,6 +487,7 @@ public interface Messages extends com.google.gwt.i18n.client.Messages {
     SafeHtml tourStandaloneRuntimeSubsystem();
     SafeHtml transactionSetUuidOrSocket();
     SafeHtml transactionUnableSetProcessId();
+    SafeHtml tuplesHint(String names);
     SafeHtml unauthorized();
     SafeHtml undeployedContent(String name);
     SafeHtml unit(String unit);
@@ -571,6 +572,7 @@ public interface Messages extends com.google.gwt.i18n.client.Messages {
     String jdbcDriverColumnFilterDescription();
     String jobExecutionColumnFilterDescription();
     String jpaColumnFilterDescription();
+    String keepDialogOpen();
     String kill(String name);
     String logfileColumnFilterDescription();
     String logFileFullStatus(int lines, String lastUpdate);

--- a/resources/src/main/resources/org/jboss/hal/resources/Messages.properties
+++ b/resources/src/main/resources/org/jboss/hal/resources/Messages.properties
@@ -253,6 +253,7 @@ jdbcDriverProvidedBy=The JDBC driver is provided by {0} <code>{1}</code>.
 jobExecutionColumnFilterDescription=Filter by: job name, deployment and execution status
 jpaColumnFilterDescription=Filter by: persistence unit name or deployment
 jpaStatisticsDisabled=Statistics are not enabled for persistence unit {0}. Please add <code>&lt;property name="hibernate.generate_statistics" value="true"/&gt;</code> to the persistence.xml and redeploy {1}.
+keepDialogOpen=Keep dialog open
 kill=Kill {0}
 killServerError=Failed to kill server <strong>{0}</strong>.
 killServerGroupError=Failed to kill server group <strong>{0}</strong>.
@@ -583,6 +584,7 @@ tourStandaloneRuntimeServer=View <strong>runtime information</strong> about the 
 tourStandaloneRuntimeSubsystem=View <strong>subsystem-specific</strong> runtime information, such as transaction or datasource metrics.
 transactionSetUuidOrSocket=Please set either Process Id Uuid or Process Id Socket Binding
 transactionUnableSetProcessId=Unable to switch process id
+tuplesHint=Add new items as <em>{0}</em>. Press <abbr class="key" title="RETURN">&crarr;</abbr> to add and <abbr class="key" title="BACKSPACE">&#x232B</abbr> to remove them.
 unauthorized=You do not have the permissions to access this resource!
 undeployedContent=The content <strong>{0}</strong> is not deployed to a server group.
 undertowListenerProcessingDisabled=Statistics are not enabled for listener <strong>{0}</strong> in server <strong>{1}</strong>. Click the button below to enable statistics. This will set the attribute <code>record-request-start-time</code> to <code>true</code>.


### PR DESCRIPTION
Issue: [HAL-1580](https://issues.redhat.com/browse/HAL-1580)

I've added an item to handle simple lists of objects (i.e. objects that don't have another object or list as a child) to be used by the DefaultFormItemProvider. The list items can be entered either as a comma-separated list of attributes or through an "add resource" dialog.

![tuple1](https://user-images.githubusercontent.com/1999074/135504010-e1476c0f-5190-4c81-9531-dfb53541852b.png)
![tuple2](https://user-images.githubusercontent.com/1999074/135504012-964e9938-8811-4481-81d1-6b349245668f.png)

It's a bit hacky in terms of adding the button to the TagsItem but I don't know if there's a better way to do it without making the appearance from scratch.

This takes care of the client/server interceptors in EJB per the original issue and also several other attributes in Elytron.