### PR TITLE
HAL-1850: fix and update dataSource wizard

### DIFF
--- a/app/src/main/java/org/jboss/hal/client/configuration/subsystem/datasource/DataSourceTemplates.java
+++ b/app/src/main/java/org/jboss/hal/client/configuration/subsystem/datasource/DataSourceTemplates.java
@@ -63,7 +63,6 @@ public class DataSourceTemplates implements Iterable<DataSourceTemplate> {
 
         Supplier<JdbcDriver> h2Driver = () -> {
             JdbcDriver driver = new JdbcDriver(H2);
-            driver.get(DRIVER_MODULE_NAME).set("com.h2database.h2");
             driver.get(DRIVER_CLASS_NAME).set("org.h2.Driver");
             driver.get(DRIVER_XA_DATASOURCE_CLASS_NAME);
             return driver;
@@ -97,7 +96,6 @@ public class DataSourceTemplates implements Iterable<DataSourceTemplate> {
 
         Supplier<JdbcDriver> postgresDriver = () -> {
             JdbcDriver driver = new JdbcDriver(POSTGRESQL);
-            driver.get(DRIVER_MODULE_NAME).set("org.postgresql");
             driver.get(DRIVER_CLASS_NAME).set("org.postgresql.Driver");
             driver.get(DRIVER_XA_DATASOURCE_CLASS_NAME);
             return driver;
@@ -139,7 +137,6 @@ public class DataSourceTemplates implements Iterable<DataSourceTemplate> {
 
         Supplier<JdbcDriver> mySqlDriver = () -> {
             JdbcDriver driver = new JdbcDriver(MYSQL);
-            driver.get(DRIVER_MODULE_NAME).set("com.mysql");
             driver.get(DRIVER_CLASS_NAME).set("com.mysql.cj.jdbc.Driver");
             driver.get(DRIVER_XA_DATASOURCE_CLASS_NAME);
             return driver;
@@ -181,7 +178,6 @@ public class DataSourceTemplates implements Iterable<DataSourceTemplate> {
 
         Supplier<JdbcDriver> mariaDBDriver = () -> {
             JdbcDriver driver = new JdbcDriver(MARIADB);
-            driver.get(DRIVER_MODULE_NAME).set("org.mariadb");
             driver.get(DRIVER_CLASS_NAME).set("org.mariadb.jdbc.Driver");
             driver.get(DRIVER_XA_DATASOURCE_CLASS_NAME);
             return driver;
@@ -223,7 +219,6 @@ public class DataSourceTemplates implements Iterable<DataSourceTemplate> {
 
         Supplier<JdbcDriver> oracleDriver = () -> {
             JdbcDriver driver = new JdbcDriver(ORACLE);
-            driver.get(DRIVER_MODULE_NAME).set("com.oracle");
             driver.get(DRIVER_CLASS_NAME).set("oracle.jdbc.driver.OracleDriver");
             driver.get(DRIVER_XA_DATASOURCE_CLASS_NAME);
             return driver;
@@ -269,7 +264,6 @@ public class DataSourceTemplates implements Iterable<DataSourceTemplate> {
 
         Supplier<JdbcDriver> msSqlDriver = () -> {
             JdbcDriver driver = new JdbcDriver(SQLSERVER);
-            driver.get(DRIVER_MODULE_NAME).set("com.microsoft");
             driver.get(DRIVER_CLASS_NAME).set("com.microsoft.sqlserver.jdbc.SQLServerDriver");
             driver.get(DRIVER_XA_DATASOURCE_CLASS_NAME);
             return driver;
@@ -309,7 +303,6 @@ public class DataSourceTemplates implements Iterable<DataSourceTemplate> {
 
         Supplier<JdbcDriver> db2Driver = () -> {
             JdbcDriver driver = new JdbcDriver("ibmdb2");
-            driver.get(DRIVER_MODULE_NAME).set("com.ibm");
             driver.get(DRIVER_CLASS_NAME).set("com.ibm.db2.jcc.DB2Driver");
             driver.get(DRIVER_XA_DATASOURCE_CLASS_NAME);
             return driver;
@@ -358,7 +351,6 @@ public class DataSourceTemplates implements Iterable<DataSourceTemplate> {
 
         Supplier<JdbcDriver> sybaseDriver = () -> {
             JdbcDriver driver = new JdbcDriver(SYBASE);
-            driver.get(DRIVER_MODULE_NAME).set("com.sybase");
             driver.get(DRIVER_CLASS_NAME).set("com.sybase.jdbc.SybDriver");
             driver.get(DRIVER_XA_DATASOURCE_CLASS_NAME);
             return driver;

--- a/app/src/main/java/org/jboss/hal/client/configuration/subsystem/datasource/wizard/ConnectionStep.java
+++ b/app/src/main/java/org/jboss/hal/client/configuration/subsystem/datasource/wizard/ConnectionStep.java
@@ -19,7 +19,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.jboss.hal.ballroom.wizard.WizardStep;
-import org.jboss.hal.core.datasource.DataSource;
 import org.jboss.hal.core.elytron.CredentialReference;
 import org.jboss.hal.core.mbui.form.ModelNodeForm;
 import org.jboss.hal.dmr.ModelNode;
@@ -34,11 +33,11 @@ import elemental2.dom.HTMLElement;
 
 import static java.util.Arrays.asList;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.ALIAS;
+import static org.jboss.hal.dmr.ModelDescriptionConstants.AUTHENTICATION_CONTEXT;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.CLEAR_TEXT;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.CONNECTION_URL;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.CREDENTIAL_REFERENCE;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.PASSWORD;
-import static org.jboss.hal.dmr.ModelDescriptionConstants.SECURITY_DOMAIN;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.STORE;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.TYPE;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.USER_NAME;
@@ -46,30 +45,32 @@ import static org.jboss.hal.dmr.ModelNodeHelper.move;
 
 class ConnectionStep extends WizardStep<Context, State> {
 
-    private final ModelNodeForm<DataSource> form;
+    private final ModelNodeForm<ModelNode> form;
+
+    private List<String> credRefAttrs = asList(STORE, ALIAS, CLEAR_TEXT, TYPE);
+    private List<String> otherAttrs = asList(USER_NAME, PASSWORD, AUTHENTICATION_CONTEXT);
 
     @SuppressWarnings({ "unchecked", "rawtypes" })
     ConnectionStep(Metadata metadata, Resources resources, boolean xa) {
         super(Names.CONNECTION);
 
-        List<String> otherAttrs = new ArrayList<>();
-        if (!xa) {
-            otherAttrs.add(CONNECTION_URL);
-        }
-        otherAttrs.addAll(asList(USER_NAME, PASSWORD, SECURITY_DOMAIN));
-        List<String> credRefAttrs = asList(STORE, ALIAS, CLEAR_TEXT, TYPE);
-
         List<String> attributes = new ArrayList<>();
+        if (!xa) {
+            attributes.add(CONNECTION_URL);
+        }
         attributes.addAll(otherAttrs);
         attributes.addAll(credRefAttrs);
 
         // split credential reference into individual attributes
         Metadata connMetadata = metadata.forComplexAttribute(CREDENTIAL_REFERENCE, true);
+        if (!xa) {
+            metadata.copyAttribute(CONNECTION_URL, connMetadata);
+        }
         for (String attr : otherAttrs) {
             metadata.copyAttribute(attr, connMetadata);
         }
 
-        form = new ModelNodeForm.Builder<DataSource>(Ids.DATA_SOURCE_CONNECTION_FORM, connMetadata)
+        form = new ModelNodeForm.Builder<>(Ids.DATA_SOURCE_CONNECTION_FORM, connMetadata)
                 .include(attributes)
                 .unsorted()
                 .onSave((form, changedValues) -> {
@@ -79,11 +80,6 @@ class ConnectionStep extends WizardStep<Context, State> {
                             wizard().getContext().recordChange(k, v);
                         }
                     });
-                    // re-create credential reference
-                    for (String credRefAttr : credRefAttrs) {
-                        move(form.getModel(), credRefAttr, CREDENTIAL_REFERENCE + "/" + credRefAttr);
-                    }
-                    wizard().getContext().dataSource = form.getModel();
                 })
                 .build();
 
@@ -109,12 +105,50 @@ class ConnectionStep extends WizardStep<Context, State> {
 
     @Override
     protected void onShow(Context context) {
-        form.edit(context.dataSource);
+        ModelNode connection = new ModelNode();
+        if (context.dataSource.hasDefined(CONNECTION_URL)) {
+            copyAttr(CONNECTION_URL, context.dataSource, connection);
+        }
+        if (context.dataSource.hasDefined(CREDENTIAL_REFERENCE)) {
+            ModelNode credRef = context.dataSource.get(CREDENTIAL_REFERENCE);
+            for (String attr : credRefAttrs) {
+                copyAttr(attr, credRef, connection);
+            }
+        }
+        for (String attr : otherAttrs) {
+            if (context.dataSource.hasDefined(attr)) {
+                copyAttr(attr, context.dataSource, connection);
+            }
+        }
+
+        form.edit(connection);
     }
 
     @Override
     protected boolean onNext(Context context) {
-        return form.save();
+        boolean valid = form.save();
+        if (valid) {
+            ModelNode dataSource = form.getModel();
+            // re-create credential reference
+            for (String credRefAttr : credRefAttrs) {
+                move(dataSource, credRefAttr, CREDENTIAL_REFERENCE + "/" + credRefAttr);
+            }
+
+            if (dataSource.has(CONNECTION_URL)) {
+                copyAttr(CONNECTION_URL, dataSource, context.dataSource);
+            }
+
+            List<String> attrs = new ArrayList<>(otherAttrs);
+            attrs.add(CREDENTIAL_REFERENCE);
+
+            for (String attr : attrs) {
+                context.dataSource.remove(attr);
+                if (dataSource.hasDefined(attr)) {
+                    copyAttr(attr, dataSource, context.dataSource);
+                }
+            }
+        }
+        return valid;
     }
 
     @Override
@@ -127,5 +161,9 @@ class ConnectionStep extends WizardStep<Context, State> {
     protected boolean onCancel(Context context) {
         form.cancel();
         return true;
+    }
+
+    private void copyAttr(String name, ModelNode from, ModelNode to) {
+        to.get(name).set(from.get(name));
     }
 }

--- a/app/src/main/java/org/jboss/hal/client/configuration/subsystem/datasource/wizard/DataSourceWizard.java
+++ b/app/src/main/java/org/jboss/hal/client/configuration/subsystem/datasource/wizard/DataSourceWizard.java
@@ -59,8 +59,6 @@ import static org.jboss.hal.client.configuration.subsystem.datasource.wizard.Sta
 import static org.jboss.hal.client.configuration.subsystem.datasource.wizard.State.XA_PROPERTIES;
 import static org.jboss.hal.core.finder.FinderColumn.RefreshMode.RESTORE_SELECTION;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.ADD;
-import static org.jboss.hal.dmr.ModelDescriptionConstants.DATASOURCE_CLASS;
-import static org.jboss.hal.dmr.ModelDescriptionConstants.DRIVER_CLASS;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.NAME;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.REMOVE;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.VALUE;
@@ -76,11 +74,7 @@ public class DataSourceWizard {
 
         List<Operation> operations = new ArrayList<>();
         if (context.isXa()) {
-
-            // remove unsupported attributes
-            payload.remove(DRIVER_CLASS);
-            payload.remove(DATASOURCE_CLASS);
-            operations.add(new Operation.Builder(address, ADD).payload(context.dataSource).build());
+            operations.add(new Operation.Builder(address, ADD).payload(payload).build());
 
             // add an operation for each property
             context.xaProperties.forEach((key, value) -> {
@@ -89,7 +83,7 @@ public class DataSourceWizard {
                 operations.add(new Operation.Builder(propertyAddress, ADD).param(VALUE, value).build());
             });
         } else {
-            operations.add(new Operation.Builder(address, ADD).payload(context.dataSource).build());
+            operations.add(new Operation.Builder(address, ADD).payload(payload).build());
         }
         return new Composite(operations);
     }

--- a/app/src/main/java/org/jboss/hal/client/configuration/subsystem/datasource/wizard/DriverStep.java
+++ b/app/src/main/java/org/jboss/hal/client/configuration/subsystem/datasource/wizard/DriverStep.java
@@ -42,7 +42,6 @@ import static org.jboss.hal.dmr.ModelDescriptionConstants.ACCESS_TYPE;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.ATTRIBUTES;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.DRIVER_CLASS;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.DRIVER_CLASS_NAME;
-import static org.jboss.hal.dmr.ModelDescriptionConstants.DRIVER_MODULE_NAME;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.DRIVER_NAME;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.DRIVER_XA_DATASOURCE_CLASS_NAME;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.NILLABLE;
@@ -62,10 +61,9 @@ class DriverStep extends WizardStep<Context, State> {
         FormItem<String> driverNameItem = new TextBoxItem(DRIVER_NAME);
         driverNameItem.setRequired(true);
         this.form = new ModelNodeForm.Builder<JdbcDriver>(Ids.DATA_SOURCE_DRIVER_FORM, adjustMetadata(metadata))
-                .include(DRIVER_MODULE_NAME, xa ? DRIVER_XA_DATASOURCE_CLASS_NAME : DRIVER_CLASS_NAME)
+                .include(xa ? DRIVER_XA_DATASOURCE_CLASS_NAME : DRIVER_CLASS_NAME)
                 .unboundFormItem(driverNameItem, 0)
                 .unsorted()
-                .onSave((form, changedValues) -> wizard().getContext().driver = form.getModel())
                 .build();
 
         if (!driversByName.isEmpty()) {
@@ -144,6 +142,7 @@ class DriverStep extends WizardStep<Context, State> {
         boolean valid = form.save();
         if (valid) {
             JdbcDriver driver = form.getModel();
+            driver.get(DRIVER_NAME).set(form.getFormItem(DRIVER_NAME).getValue().toString());
             context.dataSource.setDriver(driver);
             if (context.isCreated()) {
                 context.recordChange(DRIVER_NAME, driver.getName());

--- a/app/src/main/java/org/jboss/hal/client/configuration/subsystem/datasource/wizard/PropertiesStep.java
+++ b/app/src/main/java/org/jboss/hal/client/configuration/subsystem/datasource/wizard/PropertiesStep.java
@@ -16,7 +16,9 @@
 package org.jboss.hal.client.configuration.subsystem.datasource.wizard;
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.function.Consumer;
 
 import javax.inject.Provider;
@@ -91,7 +93,8 @@ class PropertiesStep extends WizardStep<Context, State> {
 
     @Override
     protected void onShow(Context context) {
-        propertiesItem.setValue(context.xaProperties);
+        Map<String, String> xaProperties = new HashMap<>(context.xaProperties);
+        propertiesItem.setValue(xaProperties);
         propertiesItem.setUndefined(false);
         propertiesItem.setEnabled(!context.isCreated()); // can only be changed if DS was not already created
         String dsClassname = context.dataSource.hasDefined(XA_DATASOURCE_CLASS)


### PR DESCRIPTION
Issue: [HAL-1850](https://issues.redhat.com/browse/HAL-1850)

There were several instances where the datasource model would have undefined attributes added to it, by working on the model directly instead of a copy, I've eliminated those. Fixed DRIVER_NAME propagation and XA_DATASOURCE_PROPERTIES handling.

Other changes:
* Connection Step: SECURITY_DOMAIN has been deprecated a while ago so I removed it, added AUTHENTICATION_CONTEXT which is the Elytron-based alternative
* Driver Step: removed DRIVER_MODULE_NAME (also from templates), I don't know why this was here in the first place since the value wasn't being used and it's not even a valid dataSource attribute. If it's supposed to be info for the user I can add it back as a readonly field