### PR TITLE
HAL-1793: determine the availability of statistics in case of unresol…

### DIFF
--- a/app/src/main/java/org/jboss/hal/client/runtime/subsystem/SubsystemColumn.java
+++ b/app/src/main/java/org/jboss/hal/client/runtime/subsystem/SubsystemColumn.java
@@ -104,7 +104,7 @@ public class SubsystemColumn extends FinderColumn<SubsystemMetadata> {
         customPreviews.put(BATCH_JBERET, new BatchPreview(dispatcher, statementContext, resources));
         customPreviews.put(EJB3, new ThreadPoolPreview(dispatcher, statementContext, resources));
         customPreviews.put(TRANSACTIONS, new TransactionsPreview(dispatcher, statementContext, resources));
-        customPreviews.put(UNDERTOW, new UndertowPreview(dispatcher, statementContext, resources));
+        customPreviews.put(UNDERTOW, new UndertowPreview(resources));
         customPreviews.put(WEBSERVICES, new WebservicesPreview(dispatcher, statementContext, resources));
 
         ItemsProvider<SubsystemMetadata> itemsProvider = context -> {

--- a/app/src/main/java/org/jboss/hal/client/runtime/subsystem/ejb/EjbColumn.java
+++ b/app/src/main/java/org/jboss/hal/client/runtime/subsystem/ejb/EjbColumn.java
@@ -134,7 +134,7 @@ public class EjbColumn extends FinderColumn<EjbNode> {
                         return Promise.resolve(ejbs);
                     });
                 })
-                .onPreview(item -> new EjbPreview(item, finderPathFactory, places, dispatcher, resources))
+                .onPreview(item -> new EjbPreview(item, finderPathFactory, places, dispatcher, statementContext, resources))
                 .useFirstActionAsBreadcrumbHandler()
                 .withFilter()
                 .filterDescription(resources.messages().ejbFilterDescription())

--- a/app/src/main/java/org/jboss/hal/client/runtime/subsystem/ejb/EjbPreview.java
+++ b/app/src/main/java/org/jboss/hal/client/runtime/subsystem/ejb/EjbPreview.java
@@ -19,6 +19,8 @@ import java.util.Date;
 import java.util.List;
 
 import org.jboss.elemento.Elements;
+import org.jboss.elemento.HtmlContent;
+import org.jboss.hal.ballroom.EmptyState;
 import org.jboss.hal.ballroom.Format;
 import org.jboss.hal.ballroom.LabelBuilder;
 import org.jboss.hal.ballroom.ProgressElement;
@@ -29,12 +31,17 @@ import org.jboss.hal.core.finder.PreviewAttributes;
 import org.jboss.hal.core.finder.PreviewAttributes.PreviewAttribute;
 import org.jboss.hal.core.finder.PreviewContent;
 import org.jboss.hal.core.mvp.Places;
+import org.jboss.hal.dmr.Composite;
+import org.jboss.hal.dmr.CompositeResult;
 import org.jboss.hal.dmr.ModelNode;
 import org.jboss.hal.dmr.ModelNodeHelper;
 import org.jboss.hal.dmr.Operation;
 import org.jboss.hal.dmr.ResourceAddress;
 import org.jboss.hal.dmr.dispatch.Dispatcher;
+import org.jboss.hal.meta.StatementContext;
+import org.jboss.hal.meta.security.Constraint;
 import org.jboss.hal.meta.token.NameTokens;
+import org.jboss.hal.resources.Ids;
 import org.jboss.hal.resources.Names;
 import org.jboss.hal.resources.Resources;
 
@@ -54,6 +61,7 @@ import static org.jboss.elemento.Elements.section;
 import static org.jboss.elemento.Elements.span;
 import static org.jboss.hal.ballroom.ProgressElement.Label.INLINE;
 import static org.jboss.hal.ballroom.ProgressElement.Size.NORMAL;
+import static org.jboss.hal.client.runtime.subsystem.ejb.AddressTemplates.EJB3_SUBSYSTEM_TEMPLATE;
 import static org.jboss.hal.client.runtime.subsystem.ejb.EjbNode.Type.MDB;
 import static org.jboss.hal.client.runtime.subsystem.ejb.EjbNode.Type.STATEFUL;
 import static org.jboss.hal.client.runtime.subsystem.ejb.EjbNode.Type.STATELESS;
