### PR TITLE
[HAL-1816] Hardcoded string "jdbc-compliant" could be replaced by ModelDescriptionConstants

### DIFF
--- a/app/src/main/java/org/jboss/hal/client/configuration/subsystem/datasource/JdbcDriverPreview.java
+++ b/app/src/main/java/org/jboss/hal/client/configuration/subsystem/datasource/JdbcDriverPreview.java
@@ -29,6 +29,7 @@ import static org.jboss.hal.dmr.ModelDescriptionConstants.DRIVER_CLASS_NAME;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.DRIVER_DATASOURCE_CLASS_NAME;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.DRIVER_VERSION;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.DRIVER_XA_DATASOURCE_CLASS_NAME;
+import static org.jboss.hal.dmr.ModelDescriptionConstants.JDBC_COMPLIANT;
 
 class JdbcDriverPreview extends PreviewContent<JdbcDriver> {
 
@@ -52,7 +53,7 @@ class JdbcDriverPreview extends PreviewContent<JdbcDriver> {
                 .append(DRIVER_DATASOURCE_CLASS_NAME)
                 .append(DRIVER_XA_DATASOURCE_CLASS_NAME)
                 .append(model -> new PreviewAttribute(labelBuilder.label(DRIVER_VERSION), model.getDriverVersion()))
-                .append("jdbc-compliant"); // NON-NLS
+                .append(JDBC_COMPLIANT); // NON-NLS
         previewBuilder().addAll(attributes);
     }
 }

--- a/dmr/src/main/java/org/jboss/hal/dmr/ModelDescriptionConstants.java
+++ b/dmr/src/main/java/org/jboss/hal/dmr/ModelDescriptionConstants.java
@@ -456,6 +456,7 @@ public interface ModelDescriptionConstants {
     String JAX_RS = "jaxrs";
     String JCA = "jca";
     String JDBC = "jdbc";
+    String JDBC_COMPLIANT = "jdbc-compliant";
     String JDBC_DRIVER = "jdbc-driver";
     String JDBC_REALM = "jdbc-realm";
     String JDR = "jdr";


### PR DESCRIPTION
https://issues.redhat.com/browse/HAL-1816