### PR TITLE
HAL-1872: fix id generation in Model Browser

### DIFF
--- a/core/src/main/java/org/jboss/hal/core/modelbrowser/ReadChildren.java
+++ b/core/src/main/java/org/jboss/hal/core/modelbrowser/ReadChildren.java
@@ -53,13 +53,9 @@ final class ReadChildren implements DataFunction<Context> {
 
     static String uniqueId(Node<Context> parent, String name) {
         String parentId = parent.id;
-        int index = parent.id.indexOf(ID_SEPARATOR);
-        if (index != -1) {
-            if (parent.data.isFullyQualified()) {
-                parentId = parent.id.substring(index + ID_SEPARATOR.length(), parent.id.length());
-            } else {
-                parentId = parent.id.substring(0, index);
-            }
+        int index = parent.id.lastIndexOf(ID_SEPARATOR);
+        if (index != -1 && parent.data.isFullyQualified()) {
+            parentId = parent.id.substring(index + ID_SEPARATOR.length());
         }
         return parentId + ID_SEPARATOR + name;
     }


### PR DESCRIPTION
Issue: [HAL-1872](https://issues.redhat.com/browse/HAL-1872)

Changed the ids in the tree panel to follow this pattern
```
ROOT            ROOT
 * TYPE         ROOT___TYPE
   * NAME       ROOT___TYPE___NAME   (previously just ROOT___NAME)
```
currently if TYPE and NAME are the same word the tree widget stops working.