### PR TITLE
HAL-1777: Replace ZeroClipboard with clipboardjs (3.3.x branch)

### DIFF
--- a/app/Gruntfile.js
+++ b/app/Gruntfile.js
@@ -75,12 +75,6 @@ module.exports = function (grunt) {
                     },
                     {
                         expand: true,
-                        cwd: '<%= config.node %>/zeroclipboard/dist',
-                        src: 'ZeroClipboard.swf',
-                        dest: '<%= config.public %>/js'
-                    },
-                    {
-                        expand: true,
                         cwd: '<%= config.js %>',
                         src: '*.js',
                         dest: '<%= config.public %>/js'
@@ -157,7 +151,7 @@ module.exports = function (grunt) {
                     '<%= config.node %>/jstree/dist/jstree.js',
                     '<%= config.node %>/pouchdb/dist/pouchdb.js',
                     '<%= config.js %>/tagmanager.js',
-                    '<%= config.node %>/zeroclipboard/dist/ZeroClipboard.js',
+                    '<%= config.node %>/clipboard/dist/clipboard.js',
                     '<%= config.node %>/patternfly/dist/js/patternfly.js'
                 ],
                 dest: '<%= config.public %>/js/external.js'
@@ -197,7 +191,7 @@ module.exports = function (grunt) {
                     '<%= config.node %>/jstree/dist/jstree.min.js',
                     '<%= config.node %>/pouchdb/dist/pouchdb.min.js',
                     '<%= config.js %>/tagmanager.js',
-                    '<%= config.node %>/zeroclipboard/dist/ZeroClipboard.min.js',
+                    '<%= config.node %>/clipboard/dist/clipboard.min.js',
                     '<%= config.node %>/patternfly/dist/js/patternfly.min.js'
                 ],
                 dest: '<%= config.public %>/js/external.min.js'

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -17,6 +17,7 @@
         "bootstrap-slider": "^10.6.1",
         "bootstrap-switch": "~3.3.5",
         "c3": "^0.7.1",
+        "clipboard": "^2.0.10",
         "d3": "^5.9.2",
         "datatables.net": "^1.10.19",
         "datatables.net-buttons": "^1.5.6",
@@ -34,8 +35,7 @@
         "patternfly-bootstrap-combobox": "^1.1.7",
         "pouchdb": "^7.1.1",
         "promise-polyfill": "^8.1.3",
-        "whatwg-fetch": "^3.0.0",
-        "zeroclipboard": "^2.3.0"
+        "whatwg-fetch": "^3.0.0"
       },
       "devDependencies": {
         "autoprefixer": "^9.6.0",
@@ -1286,6 +1286,16 @@
         "node": ">= 4.0"
       }
     },
+    "node_modules/clipboard": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/clipboard/-/clipboard-2.0.11.tgz",
+      "integrity": "sha512-C+0bbOqkezLIsmWSvlsXS0Q0bmkugu7jcfMIACB+RDEntIzQIkdr148we28AfSloQLRdZlYL/QYyrq05j/3Faw==",
+      "dependencies": {
+        "good-listener": "^1.2.2",
+        "select": "^1.1.2",
+        "tiny-emitter": "^2.0.0"
+      }
+    },
     "node_modules/clone": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
@@ -2018,6 +2028,11 @@
       "engines": {
         "node": ">=0.4.0"
       }
+    },
+    "node_modules/delegate": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/delegate/-/delegate-3.2.0.tgz",
+      "integrity": "sha512-IofjkYBZaZivn0V8nnsMJGBr4jVLxHDheKSW88PyxS5QC4Vo9ZbZVvhzlSxY87fVq3STR6r+4cGepyHkcWOQSw=="
     },
     "node_modules/delegates": {
       "version": "1.0.0",
@@ -3142,6 +3157,14 @@
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.3.tgz",
       "integrity": "sha1-O+39kaktOQFvz6ocaB6Pqhoe/ag=",
       "dev": true
+    },
+    "node_modules/good-listener": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/good-listener/-/good-listener-1.2.2.tgz",
+      "integrity": "sha512-goW1b+d9q/HIwbVYZzZ6SsTr4IgE+WA44A0GmPIQstuOrgsFcT7VEJ48nmr9GaRtNu0XTKacFLGnBPAM6Afouw==",
+      "dependencies": {
+        "delegate": "^3.1.2"
+      }
     },
     "node_modules/google-code-prettify": {
       "version": "1.0.5",
@@ -7270,6 +7293,11 @@
       "dev": true,
       "optional": true
     },