@@ -63,40 +71,60 @@ import static org.jboss.hal.dmr.ModelDescriptionConstants.DELIVERY_ACTIVE;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.EXECUTION_TIME;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.INCLUDE_RUNTIME;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.INVOCATIONS;
+import static org.jboss.hal.dmr.ModelDescriptionConstants.NAME;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.NEXT_TIMEOUT;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.PASSIVATED_COUNT;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.POOL_CURRENT_SIZE;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.POOL_MAX_SIZE;
+import static org.jboss.hal.dmr.ModelDescriptionConstants.READ_ATTRIBUTE_OPERATION;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.READ_RESOURCE_OPERATION;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.RECURSIVE;
+import static org.jboss.hal.dmr.ModelDescriptionConstants.RESOLVE_EXPRESSIONS;
+import static org.jboss.hal.dmr.ModelDescriptionConstants.RESULT;
+import static org.jboss.hal.dmr.ModelDescriptionConstants.STATISTICS_ENABLED;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.TIMERS;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.TIME_REMAINING;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.TOTAL_SIZE;
+import static org.jboss.hal.dmr.ModelDescriptionConstants.VALUE;
+import static org.jboss.hal.dmr.ModelDescriptionConstants.WRITE_ATTRIBUTE_OPERATION;
+import static org.jboss.hal.resources.CSS.fontAwesome;
 
 class EjbPreview extends PreviewContent<EjbNode> {
 
     private static double intervalHandle = 0; // one handle for all previews!
 
     private final Dispatcher dispatcher;
+    private final StatementContext statementContext;
     private final ResourceAddress address;
     private final LabelBuilder labelBuilder;
+    private final EmptyState noStatistics;
     private final PreviewAttributes<EjbNode> attributes;
     private final HTMLElement statefulSection;
     private final PreviewAttributes<EjbNode> statefulAttributes;
     private final HTMLElement poolSection;
     private final Utilization poolUtilization;
+    private final HTMLElement timerSection;
     private PreviewAttributes<ModelNode> timer;
     private HTMLElement nextTimeoutElement;
     private ProgressElement remainingElement;
     private int maxRemaining;
 
     EjbPreview(EjbNode ejb, FinderPathFactory finderPathFactory, Places places, Dispatcher dispatcher,
-            Resources resources) {
+            StatementContext statementContext, Resources resources) {
         super(ejb.getName(), ejb.type.type);
         this.dispatcher = dispatcher;
+        this.statementContext = statementContext;
         this.address = ejb.getAddress();
         this.labelBuilder = new LabelBuilder();
         this.maxRemaining = 0;
+
+        noStatistics = new EmptyState.Builder(Ids.EJB3_DEPLOYMENT_STATISTICS_DISABLED,
+                resources.constants().statisticsDisabledHeader())
+                .description(resources.messages().statisticsDisabled(Names.EJB3))
+                .icon(fontAwesome("line-chart"))
+                .primaryAction(resources.constants().enableStatistics(), () -> enableStatistics(ejb),
+                        Constraint.writable(EJB3_SUBSYSTEM_TEMPLATE, STATISTICS_ENABLED))
+                .build();
 
         getHeaderContainer().appendChild(refreshLink(() -> update(null)));
         FinderPath path = finderPathFactory.deployment(ejb.getDeployment());
@@ -112,6 +140,9 @@ class EjbPreview extends PreviewContent<EjbNode> {
                 asList(COMPONENT_CLASS_NAME, INVOCATIONS, EXECUTION_TIME, DELIVERY_ACTIVE));
         previewBuilder().addAll(attributes);
 
+        previewBuilder().add(noStatistics);
+        Elements.setVisible(noStatistics, false);
+
         poolSection = section().add(h(2, Names.POOL))
                 .add(poolUtilization = new Utilization(resources.constants().size(), resources.constants().instances(),
                         false, true))
@@ -121,6 +152,7 @@ class EjbPreview extends PreviewContent<EjbNode> {
         previewBuilder().addAll(poolSection, statefulSection);
 
         ModelNode firstTimer = firstTimer(ejb);
+        HtmlContent timerContent = section();
         if (firstTimer.isDefined()) {
             timer = new PreviewAttributes<>(firstTimer, Names.TIMER)
                     .append(t -> {
@@ -135,9 +167,9 @@ class EjbPreview extends PreviewContent<EjbNode> {
                         remainingElement.element().style.marginBottom = MarginBottomUnionType.of(0);
                         return new PreviewAttribute(labelBuilder.label(TIME_REMAINING), remainingElement.element());
                     });
-            previewBuilder().addAll(timer);
+            timerContent.addAll(timer);
         }
-        updateInternal(ejb);
+        previewBuilder().add(timerSection = timerContent.element());
     }
 
     @Override
@@ -148,35 +180,54 @@ class EjbPreview extends PreviewContent<EjbNode> {
 
     @Override
     public void update(EjbNode item) {
-        Operation operation = new Operation.Builder(address, READ_RESOURCE_OPERATION)
+        Operation opNode = new Operation.Builder(address, READ_RESOURCE_OPERATION)
                 .param(INCLUDE_RUNTIME, true)
                 .param(RECURSIVE, true)
                 .build();
-        dispatcher.execute(operation, result -> updateInternal(new EjbNode(address, result)));
+        ResourceAddress configurationAddress = EJB3_SUBSYSTEM_TEMPLATE.resolve(statementContext);
+        Operation opStatistics = new Operation.Builder(configurationAddress, READ_ATTRIBUTE_OPERATION)
+                .param(NAME, STATISTICS_ENABLED)
+                .param(RESOLVE_EXPRESSIONS, true)
+                .build();
+        dispatcher.execute(new Composite(opNode, opStatistics), (CompositeResult compositeResult) -> {
+            ModelNode nodeResult = compositeResult.step(0).get(RESULT);
+            ModelNode statisticsResult = compositeResult.step(1).get(RESULT);
+
+            boolean statsAvailable = nodeResult.get(INVOCATIONS).asLong() > 0;
+            boolean statsEnabled = statisticsResult.asBoolean(statsAvailable);
+
+            updateInternal(new EjbNode(address, nodeResult), statsEnabled);
+        });
     }
 
-    private void updateInternal(EjbNode ejb) {
-        Elements.setVisible(poolSection, ejb.type == MDB || ejb.type == STATELESS);
-        Elements.setVisible(statefulSection, ejb.type == STATEFUL);
-        attributes.refresh(ejb);
-        attributes.setVisible(DELIVERY_ACTIVE, ejb.type == MDB);
-        switch (ejb.type) {
-            case MDB:
-            case STATELESS:
-                poolUtilization.update(ejb.get(POOL_CURRENT_SIZE).asLong(), ejb.get(POOL_MAX_SIZE).asLong());
-                break;
-            case STATEFUL:
-                statefulAttributes.refresh(ejb);
-                break;
-            default:
-                break;
+    private void updateInternal(EjbNode ejb, boolean statsEnabled) {
+        Elements.setVisible(poolSection, statsEnabled && (ejb.type == MDB || ejb.type == STATELESS));
+        Elements.setVisible(statefulSection, statsEnabled && ejb.type == STATEFUL);
+        attributes.setVisible(DELIVERY_ACTIVE, statsEnabled && ejb.type == MDB);
+        if (statsEnabled) {
+            attributes.refresh(ejb);
+            switch (ejb.type) {
+                case MDB:
+                case STATELESS:
+                    poolUtilization.update(ejb.get(POOL_CURRENT_SIZE).asLong(), ejb.get(POOL_MAX_SIZE).asLong());
+                    break;
+                case STATEFUL:
+                    statefulAttributes.refresh(ejb);
+                    break;
+                default:
+                    break;
+            }
+            ModelNode firstTimer = firstTimer(ejb);
+            if (firstTimer.isDefined()) {
+                timer.refresh(firstTimer);
+                clearInterval(intervalHandle);
+                intervalHandle = setInterval(o -> updateRemaining(), 1000);
+            }
         }
-        ModelNode firstTimer = firstTimer(ejb);
-        if (firstTimer.isDefined()) {
-            timer.refresh(firstTimer);
-            clearInterval(intervalHandle);
-            intervalHandle = setInterval(o -> updateRemaining(), 1000);
-        }
+        Elements.setVisible(noStatistics, !statsEnabled);
+        attributes.setVisible(INVOCATIONS, statsEnabled);
+        attributes.setVisible(EXECUTION_TIME, statsEnabled);
+        Elements.setVisible(timerSection, statsEnabled);
     }
 
     private void updateRemaining() {
@@ -207,5 +258,14 @@ class EjbPreview extends PreviewContent<EjbNode> {
     private ModelNode firstTimer(ModelNode ejb) {
         List<ModelNode> timers = ModelNodeHelper.failSafeList(ejb, TIMERS);
         return timers.isEmpty() ? new ModelNode() : timers.get(0);
+    }
+
+    private void enableStatistics(EjbNode ejb) {
+        ResourceAddress address = EJB3_SUBSYSTEM_TEMPLATE.resolve(statementContext);
+        Operation operation = new Operation.Builder(address, WRITE_ATTRIBUTE_OPERATION)
+                .param(NAME, STATISTICS_ENABLED)
+                .param(VALUE, true)
+                .build();
+        dispatcher.execute(operation, result -> update(ejb));
     }
 }

--- a/app/src/main/java/org/jboss/hal/client/runtime/subsystem/messaging/DestinationColumn.java
+++ b/app/src/main/java/org/jboss/hal/client/runtime/subsystem/messaging/DestinationColumn.java
@@ -110,7 +110,8 @@ public class DestinationColumn extends FinderColumn<Destination> {
 
         super(new Builder<Destination>(finder, Ids.MESSAGING_SERVER_DESTINATION_RUNTIME, Names.DESTINATION)
                 .columnAction(columnActionFactory.refresh(Ids.MESSAGING_SERVER_DESTINATION_REFRESH))
-                .onPreview(item -> new DestinationPreview(item, finderPathFactory, places, dispatcher, resources))
+                .onPreview(item -> new DestinationPreview(item, finderPathFactory, places, dispatcher, statementContext,
+                        resources))
                 .useFirstActionAsBreadcrumbHandler()
                 .pinnable()
                 .showCount()

--- a/app/src/main/java/org/jboss/hal/client/runtime/subsystem/messaging/DestinationPreview.java
+++ b/app/src/main/java/org/jboss/hal/client/runtime/subsystem/messaging/DestinationPreview.java
@@ -16,6 +16,8 @@
 package org.jboss.hal.client.runtime.subsystem.messaging;
 
 import org.jboss.elemento.Elements;
+import org.jboss.elemento.HtmlContent;
+import org.jboss.hal.ballroom.EmptyState;
 import org.jboss.hal.ballroom.LabelBuilder;
 import org.jboss.hal.core.finder.FinderPath;
 import org.jboss.hal.core.finder.FinderPathFactory;
@@ -24,12 +26,18 @@ import org.jboss.hal.core.finder.PreviewAttributes.PreviewAttribute;
 import org.jboss.hal.core.finder.PreviewAttributes.PreviewAttributeFunction;
 import org.jboss.hal.core.finder.PreviewContent;
 import org.jboss.hal.core.mvp.Places;
+import org.jboss.hal.dmr.Composite;
+import org.jboss.hal.dmr.CompositeResult;
 import org.jboss.hal.dmr.ModelNode;
 import org.jboss.hal.dmr.ModelNodeHelper;
 import org.jboss.hal.dmr.Operation;
 import org.jboss.hal.dmr.ResourceAddress;
 import org.jboss.hal.dmr.dispatch.Dispatcher;
+import org.jboss.hal.meta.AddressTemplate;
+import org.jboss.hal.meta.StatementContext;
+import org.jboss.hal.meta.security.Constraint;
 import org.jboss.hal.meta.token.NameTokens;
+import org.jboss.hal.resources.Ids;
 import org.jboss.hal.resources.Names;
 import org.jboss.hal.resources.Resources;
 
@@ -41,7 +49,10 @@ import static elemental2.dom.DomGlobal.document;
 import static java.util.stream.Collectors.joining;
 import static org.jboss.elemento.Elements.a;
 import static org.jboss.elemento.Elements.bag;
+import static org.jboss.elemento.Elements.section;
+import static org.jboss.elemento.Elements.setVisible;
 import static org.jboss.elemento.Elements.span;
+import static org.jboss.hal.client.runtime.subsystem.messaging.AddressTemplates.MESSAGING_SERVER_TEMPLATE;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.CONSUMER_COUNT;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.DEAD_LETTER_ADDRESS;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.DELIVERING_COUNT;
@@ -53,32 +64,54 @@ import static org.jboss.hal.dmr.ModelDescriptionConstants.EXPIRY_ADDRESS;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.INCLUDE_RUNTIME;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.MESSAGES_ADDED;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.MESSAGE_COUNT;
+import static org.jboss.hal.dmr.ModelDescriptionConstants.NAME;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.NON_DURABLE_MESSAGE_COUNT;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.NON_DURABLE_SUBSCRIPTION_COUNT;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.PAUSED;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.QUEUE_ADDRESS;
+import static org.jboss.hal.dmr.ModelDescriptionConstants.READ_ATTRIBUTE_OPERATION;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.READ_RESOURCE_OPERATION;
+import static org.jboss.hal.dmr.ModelDescriptionConstants.RESOLVE_EXPRESSIONS;
+import static org.jboss.hal.dmr.ModelDescriptionConstants.RESULT;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.SCHEDULED_COUNT;
+import static org.jboss.hal.dmr.ModelDescriptionConstants.STATISTICS_ENABLED;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.SUBSCRIPTION_COUNT;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.TEMPORARY;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.TOPIC_ADDRESS;
+import static org.jboss.hal.dmr.ModelDescriptionConstants.VALUE;
+import static org.jboss.hal.dmr.ModelDescriptionConstants.WRITE_ATTRIBUTE_OPERATION;
 import static org.jboss.hal.dmr.ModelNodeHelper.failSafeBoolean;
+import static org.jboss.hal.resources.CSS.fontAwesome;
 import static org.jboss.hal.resources.CSS.marginRight5;
 import static org.jboss.hal.resources.Icons.flag;
 
 class DestinationPreview extends PreviewContent<Destination> {
 
     private final Dispatcher dispatcher;
+    private final StatementContext statementContext;
     private final ResourceAddress address;
+    private final EmptyState noStatistics;
+    private final HTMLElement statSection;
     private final PreviewAttributes<Destination> attributes;
     private final PreviewAttributes<Destination> messages;
     private final PreviewAttributes<Destination> subscriptions;
 
     DestinationPreview(Destination destination, FinderPathFactory finderPathFactory, Places places,
-            Dispatcher dispatcher, Resources resources) {
+            Dispatcher dispatcher, StatementContext statementContext, Resources resources) {
         super(destination.getName(), destination.type.type);
         this.dispatcher = dispatcher;
+        this.statementContext = statementContext;
         this.address = destination.getAddress();
+
+        AddressTemplate serverTemplate = MESSAGING_SERVER_TEMPLATE.replaceWildcards(getServerName(destination));
+        noStatistics = new EmptyState.Builder(Ids.MESSAGING_STATISTICS_DISABLED,
+                resources.constants().statisticsDisabledHeader())
+                .description(resources.messages().messagingServerStatisticsDisabled(getServerName(destination)))
+                .icon(fontAwesome("line-chart"))
+                .primaryAction(resources.constants().enableStatistics(), () -> enableStatistics(destination),
+                        Constraint.writable(serverTemplate, STATISTICS_ENABLED))
+                .build();
+        Elements.setVisible(noStatistics.element(), false);
 
         getHeaderContainer().appendChild(refreshLink(() -> update(destination)));
         if (destination.fromDeployment()) {
@@ -142,25 +175,60 @@ class DestinationPreview extends PreviewContent<Destination> {
                     .append(NON_DURABLE_SUBSCRIPTION_COUNT);
         }
 
-        previewBuilder().addAll(attributes);
-        previewBuilder().addAll(messages);
+        previewBuilder().addAll(attributes)
+                .add(noStatistics);
+        HtmlContent sectionContent = section()
+                .addAll(messages);
         if (destination.type == Destination.Type.JMS_TOPIC) {
-            previewBuilder().addAll(subscriptions);
+            sectionContent.addAll(subscriptions);
         }
+        previewBuilder().add(statSection = sectionContent
+                .element());
     }
 
     @Override
     public void update(Destination item) {
-        Operation operation = new Operation.Builder(address, READ_RESOURCE_OPERATION)
+        Operation opDestination = new Operation.Builder(address, READ_RESOURCE_OPERATION)
                 .param(INCLUDE_RUNTIME, true)
                 .build();
-        dispatcher.execute(operation, result -> {
-            Destination update = new Destination(item.getAddress(), item);
-            attributes.refresh(update);
-            messages.refresh(update);
-            if (update.type == Destination.Type.JMS_TOPIC) {
-                subscriptions.refresh(item);
+        ResourceAddress serverAddress = MESSAGING_SERVER_TEMPLATE.resolve(statementContext, getServerName(item));
+        Operation opStatistics = new Operation.Builder(serverAddress, READ_ATTRIBUTE_OPERATION)
+                .param(NAME, STATISTICS_ENABLED)
+                .param(RESOLVE_EXPRESSIONS, true)
+                .build();
+
+        dispatcher.execute(new Composite(opDestination, opStatistics), (CompositeResult compositeResult) -> {
+            ModelNode destinationResult = compositeResult.step(0).get(RESULT);
+            ModelNode statisticsResult = compositeResult.step(1).get(RESULT);
+
+            boolean statsAvailable = destinationResult.get(MESSAGES_ADDED).asLong() > 0;
+            boolean statsEnabled = statisticsResult.asBoolean(statsAvailable);
+
+            if (statsEnabled) {
+                Destination update = new Destination(item.getAddress(), item);
+                attributes.refresh(update);
+                messages.refresh(update);
+                if (update.type == Destination.Type.JMS_TOPIC) {
+                    subscriptions.refresh(item);
+                }
             }
+
+            setVisible(noStatistics, !statsEnabled);
+            setVisible(statSection, statsEnabled);
         });
+    }
+
+    private void enableStatistics(Destination item) {
+        String serverName = getServerName(item);
+        ResourceAddress serverAddress = MESSAGING_SERVER_TEMPLATE.resolve(statementContext, serverName);
+        Operation operation = new Operation.Builder(serverAddress, WRITE_ATTRIBUTE_OPERATION)
+                .param(NAME, STATISTICS_ENABLED)
+                .param(VALUE, true)
+                .build();
+        dispatcher.execute(operation, result -> update(item));
+    }
+
+    private String getServerName(Destination item) {
+        return item.getAddress().getParent().lastValue();
     }
 }

--- a/app/src/main/java/org/jboss/hal/client/runtime/subsystem/transaction/TransactionsPreview.java
+++ b/app/src/main/java/org/jboss/hal/client/runtime/subsystem/transaction/TransactionsPreview.java
@@ -117,14 +117,14 @@ public class TransactionsPreview extends PreviewContent<SubsystemMetadata> {
         ResourceAddress addressWeb = TRANSACTION_RUNTIME_TEMPLATE.resolve(statementContext);
         Operation opWeb = new Operation.Builder(addressWeb, READ_RESOURCE_OPERATION)
                 .param(INCLUDE_RUNTIME, true)
+                .param(RESOLVE_EXPRESSIONS, true)
                 .build();
         dispatcher.execute(opWeb, result -> {
-            boolean statsEnabled = result.get(STATISTICS_ENABLED).asBoolean(false);
-            Elements.setVisible(noStatistics.element(), !statsEnabled);
+            boolean statsAvailable = result.get(NUMBER_OF_TRANSACTIONS).asLong() > 0;
+            boolean statsEnabled = result.get(STATISTICS_ENABLED).asBoolean(statsAvailable);
 
             if (statsEnabled) {
                 attributes.refresh(result);
-                long maxTransactions = result.get(NUMBER_OF_TRANSACTIONS).asLong();
                 long committed = result.get(NUMBER_OF_COMMITTED_TRANSACTIONS).asLong();
                 long aborted = result.get(NUMBER_OF_ABORTED_TRANSACTIONS).asLong();
                 long timedout = result.get(NUMBER_OF_TIMEDOUT_TRANSACTIONS).asLong();
@@ -142,13 +142,11 @@ public class TransactionsPreview extends PreviewContent<SubsystemMetadata> {
                 txUpdates.put(TransactionStatus.RESOURCE_ROLLBACK.name(), resourceRollbacks);
                 txUpdates.put(TransactionStatus.APPLICATION_ROLLBACK.name(), appRollbacks);
                 transactions.update(txUpdates);
-
-                Elements.setVisible(attributesElement, true);
-                Elements.setVisible(transactions.element(), true);
-            } else {
-                Elements.setVisible(attributesElement, false);
-                Elements.setVisible(transactions.element(), false);
             }
+
+            Elements.setVisible(noStatistics.element(), !statsEnabled);
+            Elements.setVisible(attributesElement, statsEnabled);
+            Elements.setVisible(transactions.element(), statsEnabled);
         });
     }
 

--- a/app/src/main/java/org/jboss/hal/client/runtime/subsystem/undertow/ListenerPreview.java
+++ b/app/src/main/java/org/jboss/hal/client/runtime/subsystem/undertow/ListenerPreview.java
@@ -120,11 +120,13 @@ class ListenerPreview extends PreviewContent<NamedNode> {
                 .resolve(statementContext, webserver);
         Operation operation = new Operation.Builder(address, READ_RESOURCE_OPERATION)
                 .param(INCLUDE_RUNTIME, true)
+                .param(RESOLVE_EXPRESSIONS, true)
                 .build();
         dispatcher.execute(operation, result -> {
             NamedNode listenerResult = new NamedNode(result);
             previewAttributes.refresh(listenerResult);
-            boolean statisticsEnabled = listenerResult.get(RECORD_REQUEST_START_TIME).asBoolean(false);
+            boolean statsAvailable = result.get(REQUEST_COUNT).asLong() > 0;
+            boolean statisticsEnabled = listenerResult.get(RECORD_REQUEST_START_TIME).asBoolean(statsAvailable);
 
             if (statisticsEnabled) {
                 Map<String, Long> processingTimes = new HashMap<>();

--- a/app/src/main/java/org/jboss/hal/client/runtime/subsystem/undertow/UndertowPreview.java
+++ b/app/src/main/java/org/jboss/hal/client/runtime/subsystem/undertow/UndertowPreview.java
@@ -15,17 +15,8 @@
  */
 package org.jboss.hal.client.runtime.subsystem.undertow;
 
-import org.jboss.elemento.Elements;
-import org.jboss.hal.ballroom.EmptyState;
 import org.jboss.hal.core.finder.PreviewContent;
 import org.jboss.hal.core.subsystem.SubsystemMetadata;
-import org.jboss.hal.dmr.Operation;
-import org.jboss.hal.dmr.ResourceAddress;
-import org.jboss.hal.dmr.dispatch.Dispatcher;
-import org.jboss.hal.meta.AddressTemplate;
-import org.jboss.hal.meta.StatementContext;
-import org.jboss.hal.meta.security.Constraint;
-import org.jboss.hal.resources.Ids;
 import org.jboss.hal.resources.Names;
 import org.jboss.hal.resources.Previews;
 import org.jboss.hal.resources.Resources;
@@ -33,59 +24,18 @@ import org.jboss.hal.resources.Resources;
 import elemental2.dom.HTMLElement;
 
 import static org.jboss.elemento.Elements.section;
-import static org.jboss.hal.client.runtime.subsystem.undertow.AddressTemplates.WEB_SUBSYSTEM_TEMPLATE;
-import static org.jboss.hal.dmr.ModelDescriptionConstants.*;
-import static org.jboss.hal.resources.CSS.fontAwesome;
 
 public class UndertowPreview extends PreviewContent<SubsystemMetadata> {
 
-    private final Dispatcher dispatcher;
-    private final StatementContext statementContext;
-    private final EmptyState noStatistics;
     private final HTMLElement descriptionPreview;
 
-    public UndertowPreview(Dispatcher dispatcher, StatementContext statementContext, Resources resources) {
+    public UndertowPreview(Resources resources) {
         super(Names.WEB, Names.UNDERTOW);
-        this.dispatcher = dispatcher;
-        this.statementContext = statementContext;
-
-        noStatistics = new EmptyState.Builder(Ids.UNDERTOW_STATISTICS_DISABLED,
-                resources.constants().statisticsDisabledHeader())
-                .description(resources.messages().statisticsDisabled(Names.UNDERTOW))
-                .icon(fontAwesome("line-chart"))
-                .primaryAction(resources.constants().enableStatistics(), this::enableStatistics,
-                        Constraint.writable(WEB_SUBSYSTEM_TEMPLATE, STATISTICS_ENABLED))
-                .build();
-        Elements.setVisible(noStatistics.element(), false);
 
         descriptionPreview = section().element();
-        Elements.setVisible(descriptionPreview, false);
         Previews.innerHtml(descriptionPreview, resources.previews().runtimeWeb());
 
         previewBuilder()
-                .add(noStatistics)
                 .add(descriptionPreview);
-    }
-
-    @Override
-    public void update(SubsystemMetadata item) {
-        ResourceAddress addressWeb = WEB_SUBSYSTEM_TEMPLATE.resolve(statementContext);
-        Operation opWeb = new Operation.Builder(addressWeb, READ_RESOURCE_OPERATION)
-                .param(INCLUDE_RUNTIME, true)
-                .build();
-        dispatcher.execute(opWeb, result -> {
-            boolean statsEnabled = result.get(STATISTICS_ENABLED).asBoolean(false);
-            Elements.setVisible(noStatistics.element(), !statsEnabled);
-            Elements.setVisible(descriptionPreview, statsEnabled);
-        });
-    }
-
-    private void enableStatistics() {
-        ResourceAddress address = AddressTemplate.of("{selected.profile}/subsystem=undertow").resolve(statementContext);
-        Operation operation = new Operation.Builder(address, WRITE_ATTRIBUTE_OPERATION)
-                .param(NAME, STATISTICS_ENABLED)
-                .param(VALUE, true)
-                .build();
-        dispatcher.execute(operation, result -> update(null));
     }
 }

--- a/app/src/main/java/org/jboss/hal/client/runtime/subsystem/webservice/EndpointColumn.java
+++ b/app/src/main/java/org/jboss/hal/client/runtime/subsystem/webservice/EndpointColumn.java
@@ -28,6 +28,7 @@ import org.jboss.hal.core.finder.FinderPathFactory;
 import org.jboss.hal.core.finder.ItemDisplay;
 import org.jboss.hal.core.mvp.Places;
 import org.jboss.hal.dmr.dispatch.Dispatcher;
+import org.jboss.hal.meta.StatementContext;
 import org.jboss.hal.resources.Ids;
 import org.jboss.hal.resources.Names;
 import org.jboss.hal.resources.Resources;
@@ -47,7 +48,7 @@ public class EndpointColumn extends FinderColumn<DeploymentResource> {
     @Inject
     public EndpointColumn(FinderPathFactory finderPathFactory, Places places, Finder finder,
             ColumnActionFactory columnActionFactory,
-            Dispatcher dispatcher,
+            Dispatcher dispatcher, StatementContext statementContext,
             DeploymentResources deploymentResources, Resources resources) {
 
         super(new Builder<DeploymentResource>(finder, Ids.ENDPOINT, Names.ENDPOINT)
@@ -94,7 +95,8 @@ public class EndpointColumn extends FinderColumn<DeploymentResource> {
                     }
                 })
 
-                .onPreview(item -> new EndpointPreview(finderPathFactory, places, item, dispatcher, resources))
+                .onPreview(
+                        item -> new EndpointPreview(finderPathFactory, places, item, dispatcher, statementContext, resources))
                 .useFirstActionAsBreadcrumbHandler()
                 .withFilter()
                 .filterDescription(resources.messages().endpointColumnFilterDescription())

--- a/app/src/main/java/org/jboss/hal/client/runtime/subsystem/webservice/EndpointPreview.java
+++ b/app/src/main/java/org/jboss/hal/client/runtime/subsystem/webservice/EndpointPreview.java
@@ -19,6 +19,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.jboss.elemento.Elements;
+import org.jboss.hal.ballroom.EmptyState;
 import org.jboss.hal.ballroom.LabelBuilder;
 import org.jboss.hal.ballroom.PatternFly;
 import org.jboss.hal.ballroom.chart.Donut;
@@ -29,10 +30,15 @@ import org.jboss.hal.core.finder.FinderPathFactory;
 import org.jboss.hal.core.finder.PreviewAttributes;
 import org.jboss.hal.core.finder.PreviewContent;
 import org.jboss.hal.core.mvp.Places;
+import org.jboss.hal.dmr.Composite;
+import org.jboss.hal.dmr.CompositeResult;
 import org.jboss.hal.dmr.ModelNode;
 import org.jboss.hal.dmr.Operation;
 import org.jboss.hal.dmr.Property;
+import org.jboss.hal.dmr.ResourceAddress;
 import org.jboss.hal.dmr.dispatch.Dispatcher;
+import org.jboss.hal.meta.StatementContext;
+import org.jboss.hal.meta.security.Constraint;
 import org.jboss.hal.meta.token.NameTokens;
 import org.jboss.hal.resources.Ids;
 import org.jboss.hal.resources.Names;
@@ -40,10 +46,14 @@ import org.jboss.hal.resources.Resources;
 
 import com.gwtplatform.mvp.shared.proxy.PlaceRequest;
 
+import elemental2.dom.HTMLElement;
+
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 import static org.jboss.elemento.Elements.a;
 import static org.jboss.elemento.Elements.h;
+import static org.jboss.elemento.Elements.section;
+import static org.jboss.hal.client.runtime.subsystem.webservice.AddressTemplates.WEBSERVICES_CONFIGURATION_TEMPLATE;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.AVERAGE_PROCESSING_TIME;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.CHILD_TYPE;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.CLASS;
@@ -53,28 +63,50 @@ import static org.jboss.hal.dmr.ModelDescriptionConstants.FAULT_COUNT;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.INCLUDE_RUNTIME;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.MAX_PROCESSING_TIME;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.MIN_PROCESSING_TIME;
+import static org.jboss.hal.dmr.ModelDescriptionConstants.NAME;
+import static org.jboss.hal.dmr.ModelDescriptionConstants.READ_ATTRIBUTE_OPERATION;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.READ_CHILDREN_RESOURCES_OPERATION;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.REQUEST_COUNT;
+import static org.jboss.hal.dmr.ModelDescriptionConstants.RESOLVE_EXPRESSIONS;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.RESPONSE_COUNT;
+import static org.jboss.hal.dmr.ModelDescriptionConstants.RESULT;
+import static org.jboss.hal.dmr.ModelDescriptionConstants.STATISTICS_ENABLED;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.TOTAL_PROCESSING_TIME;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.TYPE;
+import static org.jboss.hal.dmr.ModelDescriptionConstants.VALUE;
+import static org.jboss.hal.dmr.ModelDescriptionConstants.WRITE_ATTRIBUTE_OPERATION;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.WSDL_URL;
+import static org.jboss.hal.resources.CSS.fontAwesome;
 import static org.jboss.hal.resources.Strings.abbreviateFqClassName;
 
 class EndpointPreview extends PreviewContent<DeploymentResource> {
 
+    private EmptyState noStatistics;
     private final Dispatcher dispatcher;
+    private final StatementContext statementContext;
     private final PreviewAttributes<DeploymentResource> previewAttributes;
     private final PreviewAttributes<DeploymentResource> totalProcessingTimeAttribute;
     private final PreviewAttributes<DeploymentResource> responseAttribute;
+    private final HTMLElement statSection;
     private final GroupedBar processingTime;
     private final Donut requests;
     private final LabelBuilder lblBuilder = new LabelBuilder();
 
     EndpointPreview(FinderPathFactory finderPathFactory, Places places,
-            DeploymentResource deploymentResource, Dispatcher dispatcher, Resources resources) {
+            DeploymentResource deploymentResource, Dispatcher dispatcher, StatementContext statementContext,
+            Resources resources) {
         super(abbreviateFqClassName(deploymentResource.getName()), deploymentResource.getPath());
         this.dispatcher = dispatcher;
+        this.statementContext = statementContext;
+
+        noStatistics = new EmptyState.Builder(Ids.WEBSERVICES_STATISTICS_DISABLED,
+                resources.constants().statisticsDisabledHeader())
+                .description(resources.messages().statisticsDisabled(Names.WEBSERVICES))
+                .icon(fontAwesome("line-chart"))
+                .primaryAction(resources.constants().enableStatistics(), () -> enableStatistics(deploymentResource),
+                        Constraint.writable(WEBSERVICES_CONFIGURATION_TEMPLATE, STATISTICS_ENABLED))
+                .build();
+        Elements.setVisible(noStatistics.element(), false);
 
         getHeaderContainer().title = deploymentResource.getName();
         getHeaderContainer().appendChild(refreshLink(() -> update(deploymentResource)));
@@ -113,14 +145,16 @@ class EndpointPreview extends PreviewContent<DeploymentResource> {
         registerAttachable(requests);
         responseAttribute = new PreviewAttributes<>(deploymentResource, null, singletonList(RESPONSE_COUNT));
 
-        previewBuilder()
-                .addAll(previewAttributes)
-                .add(h(2, resources.constants().processingTime()))
-                .add(processingTime)
-                .addAll(totalProcessingTimeAttribute)
-                .add(h(2, resources.constants().request() + " / " + resources.constants().response()))
-                .add(requests)
-                .addAll(responseAttribute);
+        previewBuilder().addAll(previewAttributes)
+                .add(noStatistics)
+                .add(statSection = section()
+                        .add(h(2, resources.constants().processingTime()))
+                        .add(processingTime)
+                        .addAll(totalProcessingTimeAttribute)
+                        .add(h(2, resources.constants().request() + " / " + resources.constants().response()))
+                        .add(requests)
+                        .addAll(responseAttribute)
+                        .element());
     }
 
     private PreviewAttributes.PreviewAttribute msAttribute(String attribute, ModelNode model) {
@@ -135,32 +169,57 @@ class EndpointPreview extends PreviewContent<DeploymentResource> {
         // in the endpointa name, causing a HTTP 500 address not found.
         // Then, read the parent resoource and interate over the endpoint results to match the endpoint name.
         String endpointName = item.getAddress().lastValue();
-        Operation operation = new Operation.Builder(item.getAddress().getParent(), READ_CHILDREN_RESOURCES_OPERATION)
+        Operation opEndpoint = new Operation.Builder(item.getAddress().getParent(), READ_CHILDREN_RESOURCES_OPERATION)
                 .param(CHILD_TYPE, ENDPOINT)
                 .param(INCLUDE_RUNTIME, true)
                 .build();
-        dispatcher.execute(operation, result -> {
-            for (Property prop : result.asPropertyList()) {
+        ResourceAddress configurationAddress = WEBSERVICES_CONFIGURATION_TEMPLATE.resolve(statementContext);
+        Operation opStatistics = new Operation.Builder(configurationAddress, READ_ATTRIBUTE_OPERATION)
+                .param(NAME, STATISTICS_ENABLED)
+                .param(RESOLVE_EXPRESSIONS, true)
+                .build();
+
+        dispatcher.execute(new Composite(opEndpoint, opStatistics), (CompositeResult compositeResult) -> {
+            ModelNode endpointResult = compositeResult.step(0).get(RESULT);
+            ModelNode statisticsResult = compositeResult.step(1).get(RESULT);
+
+            for (Property prop : endpointResult.asPropertyList()) {
                 if (prop.getName().equals(endpointName)) {
                     ModelNode node = prop.getValue();
                     DeploymentResource n = new DeploymentResource(item.getAddress(), node);
                     previewAttributes.refresh(n);
 
-                    Map<String, Long> processingTimes = new HashMap<>();
-                    processingTimes.put(MIN_PROCESSING_TIME, node.get(MIN_PROCESSING_TIME).asLong());
-                    processingTimes.put(AVERAGE_PROCESSING_TIME, node.get(AVERAGE_PROCESSING_TIME).asLong());
-                    processingTimes.put(MAX_PROCESSING_TIME, node.get(MAX_PROCESSING_TIME).asLong());
-                    processingTime.update(processingTimes);
-                    totalProcessingTimeAttribute.refresh(n);
+                    boolean statsAvailable = node.get(REQUEST_COUNT).asLong() > 0;
+                    boolean statsEnabled = statisticsResult.asBoolean(statsAvailable);
+                    if (statsEnabled) {
+                        Map<String, Long> processingTimes = new HashMap<>();
+                        processingTimes.put(MIN_PROCESSING_TIME, node.get(MIN_PROCESSING_TIME).asLong());
+                        processingTimes.put(AVERAGE_PROCESSING_TIME, node.get(AVERAGE_PROCESSING_TIME).asLong());
+                        processingTimes.put(MAX_PROCESSING_TIME, node.get(MAX_PROCESSING_TIME).asLong());
+                        processingTime.update(processingTimes);
+                        totalProcessingTimeAttribute.refresh(n);
 
-                    Map<String, Long> metricUpdates = new HashMap<>(7);
-                    metricUpdates.put(REQUEST_COUNT, node.get(REQUEST_COUNT).asLong());
-                    metricUpdates.put(FAULT_COUNT, node.get(FAULT_COUNT).asLong());
-                    requests.update(metricUpdates);
-                    responseAttribute.refresh(n);
+                        Map<String, Long> metricUpdates = new HashMap<>(7);
+                        metricUpdates.put(REQUEST_COUNT, node.get(REQUEST_COUNT).asLong());
+                        metricUpdates.put(FAULT_COUNT, node.get(FAULT_COUNT).asLong());
+                        requests.update(metricUpdates);
+                        responseAttribute.refresh(n);
+                    }
+
+                    Elements.setVisible(noStatistics.element(), !statsEnabled);
+                    Elements.setVisible(statSection, statsEnabled);
                     break;
                 }
             }
         });
+    }
+
+    private void enableStatistics(DeploymentResource item) {
+        ResourceAddress address = WEBSERVICES_CONFIGURATION_TEMPLATE.resolve(statementContext);
+        Operation operation = new Operation.Builder(address, WRITE_ATTRIBUTE_OPERATION)
+                .param(NAME, STATISTICS_ENABLED)
+                .param(VALUE, true)
+                .build();
+        dispatcher.execute(operation, result -> update(item));
     }
 }

--- a/app/src/main/java/org/jboss/hal/client/runtime/subsystem/webservice/WebservicesPreview.java
+++ b/app/src/main/java/org/jboss/hal/client/runtime/subsystem/webservice/WebservicesPreview.java
@@ -15,8 +15,6 @@
  */
 package org.jboss.hal.client.runtime.subsystem.webservice;
 
-import org.jboss.elemento.Elements;
-import org.jboss.hal.ballroom.EmptyState;
 import org.jboss.hal.core.finder.PreviewAttributes;
 import org.jboss.hal.core.finder.PreviewContent;
 import org.jboss.hal.core.subsystem.SubsystemMetadata;
@@ -24,10 +22,7 @@ import org.jboss.hal.dmr.ModelNode;
 import org.jboss.hal.dmr.Operation;
 import org.jboss.hal.dmr.ResourceAddress;
 import org.jboss.hal.dmr.dispatch.Dispatcher;
-import org.jboss.hal.meta.AddressTemplate;
 import org.jboss.hal.meta.StatementContext;
-import org.jboss.hal.meta.security.Constraint;
-import org.jboss.hal.resources.Ids;
 import org.jboss.hal.resources.Names;
 import org.jboss.hal.resources.Resources;
 
@@ -35,14 +30,11 @@ import elemental2.dom.HTMLElement;
 
 import static java.util.Arrays.asList;
 import static org.jboss.elemento.Elements.section;
-import static org.jboss.hal.client.runtime.subsystem.webservice.AddressTemplates.WEBSERVICES_CONFIGURATION_TEMPLATE;
 import static org.jboss.hal.client.runtime.subsystem.webservice.AddressTemplates.WEBSERVICES_RUNTIME_TEMPLATE;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.*;
-import static org.jboss.hal.resources.CSS.fontAwesome;
 
 public class WebservicesPreview extends PreviewContent<SubsystemMetadata> {
 
-    private EmptyState noStatistics;
     private Dispatcher dispatcher;
     private StatementContext statementContext;
     private HTMLElement attributesElement;
@@ -53,15 +45,6 @@ public class WebservicesPreview extends PreviewContent<SubsystemMetadata> {
         this.dispatcher = dispatcher;
         this.statementContext = statementContext;
 
-        noStatistics = new EmptyState.Builder(Ids.WEBSERVICES_STATISTICS_DISABLED,
-                resources.constants().statisticsDisabledHeader())
-                .description(resources.messages().statisticsDisabled(Names.WEBSERVICES))
-                .icon(fontAwesome("line-chart"))
-                .primaryAction(resources.constants().enableStatistics(), this::enableStatistics,
-                        Constraint.writable(WEBSERVICES_CONFIGURATION_TEMPLATE, STATISTICS_ENABLED))
-                .build();
-        Elements.setVisible(noStatistics.element(), false);
-
         attributes = new PreviewAttributes<>(new ModelNode(), resources.constants().attributes(),
                 asList("modify-wsdl-address", "wsdl-host", "wsdl-path-rewrite-rule", "wsdl-port", "wsdl-secure-port",
                         "wsdl-uri-scheme"));
@@ -69,7 +52,6 @@ public class WebservicesPreview extends PreviewContent<SubsystemMetadata> {
                 .addAll(attributes).element();
 
         previewBuilder()
-                .add(noStatistics)
                 .add(attributesElement);
     }
 
@@ -81,20 +63,7 @@ public class WebservicesPreview extends PreviewContent<SubsystemMetadata> {
                 .param(RESOLVE_EXPRESSIONS, true)
                 .build();
         dispatcher.execute(opSubsystem, result -> {
-            boolean statsEnabled = result.get(STATISTICS_ENABLED).asBoolean(false);
             attributes.refresh(result);
-            Elements.setVisible(noStatistics.element(), !statsEnabled);
-            Elements.setVisible(attributesElement, statsEnabled);
         });
-    }
-
-    private void enableStatistics() {
-        ResourceAddress address = AddressTemplate.of("{selected.profile}/subsystem=webservices")
-                .resolve(statementContext);
-        Operation operation = new Operation.Builder(address, WRITE_ATTRIBUTE_OPERATION)
-                .param(NAME, STATISTICS_ENABLED)
-                .param(VALUE, true)
-                .build();
-        dispatcher.execute(operation, result -> update(null));
     }
 }

--- a/core/src/main/java/org/jboss/hal/core/datasource/DataSource.java
+++ b/core/src/main/java/org/jboss/hal/core/datasource/DataSource.java
@@ -78,7 +78,7 @@ public class DataSource extends NamedNode {
     }
 
     public boolean isStatisticsEnabled() {
-        return hasDefined(STATISTICS_ENABLED) && get(STATISTICS_ENABLED).asBoolean(false);
+        return get("statistics", JDBC, STATISTICS_ENABLED).asBoolean();
     }
 
     public void setDriver(JdbcDriver driver) {

--- a/resources/src/main/java/org/jboss/hal/resources/Ids.java
+++ b/resources/src/main/java/org/jboss/hal/resources/Ids.java
@@ -197,6 +197,8 @@ public interface Ids {
     String EJB3_APPLICATION_SECURITY_DOMAIN_ITEM = "ejb3-app-security-domain-item";
     String EJB3_APPLICATION_SECURITY_DOMAIN_TABLE = "ejb3-app-security-domain-table";
     String EJB3_DEPLOYMENT = "ejb3-deployment";
+    String EJB3_DEPLOYMENT_STATISTICS_DISABLED = "ejb3-deployment-statistics-disabled";
+    String EJB3_STATISTICS_DISABLED = "ejb3-statistics-disabled";
     String ELYTRON = "elytron";
     String ELYTRON_ADD_PREFIX_ROLE_MAPPER = "elytron-add-prefix-role-mapper";
     String ELYTRON_ADD_SUFFIX_ROLE_MAPPER = "elytron-add-suffix-role-mapper";
@@ -614,6 +616,7 @@ public interface Ids {
     String MESSAGING_SERVER_TRANSACTION_TABLE = "msg-server-transaction-table";
     String MESSAGING_SOCKET_BROADCAST_GROUP = "messaging-socket-broadcast-group";
     String MESSAGING_SOCKET_DISCOVERY_GROUP = "messaging-socket-discovery-group";
+    String MESSAGING_STATISTICS_DISABLED = "messaging-statistics-disabled";
     String MICRO_PROFILE_CONFIG_SOURCE = "microprofile-config-source";
     String MICRO_PROFILE_HEALTH = "microprofile-health";
     String MICRO_PROFILE_METRICS_FORM = "microprofile-metrics-form";

--- a/resources/src/main/java/org/jboss/hal/resources/Messages.java
+++ b/resources/src/main/java/org/jboss/hal/resources/Messages.java
@@ -442,6 +442,8 @@ public interface Messages extends com.google.gwt.i18n.client.Messages {
 
     SafeHtml messageServerStopped(String name, String server);
 
+    SafeHtml messagingServerStatisticsDisabled(String server);
+
     SafeHtml metadataError();
 
     SafeHtml microprofileHealthOutcome(String outcome);

--- a/resources/src/main/resources/org/jboss/hal/resources/Messages.properties
+++ b/resources/src/main/resources/org/jboss/hal/resources/Messages.properties
@@ -307,6 +307,7 @@ manyMessages=The queue contains <strong>{0, number}</strong> messages. Reading a
 mappingHint=Add new mappings as <em>from=to</em> pairs. Press <abbr class="key" title="RETURN">&crarr;</abbr> to add and <abbr class="key" title="BACKSPACE">&#x232B</abbr> to remove them.
 messageServerStarted=The message server <strong>{0}</strong> is up and running.
 messageServerStopped=The message server <strong>{0}</strong> is stopped. Please reload server <strong>{1}</strong> to use the message server again.
+messagingServerStatisticsDisabled=Statistics are not enabled for messaging server <strong>{0}</strong>. Click the button below to enable statistics. This will set the attribute <code>statistics-enabled</code> to <code>true</code>.
 membershipColumnFilterDescription=Filter by: Principal or includes/excludes
 metadataError=Error while reading metadata.
 microprofileHealthNoChecks=There are no health checks to show.


### PR DESCRIPTION
…ved expression

Issue: [HAL-1793](https://issues.redhat.com/browse/HAL-1793)

I've changed the logic to guess if statistics are enabled in case we cannot resolve the expression, we can still get a false negative but it shouldn't be that common. In some of the subsystems we weren't checking if statistics are available, so that should now be unified.

Affected subsystems:
 * Datasources
 * EJB3
 * Messaging
 * Transactions
 * Undertow
 * Webservices
