### PR TITLE
[HAL-1760] Editing credential reference is not working

### DIFF
--- a/core/src/main/java/org/jboss/hal/core/ComplexAttributeOperations.java
+++ b/core/src/main/java/org/jboss/hal/core/ComplexAttributeOperations.java
@@ -325,6 +325,28 @@ public class ComplexAttributeOperations {
         });
     }
 
+    /**
+     * Writes the full payload to the complex attribute in the specified resource. After the resource has been
+     * updated, a success message is fired and the specified callback is executed.
+     *
+     * @param complexAttribute the name of the complex attribute
+     * @param type             the human readable name of the complex attribute
+     * @param address          the fq address for the operation
+     * @param payload          the optional payload for the complex attribute (may be null or undefined)
+     * @param callback         the callback executed after the resource has been added
+     */
+    @JsIgnore
+    public void save(String complexAttribute, String type, ResourceAddress address, @Nullable ModelNode payload,
+            Callback callback) {
+        Operation operation = new Operation.Builder(address, WRITE_ATTRIBUTE_OPERATION)
+                .param(NAME, complexAttribute)
+                .param(VALUE, payload == null ? new ModelNode().addEmptyObject() : payload)
+                .build();
+        dispatcher.execute(operation, result -> {
+            MessageEvent.fire(eventBus, Message.success(resources.messages().modifySingleResourceSuccess(type)));
+            callback.execute();
+        });
+    }
 
     // ------------------------------------------------------ (u)pdate using address
 

--- a/core/src/main/java/org/jboss/hal/core/OperationFactory.java
+++ b/core/src/main/java/org/jboss/hal/core/OperationFactory.java
@@ -252,7 +252,7 @@ public class OperationFactory {
                             case INT:
                             case LONG:
                                 if (hasDefault) {
-                                    operations.add(undefineAttribute(address, attributeName(property.getName())));
+                                    operations.add(undefineAttribute(address, property.getName()));
                                 }
                                 break;
                             case EXPRESSION:
@@ -260,7 +260,7 @@ public class OperationFactory {
                             case OBJECT:
                             case PROPERTY:
                             case STRING:
-                                operations.add(undefineAttribute(address, attributeName(property.getName())));
+                                operations.add(undefineAttribute(address, property.getName()));
                                 break;
                             case TYPE:
                             case UNDEFINED:

--- a/resources/src/main/java/org/jboss/hal/resources/Messages.java
+++ b/resources/src/main/java/org/jboss/hal/resources/Messages.java
@@ -529,6 +529,8 @@ public interface Messages extends com.google.gwt.i18n.client.Messages {
     String credentialReferenceConflict();
     String credentialReferenceParentNoResource(String parentResource);
     String credentialReferenceValidationError(String alternative);
+    String credentialReferenceValidationErrorValues();
+    String credentialReferenceInvalidCombination();
     String currentOfTotal(long current, long total);
     String datasourceFilterDescription();
     String datasourceRuntimeFilterDescription();

--- a/resources/src/main/resources/org/jboss/hal/resources/Messages.properties
+++ b/resources/src/main/resources/org/jboss/hal/resources/Messages.properties
@@ -86,6 +86,8 @@ credentialReferenceAddressError=Unable to access credential reference: No addres
 credentialReferenceConflict=Conflict with credential-reference.
 credentialReferenceParentNoResource=This credential reference settings requires the parent resource {0}.
 credentialReferenceValidationError={0} is invalid in combination with credential reference.
+credentialReferenceValidationErrorValues=Invalid combination for the credential reference. The common configuration uses store and alias to select an entry in the store. For testing purposes the clear text attribute can be specified alone. When the clear text is used together with store and alias a new entry is added or the existing alias value is replaced. If only store and clear text are used a new generated alias is added with the specified clear text as value. In all the cases a store is selected the clear text value is removed after adding/updating the entry.
+credentialReferenceInvalidCombination=Invalid combination.
 currentOfTotal={0} of {1}
 customListItemHint=Add new mappings as <em>{0}={1}</em> pairs. Press <abbr class="key" title="RETURN">&crarr;</abbr> to add and <abbr class="key" title="BACKSPACE">&#x232B</abbr> to remove them.
 dataSourceAddError=The datasource could not be created.


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/HAL-1760

Main modifications managing the credential references:

- New `save` method that writes the full object as it is done in the add operation.
- There is a new custom validator that checks the values are OK (if you want any different wording for the messages just let me now).
- The reset link has been removed as makes no sense in a credential-reference (it's always an error).

@hpehl For branch 3.3.x this commit https://github.com/hal/console/commit/85723c303de2f6b911dbd4306fc2356d2515b6ba is also needed. PR: #492