+    "node_modules/select": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/select/-/select-1.1.2.tgz",
+      "integrity": "sha512-OwpTSOfy6xSs1+pwcNrv0RBMOzI39Lp3qQKUTPVVPRjCdNa5JH/oPRiqsesIskK8TVgmRiHwO4KXlV2Li9dANA=="
+    },
     "node_modules/semver": {
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
@@ -8300,6 +8328,11 @@
         "node": ">= 6"
       }
     },
+    "node_modules/tiny-emitter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
+      "integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q=="
+    },
     "node_modules/tiny-lr": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/tiny-lr/-/tiny-lr-1.1.1.tgz",
@@ -8922,11 +8955,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/zeroclipboard": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/zeroclipboard/-/zeroclipboard-2.3.0.tgz",
-      "integrity": "sha1-WS69gzpDCGiLBzlpfT2/mJACya8="
     }
   },
   "dependencies": {
@@ -9992,6 +10020,16 @@
         "source-map": "~0.6.0"
       }
     },
+    "clipboard": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/clipboard/-/clipboard-2.0.11.tgz",
+      "integrity": "sha512-C+0bbOqkezLIsmWSvlsXS0Q0bmkugu7jcfMIACB+RDEntIzQIkdr148we28AfSloQLRdZlYL/QYyrq05j/3Faw==",
+      "requires": {
+        "good-listener": "^1.2.2",
+        "select": "^1.1.2",
+        "tiny-emitter": "^2.0.0"
+      }
+    },
     "clone": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
@@ -10636,6 +10674,11 @@
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
       "dev": true
+    },
+    "delegate": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/delegate/-/delegate-3.2.0.tgz",
+      "integrity": "sha512-IofjkYBZaZivn0V8nnsMJGBr4jVLxHDheKSW88PyxS5QC4Vo9ZbZVvhzlSxY87fVq3STR6r+4cGepyHkcWOQSw=="
     },
     "delegates": {
       "version": "1.0.0",
@@ -11554,6 +11597,14 @@
           "integrity": "sha1-O+39kaktOQFvz6ocaB6Pqhoe/ag=",
           "dev": true
         }
+      }
+    },
+    "good-listener": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/good-listener/-/good-listener-1.2.2.tgz",
+      "integrity": "sha512-goW1b+d9q/HIwbVYZzZ6SsTr4IgE+WA44A0GmPIQstuOrgsFcT7VEJ48nmr9GaRtNu0XTKacFLGnBPAM6Afouw==",
+      "requires": {
+        "delegate": "^3.1.2"
       }
     },
     "google-code-prettify": {
@@ -15025,6 +15076,11 @@
       "dev": true,
       "optional": true
     },
+    "select": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/select/-/select-1.1.2.tgz",
+      "integrity": "sha512-OwpTSOfy6xSs1+pwcNrv0RBMOzI39Lp3qQKUTPVVPRjCdNa5JH/oPRiqsesIskK8TVgmRiHwO4KXlV2Li9dANA=="
+    },
     "semver": {
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
@@ -15862,6 +15918,11 @@
         }
       }
     },
+    "tiny-emitter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
+      "integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q=="
+    },
     "tiny-lr": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/tiny-lr/-/tiny-lr-1.1.1.tgz",
@@ -16408,11 +16469,6 @@
           "dev": true
         }
       }
-    },
-    "zeroclipboard": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/zeroclipboard/-/zeroclipboard-2.3.0.tgz",
-      "integrity": "sha1-WS69gzpDCGiLBzlpfT2/mJACya8="
     }
   }
 }

