### PR TITLE
HAL-1885: handle duplicate server names in expression resolution

### DIFF
--- a/core/src/main/java/org/jboss/hal/core/expression/ExpressionResolver.java
+++ b/core/src/main/java/org/jboss/hal/core/expression/ExpressionResolver.java
@@ -102,7 +102,8 @@ public class ExpressionResolver implements ResolveExpressionEvent.ResolveExpress
                 for (Property host : hosts) {
                     List<Property> servers = host.getValue().asPropertyList();
                     for (Property server : servers) {
-                        values.put(server.getName(),
+                        // server names don't have to be unique across hosts
+                        values.put(host.getName() + "/" + server.getName(),
                                 server.getValue().get(RESPONSE).get(RESULT).asString());
                     }
                 }


### PR DESCRIPTION
Issue: [HAL-1885](https://issues.redhat.com/browse/HAL-1885)

It's possible to have the same server name among multiple hosts providing the hosts are launched from separate installations (i.e. it doesn't work from a single folder)