### PR TITLE
[HAL-1801] No resource definition registered for webservices endpoints on a host slave

### DIFF
--- a/app/src/main/java/org/jboss/hal/client/runtime/subsystem/webservice/EndpointColumn.java
+++ b/app/src/main/java/org/jboss/hal/client/runtime/subsystem/webservice/EndpointColumn.java
@@ -31,7 +31,9 @@ import org.jboss.hal.core.finder.FinderContext;
 import org.jboss.hal.core.finder.FinderPathFactory;
 import org.jboss.hal.core.finder.ItemDisplay;
 import org.jboss.hal.core.mvp.Places;
+import org.jboss.hal.dmr.ResourceAddress;
 import org.jboss.hal.dmr.dispatch.Dispatcher;
+import org.jboss.hal.meta.AddressTemplate;
 import org.jboss.hal.meta.StatementContext;
 import org.jboss.hal.resources.Ids;
 import org.jboss.hal.resources.Names;
@@ -57,10 +59,15 @@ public class EndpointColumn extends FinderColumn<DeploymentResource> {
                 .columnAction(columnActionFactory.refresh(Ids.ENDPOINT_REFRESH))
 
                 .itemsProvider((FinderContext context, AsyncCallback<List<DeploymentResource>> callback) -> {
+                    ResourceAddress baseAddress = AddressTemplate.of("{selected.host}/{selected.server}")
+                            .resolve(statementContext);
                     deploymentResources.readChildren(WEBSERVICES, ENDPOINT,
                             (address, modelNode) -> {
                                 String name = address.lastValue().replaceAll("%3A", ":");
-                                DeploymentResource deploymentResource = new DeploymentResource(name, address,
+                                ResourceAddress newAddress = baseAddress.isDefined() && !address.startsWith(baseAddress)
+                                        ? new ResourceAddress().add(baseAddress).add(address)
+                                        : address;
+                                DeploymentResource deploymentResource = new DeploymentResource(name, newAddress,
                                         modelNode);
                                 return deploymentResource;
 

--- a/app/src/main/java/org/jboss/hal/client/runtime/subsystem/webservice/EndpointPreview.java
+++ b/app/src/main/java/org/jboss/hal/client/runtime/subsystem/webservice/EndpointPreview.java
@@ -54,6 +54,7 @@ import static org.jboss.gwt.elemento.core.Elements.a;
 import static org.jboss.gwt.elemento.core.Elements.h;
 import static org.jboss.gwt.elemento.core.Elements.section;
 import static org.jboss.hal.client.runtime.subsystem.webservice.AddressTemplates.WEBSERVICES_CONFIGURATION_TEMPLATE;
+import static org.jboss.hal.client.runtime.subsystem.webservice.AddressTemplates.WEBSERVICES_RUNTIME_TEMPLATE;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.AVERAGE_PROCESSING_TIME;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.CHILD_TYPE;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.CLASS;
@@ -173,7 +174,7 @@ class EndpointPreview extends PreviewContent<DeploymentResource> {
                 .param(CHILD_TYPE, ENDPOINT)
                 .param(INCLUDE_RUNTIME, true)
                 .build();
-        ResourceAddress configurationAddress = WEBSERVICES_CONFIGURATION_TEMPLATE.resolve(statementContext);
+        ResourceAddress configurationAddress = WEBSERVICES_RUNTIME_TEMPLATE.resolve(statementContext);
         Operation opStatistics = new Operation.Builder(configurationAddress, READ_ATTRIBUTE_OPERATION)
                 .param(NAME, STATISTICS_ENABLED)
                 .param(RESOLVE_EXPRESSIONS, true)

--- a/dmr/src/main/java/org/jboss/hal/dmr/ResourceAddress.java
+++ b/dmr/src/main/java/org/jboss/hal/dmr/ResourceAddress.java
@@ -170,6 +170,24 @@ public class ResourceAddress extends ModelNode {
     }
 
     /**
+     * Checks if this resource address starts with the specified address.
+     *
+     * @param address The address to check as start
+     * @return true if this address starts with the passed one, false otherwise
+     */
+    public boolean startsWith(ResourceAddress address) {
+        if (this.size() < address.size()) {
+            return false;
+        }
+        for (int i = 0; i < address.size(); i++) {
+            if (!this.get(i).equals(address.get(i))) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
      * Replaces the value in the specified segment
      *
      * @param name     The name of the segment.

--- a/dmr/src/test/java/org/jboss/hal/dmr/ResourceAddressTest.java
+++ b/dmr/src/test/java/org/jboss/hal/dmr/ResourceAddressTest.java
@@ -50,6 +50,21 @@ public class ResourceAddressTest {
         assertArrayEquals(new String[]{"subsystem", "ee", "context-service", "default"}, segments(address));
     }
 
+    @Test
+    public void startsWith() {
+        ResourceAddress address = ResourceAddress.from("/host=primary/server=server1");
+        assertTrue(ResourceAddress.root().startsWith(ResourceAddress.root()));
+        assertTrue(ResourceAddress.from("/host=primary/server=server1").startsWith(ResourceAddress.root()));
+        assertTrue(ResourceAddress.from("/host=primary/server=server1").startsWith(address));
+        assertTrue(ResourceAddress.from("/host=primary/server=server1/").startsWith(address));
+        assertTrue(ResourceAddress.from("/host=primary/server=server1/subsystem=undertow").startsWith(address));
+        assertFalse(ResourceAddress.root().startsWith(address));
+        assertFalse(ResourceAddress.from("/host=primary").startsWith(address));
+        assertFalse(ResourceAddress.from("/host=primary/server=server2").startsWith(address));
+        assertFalse(ResourceAddress.from("/host=secondary/server=server1").startsWith(address));
+        assertFalse(ResourceAddress.from("/subsystem=undertow").startsWith(address));
+    }
+
     private String[] segments(ResourceAddress address) {
         List<String> segments = new ArrayList<>();
         for (Property property : address.asPropertyList()) {


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/HAL-1801

Doing the same that was done in other cases. I added a `startsWith` method to not add two times the `/host=*/server=*` in the DC host. Using `WEBSERVICES_RUNTIME_TEMPLATE` to check for statistics because it fails in domain mode (the resolve expressions can only be executed in runtime). A little test for `startsWith` was also added.

This PR is for branch 3.3.x.
PR for main: https://github.com/hal/console/pull/676