--- a/app/package.json
+++ b/app/package.json
@@ -13,6 +13,7 @@
     "bootstrap-slider": "^10.6.1",
     "bootstrap-switch": "~3.3.5",
     "c3": "^0.7.1",
+    "clipboard": "^2.0.10",
     "d3": "^5.9.2",
     "datatables.net": "^1.10.19",
     "datatables.net-buttons": "^1.5.6",
@@ -30,8 +31,7 @@
     "patternfly-bootstrap-combobox": "^1.1.7",
     "pouchdb": "^7.1.1",
     "promise-polyfill": "^8.1.3",
-    "whatwg-fetch": "^3.0.0",
-    "zeroclipboard": "^2.3.0"
+    "whatwg-fetch": "^3.0.0"
   },
   "dependenciesComments": {
     "bootstrap-switch": "Please use version '~3.3.5', since 3.4.x would require Bootstrap 4.x",

--- a/app/src/main/java/org/jboss/hal/client/tools/MacroEditorView.java
+++ b/app/src/main/java/org/jboss/hal/client/tools/MacroEditorView.java
@@ -52,7 +52,16 @@ import static org.jboss.gwt.elemento.core.Elements.span;
 import static org.jboss.hal.ballroom.LayoutBuilder.column;
 import static org.jboss.hal.ballroom.LayoutBuilder.row;
 import static org.jboss.hal.ballroom.Skeleton.MARGIN_BIG;
-import static org.jboss.hal.resources.CSS.*;
+import static org.jboss.hal.resources.CSS.btn;
+import static org.jboss.hal.resources.CSS.btnDefault;
+import static org.jboss.hal.resources.CSS.copy;
+import static org.jboss.hal.resources.CSS.fontAwesome;
+import static org.jboss.hal.resources.CSS.macroEditor;
+import static org.jboss.hal.resources.CSS.marginRight5;
+import static org.jboss.hal.resources.CSS.noMacros;
+import static org.jboss.hal.resources.CSS.pfIcon;
+import static org.jboss.hal.resources.CSS.px;
+import static org.jboss.hal.resources.CSS.vh;
 
 public class MacroEditorView extends HalViewImpl implements MacroEditorPresenter.MyView {
 
@@ -68,6 +77,7 @@ public class MacroEditorView extends HalViewImpl implements MacroEditorPresenter
     private final AceEditor editor;
     private final HTMLButtonElement copyToClipboard;
     private final HTMLElement row;
+    private Clipboard clipboard;
     private MacroEditorPresenter presenter;
 
     @Inject
@@ -83,7 +93,8 @@ public class MacroEditorView extends HalViewImpl implements MacroEditorPresenter
                 .build();
         empty.element().classList.add(noMacros);
 
-        ItemRenderer<Macro> itemRenderer = macro -> new ItemDisplay<Macro>() {
+        // Don't optimize! GWT compiler doesn't like diamond operators :-(
+        @SuppressWarnings("Convert2Diamond") ItemRenderer<Macro> itemRenderer = macro -> new ItemDisplay<Macro>() {
             @Override
             public String getTitle() {
                 return macro.getName();
@@ -134,8 +145,6 @@ public class MacroEditorView extends HalViewImpl implements MacroEditorPresenter
                         .title(resources.constants().copyToClipboard())
                         .add(span().css(fontAwesome("clipboard"))).element())
                 .add(editor).element();
-        Clipboard clipboard = new Clipboard(copyToClipboard);
-        clipboard.onCopy(event -> copyToClipboard(event.client));
 
         row = row()
                 .add(column(4)
@@ -156,11 +165,26 @@ public class MacroEditorView extends HalViewImpl implements MacroEditorPresenter
             adjustEditorHeight();
             return null;
         };
+
+        Clipboard.Options options = new Clipboard.Options();
+        options.text = element -> dataProvider.getSelectionInfo().getSingleSelection().asCli();
+        clipboard = new Clipboard(copyToClipboard, options);
+        clipboard.on("success", event -> {
+            Tooltip tooltip = Tooltip.element(copyToClipboard);
+            tooltip.hide()
+                    .setTitle(resources.constants().copied())
+                    .show()
+                    .onHide(() -> tooltip.setTitle(resources.constants().copyToClipboard()));
+            setTimeout((o) -> tooltip.hide(), 3000);
+        });
     }
 
     @Override
     public void detach() {
         super.detach();
+        if (clipboard != null) {
+            clipboard.destroy();
+        }
         window.onresize = null;
     }
 
@@ -214,17 +238,5 @@ public class MacroEditorView extends HalViewImpl implements MacroEditorPresenter
 
     private void loadMacro(Macro macro) {
         editor.getEditor().getSession().setValue(macro.asCli());
-    }
-
-    private void copyToClipboard(Clipboard clipboard) {
-        if (dataProvider.getSelectionInfo().getSingleSelection() != null) {
-            clipboard.setText(dataProvider.getSelectionInfo().getSingleSelection().asCli());
-            Tooltip tooltip = Tooltip.element(copyToClipboard);
-            tooltip.hide()
-                    .setTitle(resources.constants().copied())
-                    .show()
-                    .onHide(() -> tooltip.setTitle(resources.constants().copyToClipboard()));
-            setTimeout((o) -> tooltip.hide(), 1000);
-        }
     }
 }

--- a/ballroom/src/main/java/org/jboss/hal/ballroom/Clipboard.java
+++ b/ballroom/src/main/java/org/jboss/hal/ballroom/Clipboard.java
@@ -18,46 +18,55 @@ package org.jboss.hal.ballroom;
 import elemental2.dom.HTMLElement;
 import jsinterop.annotations.JsConstructor;
 import jsinterop.annotations.JsFunction;
-import jsinterop.annotations.JsOverlay;
 import jsinterop.annotations.JsType;
 
 import static jsinterop.annotations.JsPackage.GLOBAL;
 import static org.jboss.hal.resources.UIConstants.OBJECT;
 
 /**
- * Clipboard implementation based on <a href="https://zeroclipboard.github.io/">ZeroClipboard</a>.
+ * Clipboard implementation based on <a href="https://clipboardjs.com/">clipboardjs</a>.
  *
- * @see <a href="https://zeroclipboard.github.io/">https://zeroclipboard.github.io/</a>
+ * @see <a href="https://clipboardjs.com/">https://clipboardjs.com/</a>
  */
-@JsType(name = "ZeroClipboard", namespace = GLOBAL, isNative = true)
+@JsType(name = "ClipboardJS", namespace = GLOBAL, isNative = true)
 public class Clipboard {
 
     @JsConstructor
     @SuppressWarnings("UnusedParameters")
-    public Clipboard(HTMLElement element) {
+    public Clipboard(HTMLElement element, Options options) {
     }
 
-    native void on(String event, ClipboardHandler handler);
+    public native void on(String type, Handler handler);
 
-    @JsOverlay
-    public final void onCopy(ClipboardHandler handler) {
-        on("copy", handler);
+    public native void destroy();
+
+    @JsFunction
+    @FunctionalInterface
+    public interface Handler {
+
+        void handle(Event event);
     }
-
-    public native void setText(String text);
 
 
     @JsFunction
     @FunctionalInterface
-    public interface ClipboardHandler {
+    public interface TextProvider {
 
-        void handleEvent(ClipboardEvent event);
+        String provideText(HTMLElement element);
+    }
+
+    @JsType(isNative = true, namespace = GLOBAL, name = OBJECT)
+    public static class Options {
+
+        public TextProvider text;
     }
 
 
     @JsType(isNative = true, namespace = GLOBAL, name = OBJECT)
-    public static class ClipboardEvent {
+    public static class Event {
 
-        public Clipboard client;
+        public String action;
+        public String text;
+        public HTMLElement trigger;
     }
 }


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/JBEAP-23740

HAL issue: https://issues.redhat.com/browse/HAL-1777

Upstream main branch PR: https://github.com/hal/console/pull/549

I also removed `ZeroClipboard` references in `Gruntfile.js`. But, Do I need to replace them with`clipboard` there? 
