### PR TITLE
[HAL-1875] Upgrade pouchdb to 8.0.1

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -29,7 +29,7 @@
     "moment-timezone": "^0.4.1",
     "patternfly": "^3.59.2",
     "patternfly-bootstrap-combobox": "^1.1.7",
-    "pouchdb": "^7.1.1",
+    "pouchdb": "^8.0.1",
     "promise-polyfill": "^8.1.3",
     "whatwg-fetch": "^3.0.0"
   },


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/HAL-1875

`main` branch has upgraded pouchdb to 8.0.1.