### PR TITLE
[HAL-1906] allow path serparator to be part of KVP

### DIFF
--- a/meta/src/main/java/org/jboss/hal/meta/AddressTemplate.java
+++ b/meta/src/main/java/org/jboss/hal/meta/AddressTemplate.java
@@ -531,46 +531,45 @@ public final class AddressTemplate implements Iterable<String> {
 
         private static final String DELIMITER = "/";
 
-        private final String s;
-        private final int len;
-
         private int pos;
-        private String next;
+        private final LinkedList<String> tokens;
 
         StringTokenizer(String s) {
-            this.s = s;
-            this.len = s.length();
+            this.tokens = tokenize(s);
+        }
+
+        private LinkedList<String> tokenize(String s) {
+            int pos = 0;
+            final int len = s.length();
+            while (pos < len && StringTokenizer.DELIMITER.indexOf(s.charAt(pos)) != -1) {
+                pos++;
+            }
+            final String forTokenization = (pos == 0) ? s : s.substring(pos);
+            final LinkedList<String> ephemeralTokens = new LinkedList<String>();
+            final String[] rawTokens = forTokenization.split(StringTokenizer.DELIMITER);
+            for (int i = 0; i < rawTokens.length; i++) {
+                final String rawToken = rawTokens[i];
+                if (rawToken.contains("=") || rawToken.startsWith("{")) {
+                    ephemeralTokens.add(rawToken);
+                } else {
+                    // HAL-1906
+                    ephemeralTokens.set(ephemeralTokens.size() - 1,
+                            ephemeralTokens.getLast() + StringTokenizer.DELIMITER + rawToken);
+                }
+            }
+            return ephemeralTokens;
         }
 
         String nextToken() {
             if (!hasMoreTokens()) {
                 throw new NoSuchElementException();
             }
-            String result = next;
-            next = null;
+            final String result = this.tokens.get(pos++);
             return result;
         }
 
         boolean hasMoreTokens() {
-            if (next != null) {
-                return true;
-            }
-            // skip leading delimiters
-            while (pos < len && DELIMITER.indexOf(s.charAt(pos)) != -1) {
-                pos++;
-            }
-
-            if (pos >= len) {
-                return false;
-            }
-
-            int p0 = pos++;
-            while (pos < len && DELIMITER.indexOf(s.charAt(pos)) == -1) {
-                pos++;
-            }
-
-            next = s.substring(p0, pos++);
-            return true;
+            return pos < this.tokens.size();
         }
     }
 

--- a/meta/src/test/java/org/jboss/hal/meta/processing/LookupResultTest.java
+++ b/meta/src/test/java/org/jboss/hal/meta/processing/LookupResultTest.java
@@ -36,7 +36,7 @@ public class LookupResultTest {
 
     @Before
     public void setUp() {
-        template = AddressTemplate.of("template");
+        template = AddressTemplate.of("template=test");
         lookupResult = new LookupResult(Sets.<AddressTemplate> newHashSet(template));
     }
 
@@ -48,7 +48,7 @@ public class LookupResultTest {
 
     @Test(expected = MissingMetadataException.class)
     public void missingMetadata() {
-        lookupResult.missingMetadata(AddressTemplate.of("foo"));
+        lookupResult.missingMetadata(AddressTemplate.of("{foo}"));
     }
 
     @Test
@@ -73,18 +73,18 @@ public class LookupResultTest {
     @Test
     public void allPresent() {
         LookupResult localLookupResult = new LookupResult(Sets.newHashSet(
-                AddressTemplate.of("one"),
-                AddressTemplate.of("two"),
-                AddressTemplate.of("three")));
+                AddressTemplate.of("{one}"),
+                AddressTemplate.of("{two}"),
+                AddressTemplate.of("{three}")));
 
-        localLookupResult.markMetadataPresent(AddressTemplate.of("one"), ALL_PRESENT);
-        localLookupResult.markMetadataPresent(AddressTemplate.of("two"), RESOURCE_DESCRIPTION_PRESENT);
-        localLookupResult.markMetadataPresent(AddressTemplate.of("three"), SECURITY_CONTEXT_PRESENT);
+        localLookupResult.markMetadataPresent(AddressTemplate.of("{one}"), ALL_PRESENT);
+        localLookupResult.markMetadataPresent(AddressTemplate.of("{two}"), RESOURCE_DESCRIPTION_PRESENT);
+        localLookupResult.markMetadataPresent(AddressTemplate.of("{three}"), SECURITY_CONTEXT_PRESENT);
         assertFalse(localLookupResult.allPresent());
 
-        localLookupResult.markMetadataPresent(AddressTemplate.of("one"), ALL_PRESENT);
-        localLookupResult.markMetadataPresent(AddressTemplate.of("two"), ALL_PRESENT);
-        localLookupResult.markMetadataPresent(AddressTemplate.of("three"), ALL_PRESENT);
+        localLookupResult.markMetadataPresent(AddressTemplate.of("{one}"), ALL_PRESENT);
+        localLookupResult.markMetadataPresent(AddressTemplate.of("{two}"), ALL_PRESENT);
+        localLookupResult.markMetadataPresent(AddressTemplate.of("{three}"), ALL_PRESENT);
         assertTrue(localLookupResult.allPresent());
     }
 }

