### PR TITLE
HAL-1947: fix timer-service attributes handling

### DIFF
--- a/app/src/main/resources/org/jboss/hal/client/configuration/subsystem/ejb/EjbView.mbui.xml
+++ b/app/src/main/resources/org/jboss/hal/client/configuration/subsystem/ejb/EjbView.mbui.xml
@@ -212,27 +212,7 @@
                 <metadata address="/{selected.profile}/subsystem=ejb3/service=timer-service">
                     <h1>Timer</h1>
                     <p>${metadata.getDescription().getDescription()}</p>
-                    <form id="ejb3-service-timer-form" title="Timer" auto-save="true" reset="true">
-                        <attributes>
-                            <attribute name="default-data-store">
-                                <suggest-handler>
-                                    <templates>
-                                        <!-- @formatter:off -->
-                                        <template address="/{selected.profile}/subsystem=ejb3/service=timer-service/database-data-store=*"/>
-                                        <template address="/{selected.profile}/subsystem=ejb3/service=timer-service/file-data-store=*"/>
-                                        <!-- @formatter:on -->
-                                    </templates>
-                                </suggest-handler>
-                            </attribute>
-                            <attribute name="thread-pool-name">
-                                <suggest-handler>
-                                    <templates>
-                                        <template address="/{selected.profile}/subsystem=ejb3/thread-pool=*"/>
-                                    </templates>
-                                </suggest-handler>
-                            </attribute>
-                        </attributes>
-                    </form>
+                    <form id="ejb3-service-timer-form" title="Timer" auto-save="true" reset="true" />
                 </metadata>
             </sub-item>
         </item>


### PR DESCRIPTION
The timer service has 4 attributes currently but they are all tied to capability references so we don't have configure custom handlers.