### PR TITLE
[JBEAP-24529][HAL-1839] Backport of Properties in the Resource Adapter(IBM MQ) are removed when updating the connection pool with Management Console

### DIFF
--- a/app/src/main/java/org/jboss/hal/client/configuration/subsystem/resourceadapter/ResourceAdapterView.java
+++ b/app/src/main/java/org/jboss/hal/client/configuration/subsystem/resourceadapter/ResourceAdapterView.java
@@ -155,8 +155,8 @@ public abstract class ResourceAdapterView extends MbuiViewImpl<ResourceAdapterPr
         ResourceAddress address = SELECTED_CONNECTION_DEFINITIONS_TEMPLATE.resolve(selectionAwareStatementContext,
                 name);
         Metadata metadata = mbuiContext.metadataRegistry().lookup(CONNECTION_DEFINITIONS_TEMPLATE);
-        Map<String, String> properties = form.getFormItem(CONFIG_PROPERTIES) != null
-                ? form.<Map<String, String>>getFormItem(CONFIG_PROPERTIES).getValue()
+        Map<String, String> properties = connectionDefinitionsForm.getFormItem(CONFIG_PROPERTIES) != null
+                ? connectionDefinitionsForm.<Map<String, String>>getFormItem(CONFIG_PROPERTIES).getValue()
                 : Collections.emptyMap();
         mbuiContext.po().saveWithProperties(Names.CONNECTION_DEFINITION, name, address, changedValues, metadata,
                 CONFIG_PROPERTIES, properties, () -> presenter.reload());


### PR DESCRIPTION
https://issues.redhat.com/browse/HAL-1839
https://issues.redhat.com/browse/JBEAP-24529

Upstream PR: https://github.com/hal/console/pull/804