--- a/meta/src/test/java/org/jboss/hal/meta/security/ConstraintTest.java
+++ b/meta/src/test/java/org/jboss/hal/meta/security/ConstraintTest.java
@@ -23,11 +23,11 @@ import static org.junit.Assert.assertEquals;
 
 public class ConstraintTest {
 
-    private static final AddressTemplate TEMPLATE = AddressTemplate.of("j/l/p");
+    private static final AddressTemplate TEMPLATE = AddressTemplate.of("j=o/l=o/p=o");
     private static final String OPERATION = "engage";
     private static final String ATTRIBUTE = "NCC-1701-D";
-    private static final String ENGAGE_DATA = "executable(j/l/p:engage)";
-    private static final String NCC_DATA = "writable(j/l/p@NCC-1701-D)";
+    private static final String ENGAGE_DATA = "executable(j=o/l=o/p=o:engage)";
+    private static final String NCC_DATA = "writable(j=o/l=o/p=o@NCC-1701-D)";
 
     private Constraint ex, wr;
 

--- a/meta/src/test/java/org/jboss/hal/meta/security/ConstraintsTest.java
+++ b/meta/src/test/java/org/jboss/hal/meta/security/ConstraintsTest.java
@@ -26,10 +26,10 @@ import static org.junit.Assert.assertTrue;
 
 public class ConstraintsTest {
 
-    private static final Constraint ENGAGE = Constraint.executable(AddressTemplate.of("j/l/p"), "engage");
-    private static final Constraint NCC = Constraint.writable(AddressTemplate.of("da/ta"), "NCC-1701-D");
-    private static final String ENGAGE_DATA = "executable(j/l/p:engage)";
-    private static final String NCC_DATA = "writable(da/ta@NCC-1701-D)";
+    private static final Constraint ENGAGE = Constraint.executable(AddressTemplate.of("j=o/l=k/p=z"), "engage");
+    private static final Constraint NCC = Constraint.writable(AddressTemplate.of("da=ta/ta=da"), "NCC-1701-D");
+    private static final String ENGAGE_DATA = "executable(j=o/l=k/p=z:engage)";
+    private static final String NCC_DATA = "writable(da=ta/ta=da@NCC-1701-D)";
     private static final String AND_DATA = ENGAGE_DATA + "&" + NCC_DATA;
     private static final String OR_DATA = ENGAGE_DATA + "|" + NCC_DATA;
 


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/HAL-1906

Just for review now. This will likely either need update in PathTemplate JDOC contract or just wont make it.
EDIT: to be precise, it allows delimiter to be part of V.