### PR TITLE
HAL-1867: Security subsystem should be labeled also as Elytron

### DIFF
--- a/core/src/main/java/org/jboss/hal/core/subsystem/Subsystems.java
+++ b/core/src/main/java/org/jboss/hal/core/subsystem/Subsystems.java
@@ -75,6 +75,7 @@ public class Subsystems {
                 .preview(resources.previews().configurationEjb3())
                 .build());
         addConfiguration(new SubsystemMetadata.Builder(ELYTRON, Names.SECURITY)
+                .subtitle(Names.ELYTRON)
                 .nextColumn(Ids.ELYTRON)
                 .preview(resources.previews().configurationSecurityElytron())
                 .build());


### PR DESCRIPTION
https://issues.redhat.com/browse/HAL-1867