### PR TITLE
[HAL-1771] only display content hash for managed deployment

### DIFF
--- a/app/src/main/java/org/jboss/hal/client/deployment/ServerGroupDeploymentPreview.java
+++ b/app/src/main/java/org/jboss/hal/client/deployment/ServerGroupDeploymentPreview.java
@@ -95,7 +95,7 @@ class ServerGroupDeploymentPreview extends DeploymentPreview<ServerGroupDeployme
             return new PreviewAttribute(resources.constants().providedBy(), model.getName(),
                     places.historyToken(placeRequest));
         });
-        if (deployment != null) {
+        if (deployment != null && deployment.isManaged()) {
             hash(attributes, deployment);
         }
         eme(attributes);

--- a/app/src/main/java/org/jboss/hal/client/deployment/StandaloneDeploymentPreview.java
+++ b/app/src/main/java/org/jboss/hal/client/deployment/StandaloneDeploymentPreview.java
@@ -67,7 +67,9 @@ class StandaloneDeploymentPreview extends DeploymentPreview<Deployment> {
 
         PreviewAttributes<Deployment> attributes = new PreviewAttributes<>(deployment, asList(NAME, RUNTIME_NAME));
         contextRoot(attributes, deployment);
-        hash(attributes, deployment);
+        if (deployment.isManaged()) {
+            hash(attributes, deployment);
+        }
         eme(attributes);
         status(attributes, deployment);
         attributes.append(model -> new PreviewAttribute(LAST_ENABLED_AT, deployment.getEnabledTime()));


### PR DESCRIPTION
https://issues.redhat.com/browse/HAL-1771 

[HAL-1737](https://issues.redhat.com/browse/HAL-1737) adds the ability to view content hash in deployment panel, but I think it should exclude the case of unmanaged deployment. Otherwise, it causes an error when getting content hash for unmanaged deployment.