### PR TITLE
HAL-1765 Discovery and broadcast groups can't be created in messaging configuration

### DIFF
--- a/app/src/main/resources/org/jboss/hal/client/configuration/subsystem/messaging/ClusteringView.mbui.xml
+++ b/app/src/main/resources/org/jboss/hal/client/configuration/subsystem/messaging/ClusteringView.mbui.xml
@@ -25,7 +25,7 @@
                        form-ref="messaging-broadcast-group-form">
                     <actions>
                         <action title="${mbuiContext.resources().constants().add()}"
-                                handler="${presenter.add(ServerSubResource.BROADCAST_GROUP)}" constraint="add"/>
+                                handler="${presenter.addBroadcastGroup(ServerSubResource.BROADCAST_GROUP)}" constraint="add"/>
                         <action title="${mbuiContext.resources().constants().remove()}"
                                 handler="${presenter.remove(ServerSubResource.BROADCAST_GROUP, table.selectedRow())}"
                                 scope="selected" constraint="remove"/>
@@ -63,7 +63,7 @@
                        form-ref="messaging-discovery-group-form">
                     <actions>
                         <action title="${mbuiContext.resources().constants().add()}"
-                                handler="${presenter.add(ServerSubResource.DISCOVERY_GROUP)}" constraint="add"/>
+                                handler="${presenter.addDiscoveryGroup(ServerSubResource.DISCOVERY_GROUP)}" constraint="add"/>
                         <action title="${mbuiContext.resources().constants().remove()}"
                                 handler="${presenter.remove(ServerSubResource.DISCOVERY_GROUP, table.selectedRow())}"
                                 scope="selected" constraint="remove"/>

--- a/dmr/src/main/java/org/jboss/hal/dmr/ModelDescriptionConstants.java
+++ b/dmr/src/main/java/org/jboss/hal/dmr/ModelDescriptionConstants.java
@@ -449,6 +449,7 @@ public interface ModelDescriptionConstants {
     String JDBC_REALM = "jdbc-realm";
     String JDR = "jdr";
     String JGROUPS = "jgroups";
+    String JGROUPS_CLUSTER = "jgroups-cluster";
     String JMS_BRIDGE = "jms-bridge";
     String JMS_DELIVERY_MODE = "JMSDeliveryMode";
     String JMS_EXPIRATION = "JMSExpiration";

--- a/resources/src/main/java/org/jboss/hal/resources/Messages.java
+++ b/resources/src/main/java/org/jboss/hal/resources/Messages.java
@@ -627,5 +627,6 @@ public interface Messages extends com.google.gwt.i18n.client.Messages {
     String uptime(String uptime);
     String used(double value);
     String view(String type);
+    String jgroupsClusterOrSocketBindingMustBeSet();
     //@formatter:on
 }

--- a/resources/src/main/resources/org/jboss/hal/resources/Messages.properties
+++ b/resources/src/main/resources/org/jboss/hal/resources/Messages.properties
@@ -611,3 +611,4 @@ verifyRenewError=There was an error to verify if the certificate should be renew
 verifyRenewSuccess=The renewal check of certificate identified by alias <strong>{0}</strong> of Key Store <strong>{1}</strong> was verified with success.
 view=View {0}
 writeBehaviour=This store currently uses a <strong>{0}</strong> behaviour. Use the button below to switch to <strong>{1}</strong>.
+jgroupsClusterOrSocketBindingMustBeSet=Exactly one of the JGroups Cluster and the Socket Binding attributes must be set.


### PR DESCRIPTION
https://issues.redhat.com/browse/HAL-1765
https://issues.redhat.com/browse/JBEAP-23042

Upstream for https://github.com/hal/console/pull/499

This change:

* Makes the jgroups-cluster and socket-bindings fields visible in the Add
  form, because setting one of them is required by EAP..
* Adds a form validation that checks that one of the above fields is
  configured. The fields are already marked as alternatives in the model
  definition.