### PR TITLE
[HAL-1762] Aliases are removed from the credential store when passwords are updated from the admin console

### DIFF
--- a/app/src/main/java/org/jboss/hal/client/runtime/subsystem/elytron/StoreElement.java
+++ b/app/src/main/java/org/jboss/hal/client/runtime/subsystem/elytron/StoreElement.java
@@ -132,17 +132,7 @@ public class StoreElement implements IsElement<HTMLElement>, Attachable {
 
         table.bindForm(form);
 
-        // disable table buttons if there is no selected row
-        disableTableButtons();
-        table.onSelectionChange(table1 -> {
-            for (int i = 0; i < builder.buttonsHandler.size(); i++) {
-                table1.enableButton(i, table1.hasSelection());
-            }
-        });
         aliasesTable.onSelectionChange(table1 -> {
-            for (int i = 0; i < builder.aliasButtonsHandler.size(); i++) {
-                table1.enableButton(i, table1.hasSelection());
-            }
             if (table1.hasSelection()) {
                 String alias = table1.selectedRow().asString();
                 String value = aliasDetailsMapping.get(alias);
@@ -201,15 +191,6 @@ public class StoreElement implements IsElement<HTMLElement>, Attachable {
         String value = details.toString();
         aliasDetails.setValue(value);
         aliasDetailsMapping.put(details.get(ALIAS).asString(), value);
-    }
-
-    private void disableTableButtons() {
-        for (int i = 0; i < builder.buttonsHandler.size(); i++) {
-            table.enableButton(i, false);
-        }
-        for (int i = 0; i < builder.aliasButtonsHandler.size(); i++) {
-            aliasesTable.enableButton(i, false);
-        }
     }
 
     static class Builder {

--- a/app/src/main/java/org/jboss/hal/client/runtime/subsystem/elytron/StoresView.java
+++ b/app/src/main/java/org/jboss/hal/client/runtime/subsystem/elytron/StoresView.java
@@ -21,6 +21,7 @@ import javax.inject.Inject;
 
 import org.jboss.hal.ballroom.VerticalNavigation;
 import org.jboss.hal.ballroom.table.Button;
+import org.jboss.hal.ballroom.table.Scope;
 import org.jboss.hal.core.mvp.HalViewImpl;
 import org.jboss.hal.dmr.NamedNode;
 import org.jboss.hal.meta.Metadata;
@@ -58,17 +59,21 @@ public class StoresView extends HalViewImpl implements StoresPresenter.MyView {
         Metadata credentialStoreMetadata = metadataRegistry.lookup(CREDENTIAL_STORE_TEMPLATE);
         credentialStoreElement = new StoreElement.Builder(CREDENTIAL_STORE, Names.CREDENTIAL_STORE, resources,
                 credentialStoreMetadata)
-                .addButtonHandler(new Button<>(resources.constants().reload(),
+                .addButtonHandler(new Button<>(resources.constants().reload(), null,
                         table -> presenter.reloadCredentialStore(table.selectedRow().getName()),
+                        Scope.SELECTED_SINGLE,
                         Constraint.executable(CREDENTIAL_STORE_TEMPLATE, RELOAD)))
-                .addAliasButtonHandler(new Button<>(resources.constants().addAlias(),
+                .addAliasButtonHandler(new Button<>(resources.constants().addAlias(), null,
                         table -> addCredentialStoreAlias(credentialStoreMetadata),
+                        null,
                         Constraint.executable(CREDENTIAL_STORE_TEMPLATE, ADD_ALIAS)))
-                .addAliasButtonHandler(new Button<>(resources.constants().removeAlias(),
+                .addAliasButtonHandler(new Button<>(resources.constants().removeAlias(), null,
                         table -> removeCredentialStoreAlias(credentialStoreMetadata, table.selectedRow().asString()),
+                        Scope.SELECTED_SINGLE,
                         Constraint.executable(CREDENTIAL_STORE_TEMPLATE, REMOVE_ALIAS)))
-                .addAliasButtonHandler(new Button<>(resources.constants().setSecret(),
+                .addAliasButtonHandler(new Button<>(resources.constants().setSecret(), null,
                         table -> setCredentialStoreSecretAlias(credentialStoreMetadata, table.selectedRow().asString()),
+                        Scope.SELECTED_SINGLE,
                         Constraint.executable(CREDENTIAL_STORE_TEMPLATE, SET_SECRET)))
                 .build();
         // enable the add-alias button, even if there are no items
@@ -79,11 +84,13 @@ public class StoresView extends HalViewImpl implements StoresPresenter.MyView {
         Metadata filteringMetadata = metadataRegistry.lookup(FILTERING_KEY_STORE_TEMPLATE);
         filteringStoreElement = new StoreElement.Builder(FILTERING_KEY_STORE, Names.FILTERING_KEY_STORE, resources,
                 filteringMetadata)
-                .addAliasButtonHandler(new Button<>(resources.constants().removeAlias(),
+                .addAliasButtonHandler(new Button<>(resources.constants().removeAlias(), null,
                         table -> removeFilteringKeyStoreAlias(filteringMetadata, table.selectedRow().asString()),
+                        Scope.SELECTED_SINGLE,
                         Constraint.executable(FILTERING_KEY_STORE_TEMPLATE, REMOVE_ALIAS)))
-                .addAliasButtonHandler(new Button<>(resources.constants().details(),
+                .addAliasButtonHandler(new Button<>(resources.constants().details(), null,
                         table -> readFilteringAlias(filteringMetadata, table.selectedRow().asString()),
+                        Scope.SELECTED_SINGLE,
                         Constraint.executable(FILTERING_KEY_STORE_TEMPLATE, READ_ALIAS)))
                 .build();
 
@@ -100,11 +107,13 @@ public class StoresView extends HalViewImpl implements StoresPresenter.MyView {
         Metadata ldapKeystoreMetadata = metadataRegistry.lookup(LDAP_KEY_STORE_TEMPLATE);
         ldapKeystoreElement = new StoreElement.Builder(LDAP_KEY_STORE, Names.LDAP_KEY_STORE, resources,
                 ldapKeystoreMetadata)
-                .addAliasButtonHandler(new Button<>(resources.constants().removeAlias(),
+                .addAliasButtonHandler(new Button<>(resources.constants().removeAlias(), null,
                         table -> removeLdapKeyStoreAlias(ldapKeystoreMetadata, table.selectedRow().asString()),
+                        Scope.SELECTED_SINGLE,
                         Constraint.executable(LDAP_KEY_STORE_TEMPLATE, REMOVE_ALIAS)))
-                .addAliasButtonHandler(new Button<>(resources.constants().details(),
+                .addAliasButtonHandler(new Button<>(resources.constants().details(), null,
                         table -> readLdapKeystoreAlias(ldapKeystoreMetadata, table.selectedRow().asString()),
+                        Scope.SELECTED_SINGLE,
                         Constraint.executable(LDAP_KEY_STORE_TEMPLATE, READ_ALIAS)))
                 .build();
 


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/HAL-1762

Changes:
* The buttons have been modified to not enable/disable them manually but using the Scope parameter (there were issues on them).
* The setSecret operation was wrong, it called the remove and besides only the alias form field was passed. It did not work at all.
* The removeAlias called an extra STORE operation that does not exist and triggered an error.

PR for 3.3.x.
PR for develop branch: https://github.com/hal/console/pull/494
