### PR TITLE
[HAL-1802] HAL console unaviable after gwt upgrade to 2.10.0

### DIFF
--- a/core/src/main/java/org/jboss/hal/core/mvp/Places.java
+++ b/core/src/main/java/org/jboss/hal/core/mvp/Places.java
@@ -141,7 +141,10 @@ public class Places {
 
     public String historyToken(PlaceRequest placeRequest) {
         String href = location();
-        href = href.substring(0, href.indexOf('#'));
+        int pos = href.indexOf('#');
+        if (pos != -1) {
+            href = href.substring(0, pos);
+        }
         return href + "#" + tokenFormatter.toHistoryToken(singletonList(placeRequest));
     }
 


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/HAL-1802

After the gwt upgrade to 2.10.0 the location url does not have the # character and the indexOf returns -1. This triggers a StringIndexOutOfBoundsException and a loop in the initialization after login. Tested in chrome and firefox.