### PR TITLE
HAL-1877 Add error callback parameter to CrudOperations.save()

### DIFF
--- a/core/src/main/java/org/jboss/hal/core/mbui/MbuiViewImpl.java
+++ b/core/src/main/java/org/jboss/hal/core/mbui/MbuiViewImpl.java
@@ -51,12 +51,14 @@ public abstract class MbuiViewImpl<P extends MbuiPresenter> extends HalViewImpl 
 
     protected void saveForm(final String type, final String name, final ResourceAddress address,
             final Map<String, Object> changedValues, final Metadata metadata) {
-        mbuiContext.crud().save(type, name, address, changedValues, metadata, () -> presenter.reload());
+        mbuiContext.crud().save(type, name, address, changedValues, metadata, () -> presenter.reload(),
+                () -> presenter.reload());
     }
 
     protected void saveSingletonForm(final String type, final ResourceAddress address,
             final Map<String, Object> changedValues, final Metadata metadata) {
-        mbuiContext.crud().saveSingleton(type, address, changedValues, metadata, () -> presenter.reload());
+        mbuiContext.crud().saveSingleton(type, address, changedValues, metadata, () -> presenter.reload(),
+                () -> presenter.reload());
     }
 
     protected <T> void resetForm(final String type, final String name, final ResourceAddress address,

--- a/dmr/src/main/java/org/jboss/hal/dmr/dispatch/Dispatcher.java
+++ b/dmr/src/main/java/org/jboss/hal/dmr/dispatch/Dispatcher.java
@@ -132,6 +132,10 @@ public class Dispatcher implements RecordingHandler {
         };
     }
 
+    public ErrorCallback getDefaultErrorCallback() {
+        return this.errorCallback;
+    }
+
     // ------------------------------------------------------ execute composite
 
     public void execute(Composite operations, Consumer<CompositeResult> success) {


### PR DESCRIPTION
Upstream Issue: https://issues.redhat.com/browse/HAL-1877
Issue: https://issues.redhat.com/browse/JBEAP-25201

Introduces another callback to CrudOperations.save*() methods. The original callback is used when operation succeeds (as was described in Javadocs), and the new callback is triggered on failure. The new error callback is used to call `presenter.reload()`.


MbuiViewImpl.java:
```
    protected void saveForm(final String type, final String name, final ResourceAddress address,
            final Map<String, Object> changedValues, final Metadata metadata) {
        mbuiContext.crud().save(type, name, address, changedValues, metadata, () -> presenter.reload() /* original, on success callback */,
                () -> presenter.reload() /* new, on error callback */);
    }
```
