### PR TITLE
HAL-1972 Upgrade parcel version from 2.11.0 to 2.12.0

### DIFF
--- a/app/local_modules/parcel-resolver-theme/package.json
+++ b/app/local_modules/parcel-resolver-theme/package.json
@@ -7,7 +7,7 @@
     "parcel": ">=2.0.0"
   },
   "devDependencies": {
-    "@parcel/diagnostic": "^2.11.0",
+    "@parcel/diagnostic": "^2.12.0",
     "@parcel/plugin": "^2.12.0",
     "parcel": "^2.12.0"
   }

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -29,11 +29,11 @@
         "pouchdb-browser": "^8.0.1"
       },
       "devDependencies": {
-        "@parcel/plugin": "^2.11.0",
+        "@parcel/plugin": "^2.12.0",
         "@parcel/reporter-cli": "^2.12.0",
         "@parcel/transformer-less": "^2.12.0",
         "copyfiles": "^2.4.1",
-        "parcel": "^2.11.0",
+        "parcel": "^2.12.0",
         "parcel-resolver-ignore": "^2.2.0",
         "parcel-resolver-theme": "file:local_modules/parcel-resolver-theme",
         "process": "^0.11.10"
@@ -42,7 +42,7 @@
     "local_modules/parcel-resolver-theme": {
       "dev": true,
       "devDependencies": {
-        "@parcel/diagnostic": "^2.11.0",
+        "@parcel/diagnostic": "^2.12.0",
         "@parcel/plugin": "^2.12.0",
         "parcel": "^2.12.0"
       },
@@ -50,1255 +50,17 @@
         "parcel": ">=2.0.0"
       }
     },
-    "local_modules/parcel-resolver-theme/node_modules/@parcel/bundler-default": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/bundler-default/-/bundler-default-2.12.0.tgz",
-      "integrity": "sha512-3ybN74oYNMKyjD6V20c9Gerdbh7teeNvVMwIoHIQMzuIFT6IGX53PyOLlOKRLbjxMc0TMimQQxIt2eQqxR5LsA==",
-      "dev": true,
-      "dependencies": {
-        "@parcel/diagnostic": "2.12.0",
-        "@parcel/graph": "3.2.0",
-        "@parcel/plugin": "2.12.0",
-        "@parcel/rust": "2.12.0",
-        "@parcel/utils": "2.12.0",
-        "nullthrows": "^1.1.1"
-      },
-      "engines": {
-        "node": ">= 12.0.0",
-        "parcel": "^2.12.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "local_modules/parcel-resolver-theme/node_modules/@parcel/cache": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/cache/-/cache-2.12.0.tgz",
-      "integrity": "sha512-FX5ZpTEkxvq/yvWklRHDESVRz+c7sLTXgFuzz6uEnBcXV38j6dMSikflNpHA6q/L4GKkCqRywm9R6XQwhwIMyw==",
-      "dev": true,
-      "dependencies": {
-        "@parcel/fs": "2.12.0",
-        "@parcel/logger": "2.12.0",
-        "@parcel/utils": "2.12.0",
-        "lmdb": "2.8.5"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      },
-      "peerDependencies": {
-        "@parcel/core": "^2.12.0"
-      }
-    },
-    "local_modules/parcel-resolver-theme/node_modules/@parcel/codeframe": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/codeframe/-/codeframe-2.12.0.tgz",
-      "integrity": "sha512-v2VmneILFiHZJTxPiR7GEF1wey1/IXPdZMcUlNXBiPZyWDfcuNgGGVQkx/xW561rULLIvDPharOMdxz5oHOKQg==",
-      "dev": true,
-      "dependencies": {
-        "chalk": "^4.1.0"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "local_modules/parcel-resolver-theme/node_modules/@parcel/compressor-raw": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/compressor-raw/-/compressor-raw-2.12.0.tgz",
-      "integrity": "sha512-h41Q3X7ZAQ9wbQ2csP8QGrwepasLZdXiuEdpUryDce6rF9ZiHoJ97MRpdLxOhOPyASTw/xDgE1xyaPQr0Q3f5A==",
-      "dev": true,
-      "dependencies": {
-        "@parcel/plugin": "2.12.0"
-      },
-      "engines": {
-        "node": ">= 12.0.0",
-        "parcel": "^2.12.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "local_modules/parcel-resolver-theme/node_modules/@parcel/config-default": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/config-default/-/config-default-2.12.0.tgz",
-      "integrity": "sha512-dPNe2n9eEsKRc1soWIY0yToMUPirPIa2QhxcCB3Z5RjpDGIXm0pds+BaiqY6uGLEEzsjhRO0ujd4v2Rmm0vuFg==",
-      "dev": true,
-      "dependencies": {
-        "@parcel/bundler-default": "2.12.0",
-        "@parcel/compressor-raw": "2.12.0",
-        "@parcel/namer-default": "2.12.0",
-        "@parcel/optimizer-css": "2.12.0",
-        "@parcel/optimizer-htmlnano": "2.12.0",
-        "@parcel/optimizer-image": "2.12.0",
-        "@parcel/optimizer-svgo": "2.12.0",
-        "@parcel/optimizer-swc": "2.12.0",
-        "@parcel/packager-css": "2.12.0",
-        "@parcel/packager-html": "2.12.0",
-        "@parcel/packager-js": "2.12.0",
-        "@parcel/packager-raw": "2.12.0",
-        "@parcel/packager-svg": "2.12.0",
-        "@parcel/packager-wasm": "2.12.0",
-        "@parcel/reporter-dev-server": "2.12.0",
-        "@parcel/resolver-default": "2.12.0",
-        "@parcel/runtime-browser-hmr": "2.12.0",
-        "@parcel/runtime-js": "2.12.0",
-        "@parcel/runtime-react-refresh": "2.12.0",
-        "@parcel/runtime-service-worker": "2.12.0",
-        "@parcel/transformer-babel": "2.12.0",
-        "@parcel/transformer-css": "2.12.0",
-        "@parcel/transformer-html": "2.12.0",
-        "@parcel/transformer-image": "2.12.0",
-        "@parcel/transformer-js": "2.12.0",
-        "@parcel/transformer-json": "2.12.0",
-        "@parcel/transformer-postcss": "2.12.0",
-        "@parcel/transformer-posthtml": "2.12.0",
-        "@parcel/transformer-raw": "2.12.0",
-        "@parcel/transformer-react-refresh-wrap": "2.12.0",
-        "@parcel/transformer-svg": "2.12.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      },
-      "peerDependencies": {
-        "@parcel/core": "^2.12.0"
-      }
-    },
-    "local_modules/parcel-resolver-theme/node_modules/@parcel/core": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/core/-/core-2.12.0.tgz",
-      "integrity": "sha512-s+6pwEj+GfKf7vqGUzN9iSEPueUssCCQrCBUlcAfKrJe0a22hTUCjewpB0I7lNrCIULt8dkndD+sMdOrXsRl6Q==",
-      "dev": true,
-      "dependencies": {
-        "@mischnic/json-sourcemap": "^0.1.0",
-        "@parcel/cache": "2.12.0",
-        "@parcel/diagnostic": "2.12.0",
-        "@parcel/events": "2.12.0",
-        "@parcel/fs": "2.12.0",
-        "@parcel/graph": "3.2.0",
-        "@parcel/logger": "2.12.0",
-        "@parcel/package-manager": "2.12.0",
-        "@parcel/plugin": "2.12.0",
-        "@parcel/profiler": "2.12.0",
-        "@parcel/rust": "2.12.0",
-        "@parcel/source-map": "^2.1.1",
-        "@parcel/types": "2.12.0",
-        "@parcel/utils": "2.12.0",
-        "@parcel/workers": "2.12.0",
-        "abortcontroller-polyfill": "^1.1.9",
-        "base-x": "^3.0.8",
-        "browserslist": "^4.6.6",
-        "clone": "^2.1.1",
-        "dotenv": "^7.0.0",
-        "dotenv-expand": "^5.1.0",
-        "json5": "^2.2.0",
-        "msgpackr": "^1.9.9",
-        "nullthrows": "^1.1.1",
-        "semver": "^7.5.2"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "local_modules/parcel-resolver-theme/node_modules/@parcel/diagnostic": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/diagnostic/-/diagnostic-2.12.0.tgz",
-      "integrity": "sha512-8f1NOsSFK+F4AwFCKynyIu9Kr/uWHC+SywAv4oS6Bv3Acig0gtwUjugk0C9UaB8ztBZiW5TQZhw+uPZn9T/lJA==",
-      "dev": true,
-      "dependencies": {
-        "@mischnic/json-sourcemap": "^0.1.0",
-        "nullthrows": "^1.1.1"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "local_modules/parcel-resolver-theme/node_modules/@parcel/events": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/events/-/events-2.12.0.tgz",
-      "integrity": "sha512-nmAAEIKLjW1kB2cUbCYSmZOGbnGj8wCzhqnK727zCCWaA25ogzAtt657GPOeFyqW77KyosU728Tl63Fc8hphIA==",
-      "dev": true,
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "local_modules/parcel-resolver-theme/node_modules/@parcel/fs": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/fs/-/fs-2.12.0.tgz",
-      "integrity": "sha512-NnFkuvou1YBtPOhTdZr44WN7I60cGyly2wpHzqRl62yhObyi1KvW0SjwOMa0QGNcBOIzp4G0CapoZ93hD0RG5Q==",
-      "dev": true,
-      "dependencies": {
-        "@parcel/rust": "2.12.0",
-        "@parcel/types": "2.12.0",
-        "@parcel/utils": "2.12.0",
-        "@parcel/watcher": "^2.0.7",
-        "@parcel/workers": "2.12.0"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      },
-      "peerDependencies": {
-        "@parcel/core": "^2.12.0"
-      }
-    },
-    "local_modules/parcel-resolver-theme/node_modules/@parcel/graph": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@parcel/graph/-/graph-3.2.0.tgz",
-      "integrity": "sha512-xlrmCPqy58D4Fg5umV7bpwDx5Vyt7MlnQPxW68vae5+BA4GSWetfZt+Cs5dtotMG2oCHzZxhIPt7YZ7NRyQzLA==",
-      "dev": true,
-      "dependencies": {
-        "nullthrows": "^1.1.1"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "local_modules/parcel-resolver-theme/node_modules/@parcel/logger": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.12.0.tgz",
-      "integrity": "sha512-cJ7Paqa7/9VJ7C+KwgJlwMqTQBOjjn71FbKk0G07hydUEBISU2aDfmc/52o60ErL9l+vXB26zTrIBanbxS8rVg==",
-      "dev": true,
-      "dependencies": {
-        "@parcel/diagnostic": "2.12.0",
-        "@parcel/events": "2.12.0"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "local_modules/parcel-resolver-theme/node_modules/@parcel/markdown-ansi": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/markdown-ansi/-/markdown-ansi-2.12.0.tgz",
-      "integrity": "sha512-WZz3rzL8k0H3WR4qTHX6Ic8DlEs17keO9gtD4MNGyMNQbqQEvQ61lWJaIH0nAtgEetu0SOITiVqdZrb8zx/M7w==",
-      "dev": true,
-      "dependencies": {
-        "chalk": "^4.1.0"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "local_modules/parcel-resolver-theme/node_modules/@parcel/namer-default": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/namer-default/-/namer-default-2.12.0.tgz",
-      "integrity": "sha512-9DNKPDHWgMnMtqqZIMiEj/R9PNWW16lpnlHjwK3ciRlMPgjPJ8+UNc255teZODhX0T17GOzPdGbU/O/xbxVPzA==",
-      "dev": true,
-      "dependencies": {
-        "@parcel/diagnostic": "2.12.0",
-        "@parcel/plugin": "2.12.0",
-        "nullthrows": "^1.1.1"
-      },
-      "engines": {
-        "node": ">= 12.0.0",
-        "parcel": "^2.12.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "local_modules/parcel-resolver-theme/node_modules/@parcel/node-resolver-core": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@parcel/node-resolver-core/-/node-resolver-core-3.3.0.tgz",
-      "integrity": "sha512-rhPW9DYPEIqQBSlYzz3S0AjXxjN6Ub2yS6tzzsW/4S3Gpsgk/uEq4ZfxPvoPf/6TgZndVxmKwpmxaKtGMmf3cA==",
-      "dev": true,
-      "dependencies": {
-        "@mischnic/json-sourcemap": "^0.1.0",
-        "@parcel/diagnostic": "2.12.0",
-        "@parcel/fs": "2.12.0",
-        "@parcel/rust": "2.12.0",
-        "@parcel/utils": "2.12.0",
-        "nullthrows": "^1.1.1",
-        "semver": "^7.5.2"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "local_modules/parcel-resolver-theme/node_modules/@parcel/optimizer-css": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/optimizer-css/-/optimizer-css-2.12.0.tgz",
-      "integrity": "sha512-ifbcC97fRzpruTjaa8axIFeX4MjjSIlQfem3EJug3L2AVqQUXnM1XO8L0NaXGNLTW2qnh1ZjIJ7vXT/QhsphsA==",
-      "dev": true,
-      "dependencies": {
-        "@parcel/diagnostic": "2.12.0",
-        "@parcel/plugin": "2.12.0",
-        "@parcel/source-map": "^2.1.1",
-        "@parcel/utils": "2.12.0",
-        "browserslist": "^4.6.6",
-        "lightningcss": "^1.22.1",
-        "nullthrows": "^1.1.1"
-      },
-      "engines": {
-        "node": ">= 12.0.0",
-        "parcel": "^2.12.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "local_modules/parcel-resolver-theme/node_modules/@parcel/optimizer-htmlnano": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/optimizer-htmlnano/-/optimizer-htmlnano-2.12.0.tgz",
-      "integrity": "sha512-MfPMeCrT8FYiOrpFHVR+NcZQlXAptK2r4nGJjfT+ndPBhEEZp4yyL7n1y7HfX9geg5altc4WTb4Gug7rCoW8VQ==",
-      "dev": true,
-      "dependencies": {
-        "@parcel/plugin": "2.12.0",
-        "htmlnano": "^2.0.0",
-        "nullthrows": "^1.1.1",
-        "posthtml": "^0.16.5",
-        "svgo": "^2.4.0"
-      },
-      "engines": {
-        "node": ">= 12.0.0",
-        "parcel": "^2.12.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "local_modules/parcel-resolver-theme/node_modules/@parcel/optimizer-image": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/optimizer-image/-/optimizer-image-2.12.0.tgz",
-      "integrity": "sha512-bo1O7raeAIbRU5nmNVtx8divLW9Xqn0c57GVNGeAK4mygnQoqHqRZ0mR9uboh64pxv6ijXZHPhKvU9HEpjPjBQ==",
-      "dev": true,
-      "dependencies": {
-        "@parcel/diagnostic": "2.12.0",
-        "@parcel/plugin": "2.12.0",
-        "@parcel/rust": "2.12.0",
-        "@parcel/utils": "2.12.0",
-        "@parcel/workers": "2.12.0"
-      },
-      "engines": {
-        "node": ">= 12.0.0",
-        "parcel": "^2.12.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      },
-      "peerDependencies": {
-        "@parcel/core": "^2.12.0"
-      }
-    },
-    "local_modules/parcel-resolver-theme/node_modules/@parcel/optimizer-svgo": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/optimizer-svgo/-/optimizer-svgo-2.12.0.tgz",
-      "integrity": "sha512-Kyli+ZZXnoonnbeRQdoWwee9Bk2jm/49xvnfb+2OO8NN0d41lblBoRhOyFiScRnJrw7eVl1Xrz7NTkXCIO7XFQ==",
-      "dev": true,
-      "dependencies": {
-        "@parcel/diagnostic": "2.12.0",
-        "@parcel/plugin": "2.12.0",
-        "@parcel/utils": "2.12.0",
-        "svgo": "^2.4.0"
-      },
-      "engines": {
-        "node": ">= 12.0.0",
-        "parcel": "^2.12.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "local_modules/parcel-resolver-theme/node_modules/@parcel/optimizer-swc": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/optimizer-swc/-/optimizer-swc-2.12.0.tgz",
-      "integrity": "sha512-iBi6LZB3lm6WmbXfzi8J3DCVPmn4FN2lw7DGXxUXu7MouDPVWfTsM6U/5TkSHJRNRogZ2gqy5q9g34NPxHbJcw==",
-      "dev": true,
-      "dependencies": {
-        "@parcel/diagnostic": "2.12.0",
-        "@parcel/plugin": "2.12.0",
-        "@parcel/source-map": "^2.1.1",
-        "@parcel/utils": "2.12.0",
-        "@swc/core": "^1.3.36",
-        "nullthrows": "^1.1.1"
-      },
-      "engines": {
-        "node": ">= 12.0.0",
-        "parcel": "^2.12.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "local_modules/parcel-resolver-theme/node_modules/@parcel/package-manager": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/package-manager/-/package-manager-2.12.0.tgz",
-      "integrity": "sha512-0nvAezcjPx9FT+hIL+LS1jb0aohwLZXct7jAh7i0MLMtehOi0z1Sau+QpgMlA9rfEZZ1LIeFdnZZwqSy7Ccspw==",
-      "dev": true,
-      "dependencies": {
-        "@parcel/diagnostic": "2.12.0",
-        "@parcel/fs": "2.12.0",
-        "@parcel/logger": "2.12.0",
-        "@parcel/node-resolver-core": "3.3.0",
-        "@parcel/types": "2.12.0",
-        "@parcel/utils": "2.12.0",
-        "@parcel/workers": "2.12.0",
-        "@swc/core": "^1.3.36",
-        "semver": "^7.5.2"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      },
-      "peerDependencies": {
-        "@parcel/core": "^2.12.0"
-      }
-    },
-    "local_modules/parcel-resolver-theme/node_modules/@parcel/packager-css": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/packager-css/-/packager-css-2.12.0.tgz",
-      "integrity": "sha512-j3a/ODciaNKD19IYdWJT+TP+tnhhn5koBGBWWtrKSu0UxWpnezIGZetit3eE+Y9+NTePalMkvpIlit2eDhvfJA==",
-      "dev": true,
-      "dependencies": {
-        "@parcel/diagnostic": "2.12.0",
-        "@parcel/plugin": "2.12.0",
-        "@parcel/source-map": "^2.1.1",
-        "@parcel/utils": "2.12.0",
-        "lightningcss": "^1.22.1",
-        "nullthrows": "^1.1.1"
-      },
-      "engines": {
-        "node": ">= 12.0.0",
-        "parcel": "^2.12.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "local_modules/parcel-resolver-theme/node_modules/@parcel/packager-html": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/packager-html/-/packager-html-2.12.0.tgz",
-      "integrity": "sha512-PpvGB9hFFe+19NXGz2ApvPrkA9GwEqaDAninT+3pJD57OVBaxB8U+HN4a5LICKxjUppPPqmrLb6YPbD65IX4RA==",
-      "dev": true,
-      "dependencies": {
-        "@parcel/plugin": "2.12.0",
-        "@parcel/types": "2.12.0",
-        "@parcel/utils": "2.12.0",
-        "nullthrows": "^1.1.1",
-        "posthtml": "^0.16.5"
-      },
-      "engines": {
-        "node": ">= 12.0.0",
-        "parcel": "^2.12.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "local_modules/parcel-resolver-theme/node_modules/@parcel/packager-js": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/packager-js/-/packager-js-2.12.0.tgz",
-      "integrity": "sha512-viMF+FszITRRr8+2iJyk+4ruGiL27Y6AF7hQ3xbJfzqnmbOhGFtLTQwuwhOLqN/mWR2VKdgbLpZSarWaO3yAMg==",
-      "dev": true,
-      "dependencies": {
-        "@parcel/diagnostic": "2.12.0",
-        "@parcel/plugin": "2.12.0",
-        "@parcel/rust": "2.12.0",
-        "@parcel/source-map": "^2.1.1",
-        "@parcel/types": "2.12.0",
-        "@parcel/utils": "2.12.0",
-        "globals": "^13.2.0",
-        "nullthrows": "^1.1.1"
-      },
-      "engines": {
-        "node": ">= 12.0.0",
-        "parcel": "^2.12.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "local_modules/parcel-resolver-theme/node_modules/@parcel/packager-raw": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/packager-raw/-/packager-raw-2.12.0.tgz",
-      "integrity": "sha512-tJZqFbHqP24aq1F+OojFbQIc09P/u8HAW5xfndCrFnXpW4wTgM3p03P0xfw3gnNq+TtxHJ8c3UFE5LnXNNKhYA==",
-      "dev": true,
-      "dependencies": {
-        "@parcel/plugin": "2.12.0"
-      },
-      "engines": {
-        "node": ">= 12.0.0",
-        "parcel": "^2.12.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "local_modules/parcel-resolver-theme/node_modules/@parcel/packager-svg": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/packager-svg/-/packager-svg-2.12.0.tgz",
-      "integrity": "sha512-ldaGiacGb2lLqcXas97k8JiZRbAnNREmcvoY2W2dvW4loVuDT9B9fU777mbV6zODpcgcHWsLL3lYbJ5Lt3y9cg==",
-      "dev": true,
-      "dependencies": {
-        "@parcel/plugin": "2.12.0",
-        "@parcel/types": "2.12.0",
-        "@parcel/utils": "2.12.0",
-        "posthtml": "^0.16.4"
-      },
-      "engines": {
-        "node": ">= 12.0.0",
-        "parcel": "^2.12.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "local_modules/parcel-resolver-theme/node_modules/@parcel/packager-wasm": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/packager-wasm/-/packager-wasm-2.12.0.tgz",
-      "integrity": "sha512-fYqZzIqO9fGYveeImzF8ll6KRo2LrOXfD+2Y5U3BiX/wp9wv17dz50QLDQm9hmTcKGWxK4yWqKQh+Evp/fae7A==",
-      "dev": true,
-      "dependencies": {
-        "@parcel/plugin": "2.12.0"
-      },
-      "engines": {
-        "node": ">=12.0.0",
-        "parcel": "^2.12.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "local_modules/parcel-resolver-theme/node_modules/@parcel/plugin": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/plugin/-/plugin-2.12.0.tgz",
-      "integrity": "sha512-nc/uRA8DiMoe4neBbzV6kDndh/58a4wQuGKw5oEoIwBCHUvE2W8ZFSu7ollSXUGRzfacTt4NdY8TwS73ScWZ+g==",
-      "dev": true,
-      "dependencies": {
-        "@parcel/types": "2.12.0"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "local_modules/parcel-resolver-theme/node_modules/@parcel/profiler": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/profiler/-/profiler-2.12.0.tgz",
-      "integrity": "sha512-q53fvl5LDcFYzMUtSusUBZSjQrKjMlLEBgKeQHFwkimwR1mgoseaDBDuNz0XvmzDzF1UelJ02TUKCGacU8W2qA==",
-      "dev": true,
-      "dependencies": {
-        "@parcel/diagnostic": "2.12.0",
-        "@parcel/events": "2.12.0",
-        "chrome-trace-event": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "local_modules/parcel-resolver-theme/node_modules/@parcel/reporter-dev-server": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/reporter-dev-server/-/reporter-dev-server-2.12.0.tgz",
-      "integrity": "sha512-tIcDqRvAPAttRlTV28dHcbWT5K2r/MBFks7nM4nrEDHWtnrCwimkDmZTc1kD8QOCCjGVwRHcQybpHvxfwol6GA==",
-      "dev": true,
-      "dependencies": {
-        "@parcel/plugin": "2.12.0",
-        "@parcel/utils": "2.12.0"
-      },
-      "engines": {
-        "node": ">= 12.0.0",
-        "parcel": "^2.12.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "local_modules/parcel-resolver-theme/node_modules/@parcel/reporter-tracer": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/reporter-tracer/-/reporter-tracer-2.12.0.tgz",
-      "integrity": "sha512-g8rlu9GxB8Ut/F8WGx4zidIPQ4pcYFjU9bZO+fyRIPrSUFH2bKijCnbZcr4ntqzDGx74hwD6cCG4DBoleq2UlQ==",
-      "dev": true,
-      "dependencies": {
-        "@parcel/plugin": "2.12.0",
-        "@parcel/utils": "2.12.0",
-        "chrome-trace-event": "^1.0.3",
-        "nullthrows": "^1.1.1"
-      },
-      "engines": {
-        "node": ">= 12.0.0",
-        "parcel": "^2.12.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "local_modules/parcel-resolver-theme/node_modules/@parcel/resolver-default": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/resolver-default/-/resolver-default-2.12.0.tgz",
-      "integrity": "sha512-uuhbajTax37TwCxu7V98JtRLiT6hzE4VYSu5B7Qkauy14/WFt2dz6GOUXPgVsED569/hkxebPx3KCMtZW6cHHA==",
-      "dev": true,
-      "dependencies": {
-        "@parcel/node-resolver-core": "3.3.0",
-        "@parcel/plugin": "2.12.0"
-      },
-      "engines": {
-        "node": ">= 12.0.0",
-        "parcel": "^2.12.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "local_modules/parcel-resolver-theme/node_modules/@parcel/runtime-browser-hmr": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/runtime-browser-hmr/-/runtime-browser-hmr-2.12.0.tgz",
-      "integrity": "sha512-4ZLp2FWyD32r0GlTulO3+jxgsA3oO1P1b5oO2IWuWilfhcJH5LTiazpL5YdusUjtNn9PGN6QLAWfxmzRIfM+Ow==",
-      "dev": true,
-      "dependencies": {
-        "@parcel/plugin": "2.12.0",
-        "@parcel/utils": "2.12.0"
-      },
-      "engines": {
-        "node": ">= 12.0.0",
-        "parcel": "^2.12.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "local_modules/parcel-resolver-theme/node_modules/@parcel/runtime-js": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/runtime-js/-/runtime-js-2.12.0.tgz",
-      "integrity": "sha512-sBerP32Z1crX5PfLNGDSXSdqzlllM++GVnVQVeM7DgMKS8JIFG3VLi28YkX+dYYGtPypm01JoIHCkvwiZEcQJg==",
-      "dev": true,
-      "dependencies": {
-        "@parcel/diagnostic": "2.12.0",
-        "@parcel/plugin": "2.12.0",
-        "@parcel/utils": "2.12.0",
-        "nullthrows": "^1.1.1"
-      },
-      "engines": {
-        "node": ">= 12.0.0",
-        "parcel": "^2.12.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "local_modules/parcel-resolver-theme/node_modules/@parcel/runtime-react-refresh": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/runtime-react-refresh/-/runtime-react-refresh-2.12.0.tgz",
-      "integrity": "sha512-SCHkcczJIDFTFdLTzrHTkQ0aTrX3xH6jrA4UsCBL6ji61+w+ohy4jEEe9qCgJVXhnJfGLE43HNXek+0MStX+Mw==",
-      "dev": true,
-      "dependencies": {
-        "@parcel/plugin": "2.12.0",
-        "@parcel/utils": "2.12.0",
-        "react-error-overlay": "6.0.9",
-        "react-refresh": "^0.9.0"
-      },
-      "engines": {
-        "node": ">= 12.0.0",
-        "parcel": "^2.12.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "local_modules/parcel-resolver-theme/node_modules/@parcel/runtime-service-worker": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/runtime-service-worker/-/runtime-service-worker-2.12.0.tgz",
-      "integrity": "sha512-BXuMBsfiwpIEnssn+jqfC3jkgbS8oxeo3C7xhSQsuSv+AF2FwY3O3AO1c1RBskEW3XrBLNINOJujroNw80VTKA==",
-      "dev": true,
-      "dependencies": {
-        "@parcel/plugin": "2.12.0",
-        "@parcel/utils": "2.12.0",
-        "nullthrows": "^1.1.1"
-      },
-      "engines": {
-        "node": ">= 12.0.0",
-        "parcel": "^2.12.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "local_modules/parcel-resolver-theme/node_modules/@parcel/rust": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/rust/-/rust-2.12.0.tgz",
-      "integrity": "sha512-005cldMdFZFDPOjbDVEXcINQ3wT4vrxvSavRWI3Az0e3E18exO/x/mW9f648KtXugOXMAqCEqhFHcXECL9nmMw==",
-      "dev": true,
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "local_modules/parcel-resolver-theme/node_modules/@parcel/transformer-babel": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-babel/-/transformer-babel-2.12.0.tgz",
-      "integrity": "sha512-zQaBfOnf/l8rPxYGnsk/ufh/0EuqvmnxafjBIpKZ//j6rGylw5JCqXSb1QvvAqRYruKeccxGv7+HrxpqKU6V4A==",
-      "dev": true,
-      "dependencies": {
-        "@parcel/diagnostic": "2.12.0",
-        "@parcel/plugin": "2.12.0",
-        "@parcel/source-map": "^2.1.1",
-        "@parcel/utils": "2.12.0",
-        "browserslist": "^4.6.6",
-        "json5": "^2.2.0",
-        "nullthrows": "^1.1.1",
-        "semver": "^7.5.2"
-      },
-      "engines": {
-        "node": ">= 12.0.0",
-        "parcel": "^2.12.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "local_modules/parcel-resolver-theme/node_modules/@parcel/transformer-css": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-css/-/transformer-css-2.12.0.tgz",
-      "integrity": "sha512-vXhOqoAlQGATYyQ433Z1DXKmiKmzOAUmKysbYH3FD+LKEKLMEl/pA14goqp00TW+A/EjtSKKyeMyHlMIIUqj4Q==",
-      "dev": true,
-      "dependencies": {
-        "@parcel/diagnostic": "2.12.0",
-        "@parcel/plugin": "2.12.0",
-        "@parcel/source-map": "^2.1.1",
-        "@parcel/utils": "2.12.0",
-        "browserslist": "^4.6.6",
-        "lightningcss": "^1.22.1",
-        "nullthrows": "^1.1.1"
-      },
-      "engines": {
-        "node": ">= 12.0.0",
-        "parcel": "^2.12.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "local_modules/parcel-resolver-theme/node_modules/@parcel/transformer-html": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-html/-/transformer-html-2.12.0.tgz",
-      "integrity": "sha512-5jW4dFFBlYBvIQk4nrH62rfA/G/KzVzEDa6S+Nne0xXhglLjkm64Ci9b/d4tKZfuGWUbpm2ASAq8skti/nfpXw==",
-      "dev": true,
-      "dependencies": {
-        "@parcel/diagnostic": "2.12.0",
-        "@parcel/plugin": "2.12.0",
-        "@parcel/rust": "2.12.0",
-        "nullthrows": "^1.1.1",
-        "posthtml": "^0.16.5",
-        "posthtml-parser": "^0.10.1",
-        "posthtml-render": "^3.0.0",
-        "semver": "^7.5.2",
-        "srcset": "4"
-      },
-      "engines": {
-        "node": ">= 12.0.0",
-        "parcel": "^2.12.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "local_modules/parcel-resolver-theme/node_modules/@parcel/transformer-image": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-image/-/transformer-image-2.12.0.tgz",
-      "integrity": "sha512-8hXrGm2IRII49R7lZ0RpmNk27EhcsH+uNKsvxuMpXPuEnWgC/ha/IrjaI29xCng1uGur74bJF43NUSQhR4aTdw==",
-      "dev": true,
-      "dependencies": {
-        "@parcel/plugin": "2.12.0",
-        "@parcel/utils": "2.12.0",
-        "@parcel/workers": "2.12.0",
-        "nullthrows": "^1.1.1"
-      },
-      "engines": {
-        "node": ">= 12.0.0",
-        "parcel": "^2.12.0"
-      },
-      "peerDependencies": {
-        "@parcel/core": "^2.12.0"
-      }
-    },
-    "local_modules/parcel-resolver-theme/node_modules/@parcel/transformer-js": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-js/-/transformer-js-2.12.0.tgz",
-      "integrity": "sha512-OSZpOu+FGDbC/xivu24v092D9w6EGytB3vidwbdiJ2FaPgfV7rxS0WIUjH4I0OcvHAcitArRXL0a3+HrNTdQQw==",
-      "dev": true,
-      "dependencies": {
-        "@parcel/diagnostic": "2.12.0",
-        "@parcel/plugin": "2.12.0",
-        "@parcel/rust": "2.12.0",
-        "@parcel/source-map": "^2.1.1",
-        "@parcel/utils": "2.12.0",
-        "@parcel/workers": "2.12.0",
-        "@swc/helpers": "^0.5.0",
-        "browserslist": "^4.6.6",
-        "nullthrows": "^1.1.1",
-        "regenerator-runtime": "^0.13.7",
-        "semver": "^7.5.2"
-      },
-      "engines": {
-        "node": ">= 12.0.0",
-        "parcel": "^2.12.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      },
-      "peerDependencies": {
-        "@parcel/core": "^2.12.0"
-      }
-    },
-    "local_modules/parcel-resolver-theme/node_modules/@parcel/transformer-json": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-json/-/transformer-json-2.12.0.tgz",
-      "integrity": "sha512-Utv64GLRCQILK5r0KFs4o7I41ixMPllwOLOhkdjJKvf1hZmN6WqfOmB1YLbWS/y5Zb/iB52DU2pWZm96vLFQZQ==",
-      "dev": true,
-      "dependencies": {
-        "@parcel/plugin": "2.12.0",
-        "json5": "^2.2.0"
-      },
-      "engines": {
-        "node": ">= 12.0.0",
-        "parcel": "^2.12.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "local_modules/parcel-resolver-theme/node_modules/@parcel/transformer-postcss": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-postcss/-/transformer-postcss-2.12.0.tgz",
-      "integrity": "sha512-FZqn+oUtiLfPOn67EZxPpBkfdFiTnF4iwiXPqvst3XI8H+iC+yNgzmtJkunOOuylpYY6NOU5jT8d7saqWSDv2Q==",
-      "dev": true,
-      "dependencies": {
-        "@parcel/diagnostic": "2.12.0",
-        "@parcel/plugin": "2.12.0",
-        "@parcel/rust": "2.12.0",
-        "@parcel/utils": "2.12.0",
-        "clone": "^2.1.1",
-        "nullthrows": "^1.1.1",
-        "postcss-value-parser": "^4.2.0",
-        "semver": "^7.5.2"
-      },
-      "engines": {
-        "node": ">= 12.0.0",
-        "parcel": "^2.12.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "local_modules/parcel-resolver-theme/node_modules/@parcel/transformer-posthtml": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-posthtml/-/transformer-posthtml-2.12.0.tgz",
-      "integrity": "sha512-z6Z7rav/pcaWdeD+2sDUcd0mmNZRUvtHaUGa50Y2mr+poxrKilpsnFMSiWBT+oOqPt7j71jzDvrdnAF4XkCljg==",
-      "dev": true,
-      "dependencies": {
-        "@parcel/plugin": "2.12.0",
-        "@parcel/utils": "2.12.0",
-        "nullthrows": "^1.1.1",
-        "posthtml": "^0.16.5",
-        "posthtml-parser": "^0.10.1",
-        "posthtml-render": "^3.0.0",
-        "semver": "^7.5.2"
-      },
-      "engines": {
-        "node": ">= 12.0.0",
-        "parcel": "^2.12.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "local_modules/parcel-resolver-theme/node_modules/@parcel/transformer-raw": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-raw/-/transformer-raw-2.12.0.tgz",
-      "integrity": "sha512-Ht1fQvXxix0NncdnmnXZsa6hra20RXYh1VqhBYZLsDfkvGGFnXIgO03Jqn4Z8MkKoa0tiNbDhpKIeTjyclbBxQ==",
-      "dev": true,
-      "dependencies": {
-        "@parcel/plugin": "2.12.0"
-      },
-      "engines": {
-        "node": ">= 12.0.0",
-        "parcel": "^2.12.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "local_modules/parcel-resolver-theme/node_modules/@parcel/transformer-react-refresh-wrap": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-react-refresh-wrap/-/transformer-react-refresh-wrap-2.12.0.tgz",
-      "integrity": "sha512-GE8gmP2AZtkpBIV5vSCVhewgOFRhqwdM5Q9jNPOY5PKcM3/Ff0qCqDiTzzGLhk0/VMBrdjssrfZkVx6S/lHdJw==",
-      "dev": true,
-      "dependencies": {
-        "@parcel/plugin": "2.12.0",
-        "@parcel/utils": "2.12.0",
-        "react-refresh": "^0.9.0"
-      },
-      "engines": {
-        "node": ">= 12.0.0",
-        "parcel": "^2.12.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "local_modules/parcel-resolver-theme/node_modules/@parcel/transformer-svg": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-svg/-/transformer-svg-2.12.0.tgz",
-      "integrity": "sha512-cZJqGRJ4JNdYcb+vj94J7PdOuTnwyy45dM9xqbIMH+HSiiIkfrMsdEwYft0GTyFTdsnf+hdHn3tau7Qa5hhX+A==",
-      "dev": true,
-      "dependencies": {
-        "@parcel/diagnostic": "2.12.0",
-        "@parcel/plugin": "2.12.0",
-        "@parcel/rust": "2.12.0",
-        "nullthrows": "^1.1.1",
-        "posthtml": "^0.16.5",
-        "posthtml-parser": "^0.10.1",
-        "posthtml-render": "^3.0.0",
-        "semver": "^7.5.2"
-      },
-      "engines": {
-        "node": ">= 12.0.0",
-        "parcel": "^2.12.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "local_modules/parcel-resolver-theme/node_modules/@parcel/types": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/types/-/types-2.12.0.tgz",
-      "integrity": "sha512-8zAFiYNCwNTQcglIObyNwKfRYQK5ELlL13GuBOrSMxueUiI5ylgsGbTS1N7J3dAGZixHO8KhHGv5a71FILn9rQ==",
-      "dev": true,
-      "dependencies": {
-        "@parcel/cache": "2.12.0",
-        "@parcel/diagnostic": "2.12.0",
-        "@parcel/fs": "2.12.0",
-        "@parcel/package-manager": "2.12.0",
-        "@parcel/source-map": "^2.1.1",
-        "@parcel/workers": "2.12.0",
-        "utility-types": "^3.10.0"
-      }
-    },
-    "local_modules/parcel-resolver-theme/node_modules/@parcel/utils": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.12.0.tgz",
-      "integrity": "sha512-z1JhLuZ8QmDaYoEIuUCVZlhcFrS7LMfHrb2OCRui5SQFntRWBH2fNM6H/fXXUkT9SkxcuFP2DUA6/m4+Gkz72g==",
-      "dev": true,
-      "dependencies": {
-        "@parcel/codeframe": "2.12.0",
-        "@parcel/diagnostic": "2.12.0",
-        "@parcel/logger": "2.12.0",
-        "@parcel/markdown-ansi": "2.12.0",
-        "@parcel/rust": "2.12.0",
-        "@parcel/source-map": "^2.1.1",
-        "chalk": "^4.1.0",
-        "nullthrows": "^1.1.1"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "local_modules/parcel-resolver-theme/node_modules/@parcel/workers": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/workers/-/workers-2.12.0.tgz",
-      "integrity": "sha512-zv5We5Jmb+ZWXlU6A+AufyjY4oZckkxsZ8J4dvyWL0W8IQvGO1JB4FGeryyttzQv3RM3OxcN/BpTGPiDG6keBw==",
-      "dev": true,
-      "dependencies": {
-        "@parcel/diagnostic": "2.12.0",
-        "@parcel/logger": "2.12.0",
-        "@parcel/profiler": "2.12.0",
-        "@parcel/types": "2.12.0",
-        "@parcel/utils": "2.12.0",
-        "nullthrows": "^1.1.1"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      },
-      "peerDependencies": {
-        "@parcel/core": "^2.12.0"
-      }
-    },
-    "local_modules/parcel-resolver-theme/node_modules/commander": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
-      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
-      "dev": true,
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "local_modules/parcel-resolver-theme/node_modules/css-select": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/css-select/-/css-select-4.3.0.tgz",
-      "integrity": "sha512-wPpOYtnsVontu2mODhA19JrqWxNsfdatRKd64kmpRbQgh1KtItko5sTnEpPdpSaJszTOhEMlF/RPz28qj4HqhQ==",
-      "dev": true,
-      "dependencies": {
-        "boolbase": "^1.0.0",
-        "css-what": "^6.0.1",
-        "domhandler": "^4.3.1",
-        "domutils": "^2.8.0",
-        "nth-check": "^2.0.1"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/fb55"
-      }
-    },
-    "local_modules/parcel-resolver-theme/node_modules/css-tree": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.1.3.tgz",
-      "integrity": "sha512-tRpdppF7TRazZrjJ6v3stzv93qxRcSsFmW6cX0Zm2NVKpxE1WV1HblnghVv9TreireHkqI/VDEsfolRF1p6y7Q==",
-      "dev": true,
-      "dependencies": {
-        "mdn-data": "2.0.14",
-        "source-map": "^0.6.1"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "local_modules/parcel-resolver-theme/node_modules/csso": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/csso/-/csso-4.2.0.tgz",
-      "integrity": "sha512-wvlcdIbf6pwKEk7vHj8/Bkc0B4ylXZruLvOgs9doS5eOsOpuodOV2zJChSpkp+pRpYQLQMeF04nr3Z68Sta9jA==",
-      "dev": true,
-      "dependencies": {
-        "css-tree": "^1.1.2"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "local_modules/parcel-resolver-theme/node_modules/mdn-data": {
-      "version": "2.0.14",
-      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.14.tgz",
-      "integrity": "sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow==",
-      "dev": true
-    },
-    "local_modules/parcel-resolver-theme/node_modules/parcel": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/parcel/-/parcel-2.12.0.tgz",
-      "integrity": "sha512-W+gxAq7aQ9dJIg/XLKGcRT0cvnStFAQHPaI0pvD0U2l6IVLueUAm3nwN7lkY62zZNmlvNx6jNtE4wlbS+CyqSg==",
-      "dev": true,
-      "dependencies": {
-        "@parcel/config-default": "2.12.0",
-        "@parcel/core": "2.12.0",
-        "@parcel/diagnostic": "2.12.0",
-        "@parcel/events": "2.12.0",
-        "@parcel/fs": "2.12.0",
-        "@parcel/logger": "2.12.0",
-        "@parcel/package-manager": "2.12.0",
-        "@parcel/reporter-cli": "2.12.0",
-        "@parcel/reporter-dev-server": "2.12.0",
-        "@parcel/reporter-tracer": "2.12.0",
-        "@parcel/utils": "2.12.0",
-        "chalk": "^4.1.0",
-        "commander": "^7.0.0",
-        "get-port": "^4.2.0"
-      },
-      "bin": {
-        "parcel": "lib/bin.js"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "local_modules/parcel-resolver-theme/node_modules/semver": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
-      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
-      "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "local_modules/parcel-resolver-theme/node_modules/svgo": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/svgo/-/svgo-2.8.0.tgz",
-      "integrity": "sha512-+N/Q9kV1+F+UeWYoSiULYo4xYSDQlTgb+ayMobAXPwMnLvop7oxKMo9OzIrX5x3eS4L4f2UHhc9axXwY8DpChg==",
-      "dev": true,
-      "dependencies": {
-        "@trysound/sax": "0.2.0",
-        "commander": "^7.2.0",
-        "css-select": "^4.1.3",
-        "css-tree": "^1.1.3",
-        "csso": "^4.2.0",
-        "picocolors": "^1.0.0",
-        "stable": "^0.1.8"
-      },
-      "bin": {
-        "svgo": "bin/svgo"
-      },
-      "engines": {
-        "node": ">=10.13.0"
-      }
-    },
     "node_modules/@babel/code-frame": {
-      "version": "7.23.5",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.23.5.tgz",
-      "integrity": "sha512-CgH3s1a96LipHCmSUmYFPwY7MNx8C3avkq7i4Wl3cfa662ldtUe4VM1TPXX70pfmrlWTb6jLqTYrZyT2ZTJBgA==",
+      "version": "7.24.2",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.24.2.tgz",
+      "integrity": "sha512-y5+tLQyV8pg3fsiln67BVLD1P13Eg4lh5RW9mF0zUuvLrv9uIQ4MCL+CRT+FTsBlBjcIan6PGsLcBN0m3ClUyQ==",
       "dev": true,
       "dependencies": {
-        "@babel/highlight": "^7.23.4",
-        "chalk": "^2.4.2"
+        "@babel/highlight": "^7.24.2",
+        "picocolors": "^1.0.0"
       },
       "engines": {
         "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/code-frame/node_modules/ansi-styles": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "dev": true,
-      "dependencies": {
-        "color-convert": "^1.9.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@babel/code-frame/node_modules/chalk": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@babel/code-frame/node_modules/color-convert": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dev": true,
-      "dependencies": {
-        "color-name": "1.1.3"
-      }
-    },
-    "node_modules/@babel/code-frame/node_modules/color-name": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-      "dev": true
-    },
-    "node_modules/@babel/code-frame/node_modules/has-flag": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@babel/code-frame/node_modules/supports-color": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "dev": true,
-      "dependencies": {
-        "has-flag": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
@@ -1311,14 +73,15 @@
       }
     },
     "node_modules/@babel/highlight": {
-      "version": "7.23.4",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.23.4.tgz",
-      "integrity": "sha512-acGdbYSfp2WheJoJm/EBBBLh/ID8KDc64ISZ9DYtBmC8/Q204PZJLHyzeB5qMzJ5trcOkybd78M4x2KWsUq++A==",
+      "version": "7.24.2",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.24.2.tgz",
+      "integrity": "sha512-Yac1ao4flkTxTteCDZLEvdxg2fZfz1v8M4QpaGypq/WPDqg3ijHYbDfs+LG5hvzSoqaSZ9/Z9lKSP3CjZjv+pA==",
       "dev": true,
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.22.20",
         "chalk": "^2.4.2",
-        "js-tokens": "^4.0.0"
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.0.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1572,21 +335,21 @@
       ]
     },
     "node_modules/@parcel/bundler-default": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@parcel/bundler-default/-/bundler-default-2.11.0.tgz",
-      "integrity": "sha512-ZIs0865Lp871ZK83k5I9L4DeeE26muNMrHa7j8bvls6fKBJKAn8djrhfU4XOLyziU4aAOobcPwXU0+npWqs52g==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/bundler-default/-/bundler-default-2.12.0.tgz",
+      "integrity": "sha512-3ybN74oYNMKyjD6V20c9Gerdbh7teeNvVMwIoHIQMzuIFT6IGX53PyOLlOKRLbjxMc0TMimQQxIt2eQqxR5LsA==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.11.0",
-        "@parcel/graph": "3.1.0",
-        "@parcel/plugin": "2.11.0",
-        "@parcel/rust": "2.11.0",
-        "@parcel/utils": "2.11.0",
+        "@parcel/diagnostic": "2.12.0",
+        "@parcel/graph": "3.2.0",
+        "@parcel/plugin": "2.12.0",
+        "@parcel/rust": "2.12.0",
+        "@parcel/utils": "2.12.0",
         "nullthrows": "^1.1.1"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.11.0"
+        "parcel": "^2.12.0"
       },
       "funding": {
         "type": "opencollective",
@@ -1594,14 +357,14 @@
       }
     },
     "node_modules/@parcel/cache": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@parcel/cache/-/cache-2.11.0.tgz",
-      "integrity": "sha512-RSSkGNjO00lJPyftzaC9eaNVs4jMjPSAm0VJNWQ9JSm2n4A9BzQtTFAt1vhJOzzW1UsQvvBge9DdfkB7a2gIOw==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/cache/-/cache-2.12.0.tgz",
+      "integrity": "sha512-FX5ZpTEkxvq/yvWklRHDESVRz+c7sLTXgFuzz6uEnBcXV38j6dMSikflNpHA6q/L4GKkCqRywm9R6XQwhwIMyw==",
       "dev": true,
       "dependencies": {
-        "@parcel/fs": "2.11.0",
-        "@parcel/logger": "2.11.0",
-        "@parcel/utils": "2.11.0",
+        "@parcel/fs": "2.12.0",
+        "@parcel/logger": "2.12.0",
+        "@parcel/utils": "2.12.0",
         "lmdb": "2.8.5"
       },
       "engines": {
@@ -1612,13 +375,13 @@
         "url": "https://opencollective.com/parcel"
       },
       "peerDependencies": {
-        "@parcel/core": "^2.11.0"
+        "@parcel/core": "^2.12.0"
       }
     },
     "node_modules/@parcel/codeframe": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@parcel/codeframe/-/codeframe-2.11.0.tgz",
-      "integrity": "sha512-YHs9g/i5af/sd/JrWAojU9YFbKffcJ3Tx2EJaK0ME8OJsye91UaI/3lxSUYLmJG9e4WLNJtqci8V5FBMz//ZPg==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/codeframe/-/codeframe-2.12.0.tgz",
+      "integrity": "sha512-v2VmneILFiHZJTxPiR7GEF1wey1/IXPdZMcUlNXBiPZyWDfcuNgGGVQkx/xW561rULLIvDPharOMdxz5oHOKQg==",
       "dev": true,
       "dependencies": {
         "chalk": "^4.1.0"
@@ -1632,16 +395,16 @@
       }
     },
     "node_modules/@parcel/compressor-raw": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@parcel/compressor-raw/-/compressor-raw-2.11.0.tgz",
-      "integrity": "sha512-RArhBPRTCfz77soX2IECH09NUd76UBWujXiPRcXGPIHK+C3L1cRuzsNcA39QeSb3thz3b99JcozMJ1nkC2Bsgw==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/compressor-raw/-/compressor-raw-2.12.0.tgz",
+      "integrity": "sha512-h41Q3X7ZAQ9wbQ2csP8QGrwepasLZdXiuEdpUryDce6rF9ZiHoJ97MRpdLxOhOPyASTw/xDgE1xyaPQr0Q3f5A==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.11.0"
+        "@parcel/plugin": "2.12.0"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.11.0"
+        "parcel": "^2.12.0"
       },
       "funding": {
         "type": "opencollective",
@@ -1649,72 +412,72 @@
       }
     },
     "node_modules/@parcel/config-default": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@parcel/config-default/-/config-default-2.11.0.tgz",
-      "integrity": "sha512-1e2+qcZkm5/0f4eI20p/DemcYiSxq9d/eyjpTXA7PulJaHbL1wonwUAuy3mvnAvDnLOJmAk/obDVgX1ZfxMGtg==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/config-default/-/config-default-2.12.0.tgz",
+      "integrity": "sha512-dPNe2n9eEsKRc1soWIY0yToMUPirPIa2QhxcCB3Z5RjpDGIXm0pds+BaiqY6uGLEEzsjhRO0ujd4v2Rmm0vuFg==",
       "dev": true,
       "dependencies": {
-        "@parcel/bundler-default": "2.11.0",
-        "@parcel/compressor-raw": "2.11.0",
-        "@parcel/namer-default": "2.11.0",
-        "@parcel/optimizer-css": "2.11.0",
-        "@parcel/optimizer-htmlnano": "2.11.0",
-        "@parcel/optimizer-image": "2.11.0",
-        "@parcel/optimizer-svgo": "2.11.0",
-        "@parcel/optimizer-swc": "2.11.0",
-        "@parcel/packager-css": "2.11.0",
-        "@parcel/packager-html": "2.11.0",
-        "@parcel/packager-js": "2.11.0",
-        "@parcel/packager-raw": "2.11.0",
-        "@parcel/packager-svg": "2.11.0",
-        "@parcel/packager-wasm": "2.11.0",
-        "@parcel/reporter-dev-server": "2.11.0",
-        "@parcel/resolver-default": "2.11.0",
-        "@parcel/runtime-browser-hmr": "2.11.0",
-        "@parcel/runtime-js": "2.11.0",
-        "@parcel/runtime-react-refresh": "2.11.0",
-        "@parcel/runtime-service-worker": "2.11.0",
-        "@parcel/transformer-babel": "2.11.0",
-        "@parcel/transformer-css": "2.11.0",
-        "@parcel/transformer-html": "2.11.0",
-        "@parcel/transformer-image": "2.11.0",
-        "@parcel/transformer-js": "2.11.0",
-        "@parcel/transformer-json": "2.11.0",
-        "@parcel/transformer-postcss": "2.11.0",
-        "@parcel/transformer-posthtml": "2.11.0",
-        "@parcel/transformer-raw": "2.11.0",
-        "@parcel/transformer-react-refresh-wrap": "2.11.0",
-        "@parcel/transformer-svg": "2.11.0"
+        "@parcel/bundler-default": "2.12.0",
+        "@parcel/compressor-raw": "2.12.0",
+        "@parcel/namer-default": "2.12.0",
+        "@parcel/optimizer-css": "2.12.0",
+        "@parcel/optimizer-htmlnano": "2.12.0",
+        "@parcel/optimizer-image": "2.12.0",
+        "@parcel/optimizer-svgo": "2.12.0",
+        "@parcel/optimizer-swc": "2.12.0",
+        "@parcel/packager-css": "2.12.0",
+        "@parcel/packager-html": "2.12.0",
+        "@parcel/packager-js": "2.12.0",
+        "@parcel/packager-raw": "2.12.0",
+        "@parcel/packager-svg": "2.12.0",
+        "@parcel/packager-wasm": "2.12.0",
+        "@parcel/reporter-dev-server": "2.12.0",
+        "@parcel/resolver-default": "2.12.0",
+        "@parcel/runtime-browser-hmr": "2.12.0",
+        "@parcel/runtime-js": "2.12.0",
+        "@parcel/runtime-react-refresh": "2.12.0",
+        "@parcel/runtime-service-worker": "2.12.0",
+        "@parcel/transformer-babel": "2.12.0",
+        "@parcel/transformer-css": "2.12.0",
+        "@parcel/transformer-html": "2.12.0",
+        "@parcel/transformer-image": "2.12.0",
+        "@parcel/transformer-js": "2.12.0",
+        "@parcel/transformer-json": "2.12.0",
+        "@parcel/transformer-postcss": "2.12.0",
+        "@parcel/transformer-posthtml": "2.12.0",
+        "@parcel/transformer-raw": "2.12.0",
+        "@parcel/transformer-react-refresh-wrap": "2.12.0",
+        "@parcel/transformer-svg": "2.12.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
       },
       "peerDependencies": {
-        "@parcel/core": "^2.11.0"
+        "@parcel/core": "^2.12.0"
       }
     },
     "node_modules/@parcel/core": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@parcel/core/-/core-2.11.0.tgz",
-      "integrity": "sha512-Npe0S6hVaqWEwRL+HI7gtOYOaoE5bJQZTgUDhsDoppWbau51jOlRYOZTXuvRK/jxXnze4/S1sdM24xBYAQ5qkw==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/core/-/core-2.12.0.tgz",
+      "integrity": "sha512-s+6pwEj+GfKf7vqGUzN9iSEPueUssCCQrCBUlcAfKrJe0a22hTUCjewpB0I7lNrCIULt8dkndD+sMdOrXsRl6Q==",
       "dev": true,
       "dependencies": {
         "@mischnic/json-sourcemap": "^0.1.0",
-        "@parcel/cache": "2.11.0",
-        "@parcel/diagnostic": "2.11.0",
-        "@parcel/events": "2.11.0",
-        "@parcel/fs": "2.11.0",
-        "@parcel/graph": "3.1.0",
-        "@parcel/logger": "2.11.0",
-        "@parcel/package-manager": "2.11.0",
-        "@parcel/plugin": "2.11.0",
-        "@parcel/profiler": "2.11.0",
-        "@parcel/rust": "2.11.0",
+        "@parcel/cache": "2.12.0",
+        "@parcel/diagnostic": "2.12.0",
+        "@parcel/events": "2.12.0",
+        "@parcel/fs": "2.12.0",
+        "@parcel/graph": "3.2.0",
+        "@parcel/logger": "2.12.0",
+        "@parcel/package-manager": "2.12.0",
+        "@parcel/plugin": "2.12.0",
+        "@parcel/profiler": "2.12.0",
+        "@parcel/rust": "2.12.0",
         "@parcel/source-map": "^2.1.1",
-        "@parcel/types": "2.11.0",
-        "@parcel/utils": "2.11.0",
-        "@parcel/workers": "2.11.0",
+        "@parcel/types": "2.12.0",
+        "@parcel/utils": "2.12.0",
+        "@parcel/workers": "2.12.0",
         "abortcontroller-polyfill": "^1.1.9",
         "base-x": "^3.0.8",
         "browserslist": "^4.6.6",
@@ -1750,9 +513,9 @@
       }
     },
     "node_modules/@parcel/diagnostic": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@parcel/diagnostic/-/diagnostic-2.11.0.tgz",
-      "integrity": "sha512-4dJmOXVL5YGGQRRsQosQbSRONBcboB71mSwaeaEgz3pPdq9QXVPLACkGe/jTXSqa3OnAHu3g5vQLpE1g5xqBqw==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/diagnostic/-/diagnostic-2.12.0.tgz",
+      "integrity": "sha512-8f1NOsSFK+F4AwFCKynyIu9Kr/uWHC+SywAv4oS6Bv3Acig0gtwUjugk0C9UaB8ztBZiW5TQZhw+uPZn9T/lJA==",
       "dev": true,
       "dependencies": {
         "@mischnic/json-sourcemap": "^0.1.0",
@@ -1767,9 +530,9 @@
       }
     },
     "node_modules/@parcel/events": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@parcel/events/-/events-2.11.0.tgz",
-      "integrity": "sha512-K6SOjOrQsz1GdNl2qKBktq7KJ3Q3yxK8WXdmQYo10wG39dr051xtMb38aqieTp4eVhL8Yaq2iJgGkdr11fuBnA==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/events/-/events-2.12.0.tgz",
+      "integrity": "sha512-nmAAEIKLjW1kB2cUbCYSmZOGbnGj8wCzhqnK727zCCWaA25ogzAtt657GPOeFyqW77KyosU728Tl63Fc8hphIA==",
       "dev": true,
       "engines": {
         "node": ">= 12.0.0"
@@ -1780,16 +543,16 @@
       }
     },
     "node_modules/@parcel/fs": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@parcel/fs/-/fs-2.11.0.tgz",
-      "integrity": "sha512-zWckdnnovdrgdFX4QYuQV4bbKCsh6IYCkmwaB4yp47rhw1MP0lkBINLt4yFPHBxWXOpElCfxjL+z69c9xJQRBQ==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/fs/-/fs-2.12.0.tgz",
+      "integrity": "sha512-NnFkuvou1YBtPOhTdZr44WN7I60cGyly2wpHzqRl62yhObyi1KvW0SjwOMa0QGNcBOIzp4G0CapoZ93hD0RG5Q==",
       "dev": true,
       "dependencies": {
-        "@parcel/rust": "2.11.0",
-        "@parcel/types": "2.11.0",
-        "@parcel/utils": "2.11.0",
+        "@parcel/rust": "2.12.0",
+        "@parcel/types": "2.12.0",
+        "@parcel/utils": "2.12.0",
         "@parcel/watcher": "^2.0.7",
-        "@parcel/workers": "2.11.0"
+        "@parcel/workers": "2.12.0"
       },
       "engines": {
         "node": ">= 12.0.0"
@@ -1799,13 +562,13 @@
         "url": "https://opencollective.com/parcel"
       },
       "peerDependencies": {
-        "@parcel/core": "^2.11.0"
+        "@parcel/core": "^2.12.0"
       }
     },
     "node_modules/@parcel/graph": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@parcel/graph/-/graph-3.1.0.tgz",
-      "integrity": "sha512-d1dTW5C7A52HgDtoXlyvlET1ypSlmIxSIZOJ1xp3R9L9hgo3h1u3jHNyaoTe/WPkGVe2QnFxh0h+UibVJhu9vg==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@parcel/graph/-/graph-3.2.0.tgz",
+      "integrity": "sha512-xlrmCPqy58D4Fg5umV7bpwDx5Vyt7MlnQPxW68vae5+BA4GSWetfZt+Cs5dtotMG2oCHzZxhIPt7YZ7NRyQzLA==",
       "dev": true,
       "dependencies": {
         "nullthrows": "^1.1.1"
@@ -1819,13 +582,13 @@
       }
     },
     "node_modules/@parcel/logger": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.11.0.tgz",
-      "integrity": "sha512-HtMEdCq3LKnvv4T2CIskcqlf2gpBvHMm3pkeUFB/hc/7hW/hE1k6/HA2VOQvc0tBsaMpmEx7PCrfrH56usQSyA==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.12.0.tgz",
+      "integrity": "sha512-cJ7Paqa7/9VJ7C+KwgJlwMqTQBOjjn71FbKk0G07hydUEBISU2aDfmc/52o60ErL9l+vXB26zTrIBanbxS8rVg==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.11.0",
-        "@parcel/events": "2.11.0"
+        "@parcel/diagnostic": "2.12.0",
+        "@parcel/events": "2.12.0"
       },
       "engines": {
         "node": ">= 12.0.0"
@@ -1836,9 +599,9 @@
       }
     },
     "node_modules/@parcel/markdown-ansi": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@parcel/markdown-ansi/-/markdown-ansi-2.11.0.tgz",
-      "integrity": "sha512-YA60EWbXi6cLOIzcwRC2wijotPauOGQbUi0vSbu0O6/mjQ68kWCMGz0hwZjDRQcPypQVJEIvTgMymLbvumxwhg==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/markdown-ansi/-/markdown-ansi-2.12.0.tgz",
+      "integrity": "sha512-WZz3rzL8k0H3WR4qTHX6Ic8DlEs17keO9gtD4MNGyMNQbqQEvQ61lWJaIH0nAtgEetu0SOITiVqdZrb8zx/M7w==",
       "dev": true,
       "dependencies": {
         "chalk": "^4.1.0"
@@ -1852,18 +615,18 @@
       }
     },
     "node_modules/@parcel/namer-default": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@parcel/namer-default/-/namer-default-2.11.0.tgz",
-      "integrity": "sha512-DEwBSKSClg4DA2xAWimYkw9bFi7MFb9TdT7/TYZStMTsfYHPWOyyjGR7aVr3Ra4wNb+XX6g4rR41yp3HD6KO7A==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/namer-default/-/namer-default-2.12.0.tgz",
+      "integrity": "sha512-9DNKPDHWgMnMtqqZIMiEj/R9PNWW16lpnlHjwK3ciRlMPgjPJ8+UNc255teZODhX0T17GOzPdGbU/O/xbxVPzA==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.11.0",
-        "@parcel/plugin": "2.11.0",
+        "@parcel/diagnostic": "2.12.0",
+        "@parcel/plugin": "2.12.0",
         "nullthrows": "^1.1.1"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.11.0"
+        "parcel": "^2.12.0"
       },
       "funding": {
         "type": "opencollective",
@@ -1871,16 +634,16 @@
       }
     },
     "node_modules/@parcel/node-resolver-core": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@parcel/node-resolver-core/-/node-resolver-core-3.2.0.tgz",
-      "integrity": "sha512-XJRSxCkNbGFWjfmwFdcQZ/qlzWZd35qLtvLz2va8euGL7M5OMEQOv7dsvEhl0R+CC2zcnfFzZwxk78q6ezs8AQ==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@parcel/node-resolver-core/-/node-resolver-core-3.3.0.tgz",
+      "integrity": "sha512-rhPW9DYPEIqQBSlYzz3S0AjXxjN6Ub2yS6tzzsW/4S3Gpsgk/uEq4ZfxPvoPf/6TgZndVxmKwpmxaKtGMmf3cA==",
       "dev": true,
       "dependencies": {
         "@mischnic/json-sourcemap": "^0.1.0",
-        "@parcel/diagnostic": "2.11.0",
-        "@parcel/fs": "2.11.0",
-        "@parcel/rust": "2.11.0",
-        "@parcel/utils": "2.11.0",
+        "@parcel/diagnostic": "2.12.0",
+        "@parcel/fs": "2.12.0",
+        "@parcel/rust": "2.12.0",
+        "@parcel/utils": "2.12.0",
         "nullthrows": "^1.1.1",
         "semver": "^7.5.2"
       },
@@ -1893,9 +656,9 @@
       }
     },
     "node_modules/@parcel/node-resolver-core/node_modules/semver": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
       "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -1908,22 +671,22 @@
       }
     },
     "node_modules/@parcel/optimizer-css": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@parcel/optimizer-css/-/optimizer-css-2.11.0.tgz",
-      "integrity": "sha512-bV97PRxshHV3dMwOpLRgcP1QNhrVWh6VVDfm2gmWULpvsjoykcPS6vrCFksY5CpQsSvNHqJBzQjWS8FubUI76w==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/optimizer-css/-/optimizer-css-2.12.0.tgz",
+      "integrity": "sha512-ifbcC97fRzpruTjaa8axIFeX4MjjSIlQfem3EJug3L2AVqQUXnM1XO8L0NaXGNLTW2qnh1ZjIJ7vXT/QhsphsA==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.11.0",
-        "@parcel/plugin": "2.11.0",
+        "@parcel/diagnostic": "2.12.0",
+        "@parcel/plugin": "2.12.0",
         "@parcel/source-map": "^2.1.1",
-        "@parcel/utils": "2.11.0",
+        "@parcel/utils": "2.12.0",
         "browserslist": "^4.6.6",
         "lightningcss": "^1.22.1",
         "nullthrows": "^1.1.1"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.11.0"
+        "parcel": "^2.12.0"
       },
       "funding": {
         "type": "opencollective",
@@ -1931,12 +694,12 @@
       }
     },
     "node_modules/@parcel/optimizer-htmlnano": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@parcel/optimizer-htmlnano/-/optimizer-htmlnano-2.11.0.tgz",
-      "integrity": "sha512-c20pz4EFF5DNFmqYgptlIj49eT6xjGLkDTdHH3RRzxKovuSXWfYSPs3GED3ZsjVuQyjNQif+/MAk9547F7hrdQ==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/optimizer-htmlnano/-/optimizer-htmlnano-2.12.0.tgz",
+      "integrity": "sha512-MfPMeCrT8FYiOrpFHVR+NcZQlXAptK2r4nGJjfT+ndPBhEEZp4yyL7n1y7HfX9geg5altc4WTb4Gug7rCoW8VQ==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.11.0",
+        "@parcel/plugin": "2.12.0",
         "htmlnano": "^2.0.0",
         "nullthrows": "^1.1.1",
         "posthtml": "^0.16.5",
@@ -1944,7 +707,7 @@
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.11.0"
+        "parcel": "^2.12.0"
       },
       "funding": {
         "type": "opencollective",
@@ -2029,43 +792,43 @@
       }
     },
     "node_modules/@parcel/optimizer-image": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@parcel/optimizer-image/-/optimizer-image-2.11.0.tgz",
-      "integrity": "sha512-jCaJww5QFG2GuNzYW8nlSW+Ea+Cv47TRnOPJNquFIajgfTLJ5ddsWbaNal0GQsL8yNiCBKWd1AV4W0RH9tG0Jg==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/optimizer-image/-/optimizer-image-2.12.0.tgz",
+      "integrity": "sha512-bo1O7raeAIbRU5nmNVtx8divLW9Xqn0c57GVNGeAK4mygnQoqHqRZ0mR9uboh64pxv6ijXZHPhKvU9HEpjPjBQ==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.11.0",
-        "@parcel/plugin": "2.11.0",
-        "@parcel/rust": "2.11.0",
-        "@parcel/utils": "2.11.0",
-        "@parcel/workers": "2.11.0"
+        "@parcel/diagnostic": "2.12.0",
+        "@parcel/plugin": "2.12.0",
+        "@parcel/rust": "2.12.0",
+        "@parcel/utils": "2.12.0",
+        "@parcel/workers": "2.12.0"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.11.0"
+        "parcel": "^2.12.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
       },
       "peerDependencies": {
-        "@parcel/core": "^2.11.0"
+        "@parcel/core": "^2.12.0"
       }
     },
     "node_modules/@parcel/optimizer-svgo": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@parcel/optimizer-svgo/-/optimizer-svgo-2.11.0.tgz",
-      "integrity": "sha512-TQpvfBhjV2IsuFHXUolbDS6XWB3DDR2rYTlqlA8LMmuOY7jQd9Bnkl4JnapzWm/bRuzRlzdGjjVCPGL8iShFvA==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/optimizer-svgo/-/optimizer-svgo-2.12.0.tgz",
+      "integrity": "sha512-Kyli+ZZXnoonnbeRQdoWwee9Bk2jm/49xvnfb+2OO8NN0d41lblBoRhOyFiScRnJrw7eVl1Xrz7NTkXCIO7XFQ==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.11.0",
-        "@parcel/plugin": "2.11.0",
-        "@parcel/utils": "2.11.0",
+        "@parcel/diagnostic": "2.12.0",
+        "@parcel/plugin": "2.12.0",
+        "@parcel/utils": "2.12.0",
         "svgo": "^2.4.0"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.11.0"
+        "parcel": "^2.12.0"
       },
       "funding": {
         "type": "opencollective",
@@ -2150,21 +913,21 @@
       }
     },
     "node_modules/@parcel/optimizer-swc": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@parcel/optimizer-swc/-/optimizer-swc-2.11.0.tgz",
-      "integrity": "sha512-ftf42F3JyZxJb6nnLlgNGyNQ273YOla4dFGH/tWC8iTwObHUpWe7cMbCGcrSJBvAlsLkZfLpFNAXFxUgxdKyHQ==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/optimizer-swc/-/optimizer-swc-2.12.0.tgz",
+      "integrity": "sha512-iBi6LZB3lm6WmbXfzi8J3DCVPmn4FN2lw7DGXxUXu7MouDPVWfTsM6U/5TkSHJRNRogZ2gqy5q9g34NPxHbJcw==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.11.0",
-        "@parcel/plugin": "2.11.0",
+        "@parcel/diagnostic": "2.12.0",
+        "@parcel/plugin": "2.12.0",
         "@parcel/source-map": "^2.1.1",
-        "@parcel/utils": "2.11.0",
+        "@parcel/utils": "2.12.0",
         "@swc/core": "^1.3.36",
         "nullthrows": "^1.1.1"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.11.0"
+        "parcel": "^2.12.0"
       },
       "funding": {
         "type": "opencollective",
@@ -2172,18 +935,19 @@
       }
     },
     "node_modules/@parcel/package-manager": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@parcel/package-manager/-/package-manager-2.11.0.tgz",
-      "integrity": "sha512-QzdsrUYlAwIzb8by7WJjqYnbR1MoMKWbtE1MXUeYsZbFusV8B6pOH+lwqNJKS/BFtddZMRPYFueZS2N2fwzjig==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/package-manager/-/package-manager-2.12.0.tgz",
+      "integrity": "sha512-0nvAezcjPx9FT+hIL+LS1jb0aohwLZXct7jAh7i0MLMtehOi0z1Sau+QpgMlA9rfEZZ1LIeFdnZZwqSy7Ccspw==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.11.0",
-        "@parcel/fs": "2.11.0",
-        "@parcel/logger": "2.11.0",
-        "@parcel/node-resolver-core": "3.2.0",
-        "@parcel/types": "2.11.0",
-        "@parcel/utils": "2.11.0",
-        "@parcel/workers": "2.11.0",
+        "@parcel/diagnostic": "2.12.0",
+        "@parcel/fs": "2.12.0",
+        "@parcel/logger": "2.12.0",
+        "@parcel/node-resolver-core": "3.3.0",
+        "@parcel/types": "2.12.0",
+        "@parcel/utils": "2.12.0",
+        "@parcel/workers": "2.12.0",
+        "@swc/core": "^1.3.36",
         "semver": "^7.5.2"
       },
       "engines": {
@@ -2194,13 +958,13 @@
         "url": "https://opencollective.com/parcel"
       },
       "peerDependencies": {
-        "@parcel/core": "^2.11.0"
+        "@parcel/core": "^2.12.0"
       }
     },
     "node_modules/@parcel/package-manager/node_modules/semver": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
       "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -2213,20 +977,21 @@
       }
     },
     "node_modules/@parcel/packager-css": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@parcel/packager-css/-/packager-css-2.11.0.tgz",
-      "integrity": "sha512-AyIxsp4eL8c22vp2oO2hSRnr3hSVNkARNZc9DG6uXxCc2Is5tUEX0I4PwxWnAx0EI44l+3zX/o414zT8yV9wwQ==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/packager-css/-/packager-css-2.12.0.tgz",
+      "integrity": "sha512-j3a/ODciaNKD19IYdWJT+TP+tnhhn5koBGBWWtrKSu0UxWpnezIGZetit3eE+Y9+NTePalMkvpIlit2eDhvfJA==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.11.0",
-        "@parcel/plugin": "2.11.0",
+        "@parcel/diagnostic": "2.12.0",
+        "@parcel/plugin": "2.12.0",
         "@parcel/source-map": "^2.1.1",
-        "@parcel/utils": "2.11.0",
+        "@parcel/utils": "2.12.0",
+        "lightningcss": "^1.22.1",
         "nullthrows": "^1.1.1"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.11.0"
+        "parcel": "^2.12.0"
       },
       "funding": {
         "type": "opencollective",
@@ -2234,20 +999,20 @@
       }
     },
     "node_modules/@parcel/packager-html": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@parcel/packager-html/-/packager-html-2.11.0.tgz",
-      "integrity": "sha512-ho5AQ70naTV8IqkKIbKtK+jsXQ5TJfFgtBvmJlyB3YydRMbIc+3g4G0xgIvf15V4uCMw9Md0Sv1W65nQXHPQoA==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/packager-html/-/packager-html-2.12.0.tgz",
+      "integrity": "sha512-PpvGB9hFFe+19NXGz2ApvPrkA9GwEqaDAninT+3pJD57OVBaxB8U+HN4a5LICKxjUppPPqmrLb6YPbD65IX4RA==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.11.0",
-        "@parcel/types": "2.11.0",
-        "@parcel/utils": "2.11.0",
+        "@parcel/plugin": "2.12.0",
+        "@parcel/types": "2.12.0",
+        "@parcel/utils": "2.12.0",
         "nullthrows": "^1.1.1",
         "posthtml": "^0.16.5"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.11.0"
+        "parcel": "^2.12.0"
       },
       "funding": {
         "type": "opencollective",
@@ -2255,23 +1020,23 @@
       }
     },
     "node_modules/@parcel/packager-js": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@parcel/packager-js/-/packager-js-2.11.0.tgz",
-      "integrity": "sha512-SxjCsd0xQfg5H73YtVJj9VOpr9s0rwMsSoeykjkatbkEla9NsZajsUkd/bfYf+/0WvEKOrB8oUBo15HkGOgKug==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/packager-js/-/packager-js-2.12.0.tgz",
+      "integrity": "sha512-viMF+FszITRRr8+2iJyk+4ruGiL27Y6AF7hQ3xbJfzqnmbOhGFtLTQwuwhOLqN/mWR2VKdgbLpZSarWaO3yAMg==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.11.0",
-        "@parcel/plugin": "2.11.0",
-        "@parcel/rust": "2.11.0",
+        "@parcel/diagnostic": "2.12.0",
+        "@parcel/plugin": "2.12.0",
+        "@parcel/rust": "2.12.0",
         "@parcel/source-map": "^2.1.1",
-        "@parcel/types": "2.11.0",
-        "@parcel/utils": "2.11.0",
+        "@parcel/types": "2.12.0",
+        "@parcel/utils": "2.12.0",
         "globals": "^13.2.0",
         "nullthrows": "^1.1.1"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.11.0"
+        "parcel": "^2.12.0"
       },
       "funding": {
         "type": "opencollective",
@@ -2279,16 +1044,16 @@
       }
     },
     "node_modules/@parcel/packager-raw": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@parcel/packager-raw/-/packager-raw-2.11.0.tgz",
-      "integrity": "sha512-2/0JQ8DZrz7cVNXwD6OYoUUtSSnlr4dsz8ZkpFDKsBJhvMHtC78Sq+1EDixDGOMiUcalSEjNsoHtkpq9uNh+Xw==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/packager-raw/-/packager-raw-2.12.0.tgz",
+      "integrity": "sha512-tJZqFbHqP24aq1F+OojFbQIc09P/u8HAW5xfndCrFnXpW4wTgM3p03P0xfw3gnNq+TtxHJ8c3UFE5LnXNNKhYA==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.11.0"
+        "@parcel/plugin": "2.12.0"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.11.0"
+        "parcel": "^2.12.0"
       },
       "funding": {
         "type": "opencollective",
@@ -2296,19 +1061,19 @@
       }
     },
     "node_modules/@parcel/packager-svg": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@parcel/packager-svg/-/packager-svg-2.11.0.tgz",
-      "integrity": "sha512-2wQBkzLwcaWFGWz8TP+bgsXgiueWPzrjKsWugWdDfq0FbXh8XVeR/599qnus3RFHZy4cH6L6yq/7zxcljtxK8A==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/packager-svg/-/packager-svg-2.12.0.tgz",
+      "integrity": "sha512-ldaGiacGb2lLqcXas97k8JiZRbAnNREmcvoY2W2dvW4loVuDT9B9fU777mbV6zODpcgcHWsLL3lYbJ5Lt3y9cg==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.11.0",
-        "@parcel/types": "2.11.0",
-        "@parcel/utils": "2.11.0",
+        "@parcel/plugin": "2.12.0",
+        "@parcel/types": "2.12.0",
+        "@parcel/utils": "2.12.0",
         "posthtml": "^0.16.4"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.11.0"
+        "parcel": "^2.12.0"
       },
       "funding": {
         "type": "opencollective",
@@ -2316,16 +1081,16 @@
       }
     },
     "node_modules/@parcel/packager-wasm": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@parcel/packager-wasm/-/packager-wasm-2.11.0.tgz",
-      "integrity": "sha512-tTy4EbDXeeiZ0oB7L2FWaHSD1mbmYZP6R5HXqkvc5dECGUKPU5Jz6ek2C5AM+HfQdQLKXPQ/Xw3eJnI/AmctVg==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/packager-wasm/-/packager-wasm-2.12.0.tgz",
+      "integrity": "sha512-fYqZzIqO9fGYveeImzF8ll6KRo2LrOXfD+2Y5U3BiX/wp9wv17dz50QLDQm9hmTcKGWxK4yWqKQh+Evp/fae7A==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.11.0"
+        "@parcel/plugin": "2.12.0"
       },
       "engines": {
         "node": ">=12.0.0",
-        "parcel": "^2.11.0"
+        "parcel": "^2.12.0"
       },
       "funding": {
         "type": "opencollective",
@@ -2333,12 +1098,12 @@
       }
     },
     "node_modules/@parcel/plugin": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@parcel/plugin/-/plugin-2.11.0.tgz",
-      "integrity": "sha512-9npuKBlhnPn7oeUpLJGecceg16GkXbvzbr6MNSZiHhkx3IBeITHQXlZnp2zAjUOFreNsYOfifwEF2S4KsARfBQ==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/plugin/-/plugin-2.12.0.tgz",
+      "integrity": "sha512-nc/uRA8DiMoe4neBbzV6kDndh/58a4wQuGKw5oEoIwBCHUvE2W8ZFSu7ollSXUGRzfacTt4NdY8TwS73ScWZ+g==",
       "dev": true,
       "dependencies": {
-        "@parcel/types": "2.11.0"
+        "@parcel/types": "2.12.0"
       },
       "engines": {
         "node": ">= 12.0.0"
@@ -2349,13 +1114,13 @@
       }
     },
     "node_modules/@parcel/profiler": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@parcel/profiler/-/profiler-2.11.0.tgz",
-      "integrity": "sha512-s10SS09prOdwnaAcjK8M5zO8o+zPJJW5oOqXPNdf6KH4NGD/ue7iOk2xM8QLw6ulSwxE7NDt++lyfW3AXgCZwg==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/profiler/-/profiler-2.12.0.tgz",
+      "integrity": "sha512-q53fvl5LDcFYzMUtSusUBZSjQrKjMlLEBgKeQHFwkimwR1mgoseaDBDuNz0XvmzDzF1UelJ02TUKCGacU8W2qA==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.11.0",
-        "@parcel/events": "2.11.0",
+        "@parcel/diagnostic": "2.12.0",
+        "@parcel/events": "2.12.0",
         "chrome-trace-event": "^1.0.2"
       },
       "engines": {
@@ -2387,373 +1152,18 @@
         "url": "https://opencollective.com/parcel"
       }
     },
-    "node_modules/@parcel/reporter-cli/node_modules/@parcel/cache": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/cache/-/cache-2.12.0.tgz",
-      "integrity": "sha512-FX5ZpTEkxvq/yvWklRHDESVRz+c7sLTXgFuzz6uEnBcXV38j6dMSikflNpHA6q/L4GKkCqRywm9R6XQwhwIMyw==",
-      "dev": true,
-      "dependencies": {
-        "@parcel/fs": "2.12.0",
-        "@parcel/logger": "2.12.0",
-        "@parcel/utils": "2.12.0",
-        "lmdb": "2.8.5"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      },
-      "peerDependencies": {
-        "@parcel/core": "^2.12.0"
-      }
-    },
-    "node_modules/@parcel/reporter-cli/node_modules/@parcel/codeframe": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/codeframe/-/codeframe-2.12.0.tgz",
-      "integrity": "sha512-v2VmneILFiHZJTxPiR7GEF1wey1/IXPdZMcUlNXBiPZyWDfcuNgGGVQkx/xW561rULLIvDPharOMdxz5oHOKQg==",
-      "dev": true,
-      "dependencies": {
-        "chalk": "^4.1.0"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/reporter-cli/node_modules/@parcel/core": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/core/-/core-2.12.0.tgz",
-      "integrity": "sha512-s+6pwEj+GfKf7vqGUzN9iSEPueUssCCQrCBUlcAfKrJe0a22hTUCjewpB0I7lNrCIULt8dkndD+sMdOrXsRl6Q==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "@mischnic/json-sourcemap": "^0.1.0",
-        "@parcel/cache": "2.12.0",
-        "@parcel/diagnostic": "2.12.0",
-        "@parcel/events": "2.12.0",
-        "@parcel/fs": "2.12.0",
-        "@parcel/graph": "3.2.0",
-        "@parcel/logger": "2.12.0",
-        "@parcel/package-manager": "2.12.0",
-        "@parcel/plugin": "2.12.0",
-        "@parcel/profiler": "2.12.0",
-        "@parcel/rust": "2.12.0",
-        "@parcel/source-map": "^2.1.1",
-        "@parcel/types": "2.12.0",
-        "@parcel/utils": "2.12.0",
-        "@parcel/workers": "2.12.0",
-        "abortcontroller-polyfill": "^1.1.9",
-        "base-x": "^3.0.8",
-        "browserslist": "^4.6.6",
-        "clone": "^2.1.1",
-        "dotenv": "^7.0.0",
-        "dotenv-expand": "^5.1.0",
-        "json5": "^2.2.0",
-        "msgpackr": "^1.9.9",
-        "nullthrows": "^1.1.1",
-        "semver": "^7.5.2"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/reporter-cli/node_modules/@parcel/diagnostic": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/diagnostic/-/diagnostic-2.12.0.tgz",
-      "integrity": "sha512-8f1NOsSFK+F4AwFCKynyIu9Kr/uWHC+SywAv4oS6Bv3Acig0gtwUjugk0C9UaB8ztBZiW5TQZhw+uPZn9T/lJA==",
-      "dev": true,
-      "dependencies": {
-        "@mischnic/json-sourcemap": "^0.1.0",
-        "nullthrows": "^1.1.1"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/reporter-cli/node_modules/@parcel/events": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/events/-/events-2.12.0.tgz",
-      "integrity": "sha512-nmAAEIKLjW1kB2cUbCYSmZOGbnGj8wCzhqnK727zCCWaA25ogzAtt657GPOeFyqW77KyosU728Tl63Fc8hphIA==",
-      "dev": true,
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/reporter-cli/node_modules/@parcel/fs": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/fs/-/fs-2.12.0.tgz",
-      "integrity": "sha512-NnFkuvou1YBtPOhTdZr44WN7I60cGyly2wpHzqRl62yhObyi1KvW0SjwOMa0QGNcBOIzp4G0CapoZ93hD0RG5Q==",
-      "dev": true,
-      "dependencies": {
-        "@parcel/rust": "2.12.0",
-        "@parcel/types": "2.12.0",
-        "@parcel/utils": "2.12.0",
-        "@parcel/watcher": "^2.0.7",
-        "@parcel/workers": "2.12.0"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      },
-      "peerDependencies": {
-        "@parcel/core": "^2.12.0"
-      }
-    },
-    "node_modules/@parcel/reporter-cli/node_modules/@parcel/graph": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@parcel/graph/-/graph-3.2.0.tgz",
-      "integrity": "sha512-xlrmCPqy58D4Fg5umV7bpwDx5Vyt7MlnQPxW68vae5+BA4GSWetfZt+Cs5dtotMG2oCHzZxhIPt7YZ7NRyQzLA==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "nullthrows": "^1.1.1"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/reporter-cli/node_modules/@parcel/logger": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.12.0.tgz",
-      "integrity": "sha512-cJ7Paqa7/9VJ7C+KwgJlwMqTQBOjjn71FbKk0G07hydUEBISU2aDfmc/52o60ErL9l+vXB26zTrIBanbxS8rVg==",
-      "dev": true,
-      "dependencies": {
-        "@parcel/diagnostic": "2.12.0",
-        "@parcel/events": "2.12.0"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/reporter-cli/node_modules/@parcel/markdown-ansi": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/markdown-ansi/-/markdown-ansi-2.12.0.tgz",
-      "integrity": "sha512-WZz3rzL8k0H3WR4qTHX6Ic8DlEs17keO9gtD4MNGyMNQbqQEvQ61lWJaIH0nAtgEetu0SOITiVqdZrb8zx/M7w==",
-      "dev": true,
-      "dependencies": {
-        "chalk": "^4.1.0"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/reporter-cli/node_modules/@parcel/node-resolver-core": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@parcel/node-resolver-core/-/node-resolver-core-3.3.0.tgz",
-      "integrity": "sha512-rhPW9DYPEIqQBSlYzz3S0AjXxjN6Ub2yS6tzzsW/4S3Gpsgk/uEq4ZfxPvoPf/6TgZndVxmKwpmxaKtGMmf3cA==",
-      "dev": true,
-      "dependencies": {
-        "@mischnic/json-sourcemap": "^0.1.0",
-        "@parcel/diagnostic": "2.12.0",
-        "@parcel/fs": "2.12.0",
-        "@parcel/rust": "2.12.0",
-        "@parcel/utils": "2.12.0",
-        "nullthrows": "^1.1.1",
-        "semver": "^7.5.2"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/reporter-cli/node_modules/@parcel/package-manager": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/package-manager/-/package-manager-2.12.0.tgz",
-      "integrity": "sha512-0nvAezcjPx9FT+hIL+LS1jb0aohwLZXct7jAh7i0MLMtehOi0z1Sau+QpgMlA9rfEZZ1LIeFdnZZwqSy7Ccspw==",
-      "dev": true,
-      "dependencies": {
-        "@parcel/diagnostic": "2.12.0",
-        "@parcel/fs": "2.12.0",
-        "@parcel/logger": "2.12.0",
-        "@parcel/node-resolver-core": "3.3.0",
-        "@parcel/types": "2.12.0",
-        "@parcel/utils": "2.12.0",
-        "@parcel/workers": "2.12.0",
-        "@swc/core": "^1.3.36",
-        "semver": "^7.5.2"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      },
-      "peerDependencies": {
-        "@parcel/core": "^2.12.0"
-      }
-    },
-    "node_modules/@parcel/reporter-cli/node_modules/@parcel/plugin": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/plugin/-/plugin-2.12.0.tgz",
-      "integrity": "sha512-nc/uRA8DiMoe4neBbzV6kDndh/58a4wQuGKw5oEoIwBCHUvE2W8ZFSu7ollSXUGRzfacTt4NdY8TwS73ScWZ+g==",
-      "dev": true,
-      "dependencies": {
-        "@parcel/types": "2.12.0"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/reporter-cli/node_modules/@parcel/profiler": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/profiler/-/profiler-2.12.0.tgz",
-      "integrity": "sha512-q53fvl5LDcFYzMUtSusUBZSjQrKjMlLEBgKeQHFwkimwR1mgoseaDBDuNz0XvmzDzF1UelJ02TUKCGacU8W2qA==",
-      "dev": true,
-      "dependencies": {
-        "@parcel/diagnostic": "2.12.0",
-        "@parcel/events": "2.12.0",
-        "chrome-trace-event": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/reporter-cli/node_modules/@parcel/rust": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/rust/-/rust-2.12.0.tgz",
-      "integrity": "sha512-005cldMdFZFDPOjbDVEXcINQ3wT4vrxvSavRWI3Az0e3E18exO/x/mW9f648KtXugOXMAqCEqhFHcXECL9nmMw==",
-      "dev": true,
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/reporter-cli/node_modules/@parcel/types": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/types/-/types-2.12.0.tgz",
-      "integrity": "sha512-8zAFiYNCwNTQcglIObyNwKfRYQK5ELlL13GuBOrSMxueUiI5ylgsGbTS1N7J3dAGZixHO8KhHGv5a71FILn9rQ==",
-      "dev": true,
-      "dependencies": {
-        "@parcel/cache": "2.12.0",
-        "@parcel/diagnostic": "2.12.0",
-        "@parcel/fs": "2.12.0",
-        "@parcel/package-manager": "2.12.0",
-        "@parcel/source-map": "^2.1.1",
-        "@parcel/workers": "2.12.0",
-        "utility-types": "^3.10.0"
-      }
-    },
-    "node_modules/@parcel/reporter-cli/node_modules/@parcel/utils": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.12.0.tgz",
-      "integrity": "sha512-z1JhLuZ8QmDaYoEIuUCVZlhcFrS7LMfHrb2OCRui5SQFntRWBH2fNM6H/fXXUkT9SkxcuFP2DUA6/m4+Gkz72g==",
-      "dev": true,
-      "dependencies": {
-        "@parcel/codeframe": "2.12.0",
-        "@parcel/diagnostic": "2.12.0",
-        "@parcel/logger": "2.12.0",
-        "@parcel/markdown-ansi": "2.12.0",
-        "@parcel/rust": "2.12.0",
-        "@parcel/source-map": "^2.1.1",
-        "chalk": "^4.1.0",
-        "nullthrows": "^1.1.1"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/reporter-cli/node_modules/@parcel/workers": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/workers/-/workers-2.12.0.tgz",
-      "integrity": "sha512-zv5We5Jmb+ZWXlU6A+AufyjY4oZckkxsZ8J4dvyWL0W8IQvGO1JB4FGeryyttzQv3RM3OxcN/BpTGPiDG6keBw==",
-      "dev": true,
-      "dependencies": {
-        "@parcel/diagnostic": "2.12.0",
-        "@parcel/logger": "2.12.0",
-        "@parcel/profiler": "2.12.0",
-        "@parcel/types": "2.12.0",
-        "@parcel/utils": "2.12.0",
-        "nullthrows": "^1.1.1"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      },
-      "peerDependencies": {
-        "@parcel/core": "^2.12.0"
-      }
-    },
-    "node_modules/@parcel/reporter-cli/node_modules/semver": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
-      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
-      "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/@parcel/reporter-dev-server": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@parcel/reporter-dev-server/-/reporter-dev-server-2.11.0.tgz",
-      "integrity": "sha512-T4ue1+oLFNdcd9maw8QWQuxzOS2kX2jOrSvYKwYd9oGnqiAr1rpiHYYKJhHng+PF5ybwWkj8dUJfGh2NoQysJA==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/reporter-dev-server/-/reporter-dev-server-2.12.0.tgz",
+      "integrity": "sha512-tIcDqRvAPAttRlTV28dHcbWT5K2r/MBFks7nM4nrEDHWtnrCwimkDmZTc1kD8QOCCjGVwRHcQybpHvxfwol6GA==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.11.0",
-        "@parcel/utils": "2.11.0"
+        "@parcel/plugin": "2.12.0",
+        "@parcel/utils": "2.12.0"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.11.0"
+        "parcel": "^2.12.0"
       },
       "funding": {
         "type": "opencollective",
@@ -2761,19 +1171,19 @@
       }
     },
     "node_modules/@parcel/reporter-tracer": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@parcel/reporter-tracer/-/reporter-tracer-2.11.0.tgz",
-      "integrity": "sha512-33q4ftO26OPWHkUpEm0bzzSjW2kHEh6q/JFePwf8W6APTQVruj4mV46+Fh6rxX42ixs92K/QoiE0gYgWZQVDHA==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/reporter-tracer/-/reporter-tracer-2.12.0.tgz",
+      "integrity": "sha512-g8rlu9GxB8Ut/F8WGx4zidIPQ4pcYFjU9bZO+fyRIPrSUFH2bKijCnbZcr4ntqzDGx74hwD6cCG4DBoleq2UlQ==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.11.0",
-        "@parcel/utils": "2.11.0",
+        "@parcel/plugin": "2.12.0",
+        "@parcel/utils": "2.12.0",
         "chrome-trace-event": "^1.0.3",
         "nullthrows": "^1.1.1"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.11.0"
+        "parcel": "^2.12.0"
       },
       "funding": {
         "type": "opencollective",
@@ -2781,17 +1191,17 @@
       }
     },
     "node_modules/@parcel/resolver-default": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@parcel/resolver-default/-/resolver-default-2.11.0.tgz",
-      "integrity": "sha512-suZNN2lE5W48LPTwAbG7gnj1IeubkCVEm0XspWXcXUtCzglimNJ8PVVBGx171o5CqDpdbGF3AqHjG9N3uOwXag==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/resolver-default/-/resolver-default-2.12.0.tgz",
+      "integrity": "sha512-uuhbajTax37TwCxu7V98JtRLiT6hzE4VYSu5B7Qkauy14/WFt2dz6GOUXPgVsED569/hkxebPx3KCMtZW6cHHA==",
       "dev": true,
       "dependencies": {
-        "@parcel/node-resolver-core": "3.2.0",
-        "@parcel/plugin": "2.11.0"
+        "@parcel/node-resolver-core": "3.3.0",
+        "@parcel/plugin": "2.12.0"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.11.0"
+        "parcel": "^2.12.0"
       },
       "funding": {
         "type": "opencollective",
@@ -2799,17 +1209,17 @@
       }
     },
     "node_modules/@parcel/runtime-browser-hmr": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@parcel/runtime-browser-hmr/-/runtime-browser-hmr-2.11.0.tgz",
-      "integrity": "sha512-uVwNBtoLMrlPHLvRS05BVhLseduMOpZT36yiIjS0YSBJcC6/otI9AY7ZiDPYmrB5xTqM0R+D554JhPaJHCuocw==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/runtime-browser-hmr/-/runtime-browser-hmr-2.12.0.tgz",
+      "integrity": "sha512-4ZLp2FWyD32r0GlTulO3+jxgsA3oO1P1b5oO2IWuWilfhcJH5LTiazpL5YdusUjtNn9PGN6QLAWfxmzRIfM+Ow==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.11.0",
-        "@parcel/utils": "2.11.0"
+        "@parcel/plugin": "2.12.0",
+        "@parcel/utils": "2.12.0"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.11.0"
+        "parcel": "^2.12.0"
       },
       "funding": {
         "type": "opencollective",
@@ -2817,19 +1227,19 @@
       }
     },
     "node_modules/@parcel/runtime-js": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@parcel/runtime-js/-/runtime-js-2.11.0.tgz",
-      "integrity": "sha512-fH3nJoexINz7s4cDzp0Vjsx0k1pMYSa5ch38LbbNqCKTermy0pS0zZuvgfLfHFFP+AMRpFQenrF7h7N3bgDmHw==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/runtime-js/-/runtime-js-2.12.0.tgz",
+      "integrity": "sha512-sBerP32Z1crX5PfLNGDSXSdqzlllM++GVnVQVeM7DgMKS8JIFG3VLi28YkX+dYYGtPypm01JoIHCkvwiZEcQJg==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.11.0",
-        "@parcel/plugin": "2.11.0",
-        "@parcel/utils": "2.11.0",
+        "@parcel/diagnostic": "2.12.0",
+        "@parcel/plugin": "2.12.0",
+        "@parcel/utils": "2.12.0",
         "nullthrows": "^1.1.1"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.11.0"
+        "parcel": "^2.12.0"
       },
       "funding": {
         "type": "opencollective",
@@ -2837,19 +1247,19 @@
       }
     },
     "node_modules/@parcel/runtime-react-refresh": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@parcel/runtime-react-refresh/-/runtime-react-refresh-2.11.0.tgz",
-      "integrity": "sha512-Kfnc7gLjhoephLMnjABrkIkzVfzPrpJlxiJFIleY2Fm57YhmCfKsEYxm3lHOutNaYl1VArW0LKClPH/VHG9vfQ==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/runtime-react-refresh/-/runtime-react-refresh-2.12.0.tgz",
+      "integrity": "sha512-SCHkcczJIDFTFdLTzrHTkQ0aTrX3xH6jrA4UsCBL6ji61+w+ohy4jEEe9qCgJVXhnJfGLE43HNXek+0MStX+Mw==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.11.0",
-        "@parcel/utils": "2.11.0",
+        "@parcel/plugin": "2.12.0",
+        "@parcel/utils": "2.12.0",
         "react-error-overlay": "6.0.9",
         "react-refresh": "^0.9.0"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.11.0"
+        "parcel": "^2.12.0"
       },
       "funding": {
         "type": "opencollective",
@@ -2857,18 +1267,18 @@
       }
     },
     "node_modules/@parcel/runtime-service-worker": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@parcel/runtime-service-worker/-/runtime-service-worker-2.11.0.tgz",
-      "integrity": "sha512-c8MaSpSbXIKuN5sA/g4UsrsH1BtBZ6Em+eSxt9AYbdPtWrW+qwCioNVZj9lugBRUzDMjVfJz0yK59nS42hABvw==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/runtime-service-worker/-/runtime-service-worker-2.12.0.tgz",
+      "integrity": "sha512-BXuMBsfiwpIEnssn+jqfC3jkgbS8oxeo3C7xhSQsuSv+AF2FwY3O3AO1c1RBskEW3XrBLNINOJujroNw80VTKA==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.11.0",
-        "@parcel/utils": "2.11.0",
+        "@parcel/plugin": "2.12.0",
+        "@parcel/utils": "2.12.0",
         "nullthrows": "^1.1.1"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.11.0"
+        "parcel": "^2.12.0"
       },
       "funding": {
         "type": "opencollective",
@@ -2876,9 +1286,9 @@
       }
     },
     "node_modules/@parcel/rust": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@parcel/rust/-/rust-2.11.0.tgz",
-      "integrity": "sha512-UkLWdHOD8Md2YmJDPsqd3yIs9chhdl/ATfV/B/xdPKGmqtNouYpDCRlq+WxMt3mLoYgHEg9UwrWLTebo2rr2iQ==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/rust/-/rust-2.12.0.tgz",
+      "integrity": "sha512-005cldMdFZFDPOjbDVEXcINQ3wT4vrxvSavRWI3Az0e3E18exO/x/mW9f648KtXugOXMAqCEqhFHcXECL9nmMw==",
       "dev": true,
       "engines": {
         "node": ">= 12.0.0"
@@ -2901,15 +1311,15 @@
       }
     },
     "node_modules/@parcel/transformer-babel": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-babel/-/transformer-babel-2.11.0.tgz",
-      "integrity": "sha512-WKGblnp7r426VG+cpeQzc6dj/30EoUaYwyl4OEaigQSJizyuPWTBWTz6FUw+ih1/sg37h+D1BIh9C2FsVzpzbw==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-babel/-/transformer-babel-2.12.0.tgz",
+      "integrity": "sha512-zQaBfOnf/l8rPxYGnsk/ufh/0EuqvmnxafjBIpKZ//j6rGylw5JCqXSb1QvvAqRYruKeccxGv7+HrxpqKU6V4A==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.11.0",
-        "@parcel/plugin": "2.11.0",
+        "@parcel/diagnostic": "2.12.0",
+        "@parcel/plugin": "2.12.0",
         "@parcel/source-map": "^2.1.1",
-        "@parcel/utils": "2.11.0",
+        "@parcel/utils": "2.12.0",
         "browserslist": "^4.6.6",
         "json5": "^2.2.0",
         "nullthrows": "^1.1.1",
@@ -2917,7 +1327,7 @@
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.11.0"
+        "parcel": "^2.12.0"
       },
       "funding": {
         "type": "opencollective",
@@ -2925,9 +1335,9 @@
       }
     },
     "node_modules/@parcel/transformer-babel/node_modules/semver": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
       "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -2940,22 +1350,22 @@
       }
     },
     "node_modules/@parcel/transformer-css": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-css/-/transformer-css-2.11.0.tgz",
-      "integrity": "sha512-nFmBulF/ErNoafO87JbVrBavjBMNwE/kahbCRVxc2Mvlphz4F4lBW4eDRS5l4xBqFJaNkHr9R55ehLBBilF4Jw==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-css/-/transformer-css-2.12.0.tgz",
+      "integrity": "sha512-vXhOqoAlQGATYyQ433Z1DXKmiKmzOAUmKysbYH3FD+LKEKLMEl/pA14goqp00TW+A/EjtSKKyeMyHlMIIUqj4Q==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.11.0",
-        "@parcel/plugin": "2.11.0",
+        "@parcel/diagnostic": "2.12.0",
+        "@parcel/plugin": "2.12.0",
         "@parcel/source-map": "^2.1.1",
-        "@parcel/utils": "2.11.0",
+        "@parcel/utils": "2.12.0",
         "browserslist": "^4.6.6",
         "lightningcss": "^1.22.1",
         "nullthrows": "^1.1.1"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.11.0"
+        "parcel": "^2.12.0"
       },
       "funding": {
         "type": "opencollective",
@@ -2963,14 +1373,14 @@
       }
     },
     "node_modules/@parcel/transformer-html": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-html/-/transformer-html-2.11.0.tgz",
-      "integrity": "sha512-90vp7mbvvfqPr9XIINpMcELtywj56f1bxfOkLQgWU1bm22H0FT3i5dqdac++2My0IGDvMwhAEjQfbn4pA579NQ==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-html/-/transformer-html-2.12.0.tgz",
+      "integrity": "sha512-5jW4dFFBlYBvIQk4nrH62rfA/G/KzVzEDa6S+Nne0xXhglLjkm64Ci9b/d4tKZfuGWUbpm2ASAq8skti/nfpXw==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.11.0",
-        "@parcel/plugin": "2.11.0",
-        "@parcel/rust": "2.11.0",
+        "@parcel/diagnostic": "2.12.0",
+        "@parcel/plugin": "2.12.0",
+        "@parcel/rust": "2.12.0",
         "nullthrows": "^1.1.1",
         "posthtml": "^0.16.5",
         "posthtml-parser": "^0.10.1",
@@ -2980,7 +1390,7 @@
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.11.0"
+        "parcel": "^2.12.0"
       },
       "funding": {
         "type": "opencollective",
@@ -2988,9 +1398,9 @@
       }
     },
     "node_modules/@parcel/transformer-html/node_modules/semver": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
       "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -3003,36 +1413,36 @@
       }
     },
     "node_modules/@parcel/transformer-image": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-image/-/transformer-image-2.11.0.tgz",
-      "integrity": "sha512-QiZj18UHf3lVFsi65Vz8YbS3ydx9Pe9x8ktMxE1oh9qpznN8lD7gE/Z9DxuTZB84EZ9pKytKwcv5WGXP25xIFg==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-image/-/transformer-image-2.12.0.tgz",
+      "integrity": "sha512-8hXrGm2IRII49R7lZ0RpmNk27EhcsH+uNKsvxuMpXPuEnWgC/ha/IrjaI29xCng1uGur74bJF43NUSQhR4aTdw==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.11.0",
-        "@parcel/utils": "2.11.0",
-        "@parcel/workers": "2.11.0",
+        "@parcel/plugin": "2.12.0",
+        "@parcel/utils": "2.12.0",
+        "@parcel/workers": "2.12.0",
         "nullthrows": "^1.1.1"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.11.0"
+        "parcel": "^2.12.0"
       },
       "peerDependencies": {
-        "@parcel/core": "^2.11.0"
+        "@parcel/core": "^2.12.0"
       }
     },
     "node_modules/@parcel/transformer-js": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-js/-/transformer-js-2.11.0.tgz",
-      "integrity": "sha512-G1sv0n8/fJqHqwUs0iVnVdmRY0Kh8kWaDkuWcU/GJBHMGhUnLXKdNwxX2Av9UdBL14bU1nTINfr9qOfnQotXWg==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-js/-/transformer-js-2.12.0.tgz",
+      "integrity": "sha512-OSZpOu+FGDbC/xivu24v092D9w6EGytB3vidwbdiJ2FaPgfV7rxS0WIUjH4I0OcvHAcitArRXL0a3+HrNTdQQw==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.11.0",
-        "@parcel/plugin": "2.11.0",
-        "@parcel/rust": "2.11.0",
+        "@parcel/diagnostic": "2.12.0",
+        "@parcel/plugin": "2.12.0",
+        "@parcel/rust": "2.12.0",
         "@parcel/source-map": "^2.1.1",
-        "@parcel/utils": "2.11.0",
-        "@parcel/workers": "2.11.0",
+        "@parcel/utils": "2.12.0",
+        "@parcel/workers": "2.12.0",
         "@swc/helpers": "^0.5.0",
         "browserslist": "^4.6.6",
         "nullthrows": "^1.1.1",
@@ -3041,20 +1451,20 @@
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.11.0"
+        "parcel": "^2.12.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
       },
       "peerDependencies": {
-        "@parcel/core": "^2.11.0"
+        "@parcel/core": "^2.12.0"
       }
     },
     "node_modules/@parcel/transformer-js/node_modules/semver": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
       "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -3067,17 +1477,17 @@
       }
     },
     "node_modules/@parcel/transformer-json": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-json/-/transformer-json-2.11.0.tgz",
-      "integrity": "sha512-Wt/wgSBaRWmPL4gpvjkV0bCBRxFOtsuLNzsm8vYA5poxTFhuLY+AoyQ8S2+xXU4VxwBfdppfIr2Ny3SwGs8xbQ==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-json/-/transformer-json-2.12.0.tgz",
+      "integrity": "sha512-Utv64GLRCQILK5r0KFs4o7I41ixMPllwOLOhkdjJKvf1hZmN6WqfOmB1YLbWS/y5Zb/iB52DU2pWZm96vLFQZQ==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.11.0",
+        "@parcel/plugin": "2.12.0",
         "json5": "^2.2.0"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.11.0"
+        "parcel": "^2.12.0"
       },
       "funding": {
         "type": "opencollective",
@@ -3103,347 +1513,31 @@
         "url": "https://opencollective.com/parcel"
       }
     },
-    "node_modules/@parcel/transformer-less/node_modules/@parcel/cache": {
+    "node_modules/@parcel/transformer-postcss": {
       "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/cache/-/cache-2.12.0.tgz",
-      "integrity": "sha512-FX5ZpTEkxvq/yvWklRHDESVRz+c7sLTXgFuzz6uEnBcXV38j6dMSikflNpHA6q/L4GKkCqRywm9R6XQwhwIMyw==",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-postcss/-/transformer-postcss-2.12.0.tgz",
+      "integrity": "sha512-FZqn+oUtiLfPOn67EZxPpBkfdFiTnF4iwiXPqvst3XI8H+iC+yNgzmtJkunOOuylpYY6NOU5jT8d7saqWSDv2Q==",
       "dev": true,
       "dependencies": {
-        "@parcel/fs": "2.12.0",
-        "@parcel/logger": "2.12.0",
-        "@parcel/utils": "2.12.0",
-        "lmdb": "2.8.5"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      },
-      "peerDependencies": {
-        "@parcel/core": "^2.12.0"
-      }
-    },
-    "node_modules/@parcel/transformer-less/node_modules/@parcel/codeframe": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/codeframe/-/codeframe-2.12.0.tgz",
-      "integrity": "sha512-v2VmneILFiHZJTxPiR7GEF1wey1/IXPdZMcUlNXBiPZyWDfcuNgGGVQkx/xW561rULLIvDPharOMdxz5oHOKQg==",
-      "dev": true,
-      "dependencies": {
-        "chalk": "^4.1.0"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/transformer-less/node_modules/@parcel/core": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/core/-/core-2.12.0.tgz",
-      "integrity": "sha512-s+6pwEj+GfKf7vqGUzN9iSEPueUssCCQrCBUlcAfKrJe0a22hTUCjewpB0I7lNrCIULt8dkndD+sMdOrXsRl6Q==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "@mischnic/json-sourcemap": "^0.1.0",
-        "@parcel/cache": "2.12.0",
         "@parcel/diagnostic": "2.12.0",
-        "@parcel/events": "2.12.0",
-        "@parcel/fs": "2.12.0",
-        "@parcel/graph": "3.2.0",
-        "@parcel/logger": "2.12.0",
-        "@parcel/package-manager": "2.12.0",
         "@parcel/plugin": "2.12.0",
-        "@parcel/profiler": "2.12.0",
         "@parcel/rust": "2.12.0",
-        "@parcel/source-map": "^2.1.1",
-        "@parcel/types": "2.12.0",
         "@parcel/utils": "2.12.0",
-        "@parcel/workers": "2.12.0",
-        "abortcontroller-polyfill": "^1.1.9",
-        "base-x": "^3.0.8",
-        "browserslist": "^4.6.6",
         "clone": "^2.1.1",
-        "dotenv": "^7.0.0",
-        "dotenv-expand": "^5.1.0",
-        "json5": "^2.2.0",
-        "msgpackr": "^1.9.9",
         "nullthrows": "^1.1.1",
+        "postcss-value-parser": "^4.2.0",
         "semver": "^7.5.2"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">= 12.0.0",
+        "parcel": "^2.12.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
       }
     },
-    "node_modules/@parcel/transformer-less/node_modules/@parcel/diagnostic": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/diagnostic/-/diagnostic-2.12.0.tgz",
-      "integrity": "sha512-8f1NOsSFK+F4AwFCKynyIu9Kr/uWHC+SywAv4oS6Bv3Acig0gtwUjugk0C9UaB8ztBZiW5TQZhw+uPZn9T/lJA==",
-      "dev": true,
-      "dependencies": {
-        "@mischnic/json-sourcemap": "^0.1.0",
-        "nullthrows": "^1.1.1"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/transformer-less/node_modules/@parcel/events": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/events/-/events-2.12.0.tgz",
-      "integrity": "sha512-nmAAEIKLjW1kB2cUbCYSmZOGbnGj8wCzhqnK727zCCWaA25ogzAtt657GPOeFyqW77KyosU728Tl63Fc8hphIA==",
-      "dev": true,
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/transformer-less/node_modules/@parcel/fs": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/fs/-/fs-2.12.0.tgz",
-      "integrity": "sha512-NnFkuvou1YBtPOhTdZr44WN7I60cGyly2wpHzqRl62yhObyi1KvW0SjwOMa0QGNcBOIzp4G0CapoZ93hD0RG5Q==",
-      "dev": true,
-      "dependencies": {
-        "@parcel/rust": "2.12.0",
-        "@parcel/types": "2.12.0",
-        "@parcel/utils": "2.12.0",
-        "@parcel/watcher": "^2.0.7",
-        "@parcel/workers": "2.12.0"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      },
-      "peerDependencies": {
-        "@parcel/core": "^2.12.0"
-      }
-    },
-    "node_modules/@parcel/transformer-less/node_modules/@parcel/graph": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@parcel/graph/-/graph-3.2.0.tgz",
-      "integrity": "sha512-xlrmCPqy58D4Fg5umV7bpwDx5Vyt7MlnQPxW68vae5+BA4GSWetfZt+Cs5dtotMG2oCHzZxhIPt7YZ7NRyQzLA==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "nullthrows": "^1.1.1"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/transformer-less/node_modules/@parcel/logger": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.12.0.tgz",
-      "integrity": "sha512-cJ7Paqa7/9VJ7C+KwgJlwMqTQBOjjn71FbKk0G07hydUEBISU2aDfmc/52o60ErL9l+vXB26zTrIBanbxS8rVg==",
-      "dev": true,
-      "dependencies": {
-        "@parcel/diagnostic": "2.12.0",
-        "@parcel/events": "2.12.0"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/transformer-less/node_modules/@parcel/markdown-ansi": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/markdown-ansi/-/markdown-ansi-2.12.0.tgz",
-      "integrity": "sha512-WZz3rzL8k0H3WR4qTHX6Ic8DlEs17keO9gtD4MNGyMNQbqQEvQ61lWJaIH0nAtgEetu0SOITiVqdZrb8zx/M7w==",
-      "dev": true,
-      "dependencies": {
-        "chalk": "^4.1.0"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/transformer-less/node_modules/@parcel/node-resolver-core": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@parcel/node-resolver-core/-/node-resolver-core-3.3.0.tgz",
-      "integrity": "sha512-rhPW9DYPEIqQBSlYzz3S0AjXxjN6Ub2yS6tzzsW/4S3Gpsgk/uEq4ZfxPvoPf/6TgZndVxmKwpmxaKtGMmf3cA==",
-      "dev": true,
-      "dependencies": {
-        "@mischnic/json-sourcemap": "^0.1.0",
-        "@parcel/diagnostic": "2.12.0",
-        "@parcel/fs": "2.12.0",
-        "@parcel/rust": "2.12.0",
-        "@parcel/utils": "2.12.0",
-        "nullthrows": "^1.1.1",
-        "semver": "^7.5.2"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/transformer-less/node_modules/@parcel/package-manager": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/package-manager/-/package-manager-2.12.0.tgz",
-      "integrity": "sha512-0nvAezcjPx9FT+hIL+LS1jb0aohwLZXct7jAh7i0MLMtehOi0z1Sau+QpgMlA9rfEZZ1LIeFdnZZwqSy7Ccspw==",
-      "dev": true,
-      "dependencies": {
-        "@parcel/diagnostic": "2.12.0",
-        "@parcel/fs": "2.12.0",
-        "@parcel/logger": "2.12.0",
-        "@parcel/node-resolver-core": "3.3.0",
-        "@parcel/types": "2.12.0",
-        "@parcel/utils": "2.12.0",
-        "@parcel/workers": "2.12.0",
-        "@swc/core": "^1.3.36",
-        "semver": "^7.5.2"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      },
-      "peerDependencies": {
-        "@parcel/core": "^2.12.0"
-      }
-    },
-    "node_modules/@parcel/transformer-less/node_modules/@parcel/plugin": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/plugin/-/plugin-2.12.0.tgz",
-      "integrity": "sha512-nc/uRA8DiMoe4neBbzV6kDndh/58a4wQuGKw5oEoIwBCHUvE2W8ZFSu7ollSXUGRzfacTt4NdY8TwS73ScWZ+g==",
-      "dev": true,
-      "dependencies": {
-        "@parcel/types": "2.12.0"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/transformer-less/node_modules/@parcel/profiler": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/profiler/-/profiler-2.12.0.tgz",
-      "integrity": "sha512-q53fvl5LDcFYzMUtSusUBZSjQrKjMlLEBgKeQHFwkimwR1mgoseaDBDuNz0XvmzDzF1UelJ02TUKCGacU8W2qA==",
-      "dev": true,
-      "dependencies": {
-        "@parcel/diagnostic": "2.12.0",
-        "@parcel/events": "2.12.0",
-        "chrome-trace-event": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/transformer-less/node_modules/@parcel/rust": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/rust/-/rust-2.12.0.tgz",
-      "integrity": "sha512-005cldMdFZFDPOjbDVEXcINQ3wT4vrxvSavRWI3Az0e3E18exO/x/mW9f648KtXugOXMAqCEqhFHcXECL9nmMw==",
-      "dev": true,
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/transformer-less/node_modules/@parcel/types": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/types/-/types-2.12.0.tgz",
-      "integrity": "sha512-8zAFiYNCwNTQcglIObyNwKfRYQK5ELlL13GuBOrSMxueUiI5ylgsGbTS1N7J3dAGZixHO8KhHGv5a71FILn9rQ==",
-      "dev": true,
-      "dependencies": {
-        "@parcel/cache": "2.12.0",
-        "@parcel/diagnostic": "2.12.0",
-        "@parcel/fs": "2.12.0",
-        "@parcel/package-manager": "2.12.0",
-        "@parcel/source-map": "^2.1.1",
-        "@parcel/workers": "2.12.0",
-        "utility-types": "^3.10.0"
-      }
-    },
-    "node_modules/@parcel/transformer-less/node_modules/@parcel/utils": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.12.0.tgz",
-      "integrity": "sha512-z1JhLuZ8QmDaYoEIuUCVZlhcFrS7LMfHrb2OCRui5SQFntRWBH2fNM6H/fXXUkT9SkxcuFP2DUA6/m4+Gkz72g==",
-      "dev": true,
-      "dependencies": {
-        "@parcel/codeframe": "2.12.0",
-        "@parcel/diagnostic": "2.12.0",
-        "@parcel/logger": "2.12.0",
-        "@parcel/markdown-ansi": "2.12.0",
-        "@parcel/rust": "2.12.0",
-        "@parcel/source-map": "^2.1.1",
-        "chalk": "^4.1.0",
-        "nullthrows": "^1.1.1"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/transformer-less/node_modules/@parcel/workers": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/workers/-/workers-2.12.0.tgz",
-      "integrity": "sha512-zv5We5Jmb+ZWXlU6A+AufyjY4oZckkxsZ8J4dvyWL0W8IQvGO1JB4FGeryyttzQv3RM3OxcN/BpTGPiDG6keBw==",
-      "dev": true,
-      "dependencies": {
-        "@parcel/diagnostic": "2.12.0",
-        "@parcel/logger": "2.12.0",
-        "@parcel/profiler": "2.12.0",
-        "@parcel/types": "2.12.0",
-        "@parcel/utils": "2.12.0",
-        "nullthrows": "^1.1.1"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      },
-      "peerDependencies": {
-        "@parcel/core": "^2.12.0"
-      }
-    },
-    "node_modules/@parcel/transformer-less/node_modules/semver": {
+    "node_modules/@parcel/transformer-postcss/node_modules/semver": {
       "version": "7.6.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
       "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
@@ -3458,53 +1552,14 @@
         "node": ">=10"
       }
     },
-    "node_modules/@parcel/transformer-postcss": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-postcss/-/transformer-postcss-2.11.0.tgz",
-      "integrity": "sha512-Ugy8XHBaUptGotsvwzq7gPCvkCopTIqqZ0JZ40Jmy9slGms8wnx06pNHA1Be/RcJwkJ2TbSu+7ncZdgmP5x5GQ==",
-      "dev": true,
-      "dependencies": {
-        "@parcel/diagnostic": "2.11.0",
-        "@parcel/plugin": "2.11.0",
-        "@parcel/rust": "2.11.0",
-        "@parcel/utils": "2.11.0",
-        "clone": "^2.1.1",
-        "nullthrows": "^1.1.1",
-        "postcss-value-parser": "^4.2.0",
-        "semver": "^7.5.2"
-      },
-      "engines": {
-        "node": ">= 12.0.0",
-        "parcel": "^2.11.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/transformer-postcss/node_modules/semver": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-      "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/@parcel/transformer-posthtml": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-posthtml/-/transformer-posthtml-2.11.0.tgz",
-      "integrity": "sha512-dMK4p1RRAoIJEjK/Wz9GOLqwHqdD/VQDhMPk+6sUKp5zf2MhSohUstpp5gKsSZivCM3PS2f8k9rgroacJ/ReuA==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-posthtml/-/transformer-posthtml-2.12.0.tgz",
+      "integrity": "sha512-z6Z7rav/pcaWdeD+2sDUcd0mmNZRUvtHaUGa50Y2mr+poxrKilpsnFMSiWBT+oOqPt7j71jzDvrdnAF4XkCljg==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.11.0",
-        "@parcel/utils": "2.11.0",
+        "@parcel/plugin": "2.12.0",
+        "@parcel/utils": "2.12.0",
         "nullthrows": "^1.1.1",
         "posthtml": "^0.16.5",
         "posthtml-parser": "^0.10.1",
@@ -3513,7 +1568,7 @@
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.11.0"
+        "parcel": "^2.12.0"
       },
       "funding": {
         "type": "opencollective",
@@ -3521,9 +1576,9 @@
       }
     },
     "node_modules/@parcel/transformer-posthtml/node_modules/semver": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
       "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -3536,16 +1591,16 @@
       }
     },
     "node_modules/@parcel/transformer-raw": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-raw/-/transformer-raw-2.11.0.tgz",
-      "integrity": "sha512-2ltp3TgS+cxEqSM1vk5gDtJrYx4KMuRRtbSgSvkdldyOgPhflnLU3/HRz72hXSNGqYOV0/JN0+ocsfPnqR00ug==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-raw/-/transformer-raw-2.12.0.tgz",
+      "integrity": "sha512-Ht1fQvXxix0NncdnmnXZsa6hra20RXYh1VqhBYZLsDfkvGGFnXIgO03Jqn4Z8MkKoa0tiNbDhpKIeTjyclbBxQ==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.11.0"
+        "@parcel/plugin": "2.12.0"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.11.0"
+        "parcel": "^2.12.0"
       },
       "funding": {
         "type": "opencollective",
@@ -3553,18 +1608,18 @@
       }
     },
     "node_modules/@parcel/transformer-react-refresh-wrap": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-react-refresh-wrap/-/transformer-react-refresh-wrap-2.11.0.tgz",
-      "integrity": "sha512-6pY0CdIgIpXC6XpsDWizf+zLgiuEsJ106HjWLwF7/R72BrvDhLPZ6jRu4UTrnd6bM89KahPw9fZZzjKoA5Efcw==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-react-refresh-wrap/-/transformer-react-refresh-wrap-2.12.0.tgz",
+      "integrity": "sha512-GE8gmP2AZtkpBIV5vSCVhewgOFRhqwdM5Q9jNPOY5PKcM3/Ff0qCqDiTzzGLhk0/VMBrdjssrfZkVx6S/lHdJw==",
       "dev": true,
       "dependencies": {
-        "@parcel/plugin": "2.11.0",
-        "@parcel/utils": "2.11.0",
+        "@parcel/plugin": "2.12.0",
+        "@parcel/utils": "2.12.0",
         "react-refresh": "^0.9.0"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.11.0"
+        "parcel": "^2.12.0"
       },
       "funding": {
         "type": "opencollective",
@@ -3572,14 +1627,14 @@
       }
     },
     "node_modules/@parcel/transformer-svg": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-svg/-/transformer-svg-2.11.0.tgz",
-      "integrity": "sha512-GrTNi04OoQSXsyrB7FqQPeYREscEXFhIBPkyQ0q7WDG/yYynWljiA0kwITCtMjPfv2EDVks292dvM3EcnERRIA==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-svg/-/transformer-svg-2.12.0.tgz",
+      "integrity": "sha512-cZJqGRJ4JNdYcb+vj94J7PdOuTnwyy45dM9xqbIMH+HSiiIkfrMsdEwYft0GTyFTdsnf+hdHn3tau7Qa5hhX+A==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.11.0",
-        "@parcel/plugin": "2.11.0",
-        "@parcel/rust": "2.11.0",
+        "@parcel/diagnostic": "2.12.0",
+        "@parcel/plugin": "2.12.0",
+        "@parcel/rust": "2.12.0",
         "nullthrows": "^1.1.1",
         "posthtml": "^0.16.5",
         "posthtml-parser": "^0.10.1",
@@ -3588,7 +1643,7 @@
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.11.0"
+        "parcel": "^2.12.0"
       },
       "funding": {
         "type": "opencollective",
@@ -3596,9 +1651,9 @@
       }
     },
     "node_modules/@parcel/transformer-svg/node_modules/semver": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
       "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -3611,31 +1666,31 @@
       }
     },
     "node_modules/@parcel/types": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@parcel/types/-/types-2.11.0.tgz",
-      "integrity": "sha512-lN5XlfV9b1s2rli8q1LqsLtu+D4ZwNI3sKmNcL/3tohSfQcF2EgF+MaiANGo9VzXOzoWFHt4dqWjO4OcdyC5tg==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/types/-/types-2.12.0.tgz",
+      "integrity": "sha512-8zAFiYNCwNTQcglIObyNwKfRYQK5ELlL13GuBOrSMxueUiI5ylgsGbTS1N7J3dAGZixHO8KhHGv5a71FILn9rQ==",
       "dev": true,
       "dependencies": {
-        "@parcel/cache": "2.11.0",
-        "@parcel/diagnostic": "2.11.0",
-        "@parcel/fs": "2.11.0",
-        "@parcel/package-manager": "2.11.0",
+        "@parcel/cache": "2.12.0",
+        "@parcel/diagnostic": "2.12.0",
+        "@parcel/fs": "2.12.0",
+        "@parcel/package-manager": "2.12.0",
         "@parcel/source-map": "^2.1.1",
-        "@parcel/workers": "2.11.0",
+        "@parcel/workers": "2.12.0",
         "utility-types": "^3.10.0"
       }
     },
     "node_modules/@parcel/utils": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.11.0.tgz",
-      "integrity": "sha512-AcL70cXlIyE7eQdvjQbYxegN5l+skqvlJllxTWg4YkIZe9p8Gmv74jLAeLWh5F+IGl5WRn0TSy9JhNJjIMQGwQ==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.12.0.tgz",
+      "integrity": "sha512-z1JhLuZ8QmDaYoEIuUCVZlhcFrS7LMfHrb2OCRui5SQFntRWBH2fNM6H/fXXUkT9SkxcuFP2DUA6/m4+Gkz72g==",
       "dev": true,
       "dependencies": {
-        "@parcel/codeframe": "2.11.0",
-        "@parcel/diagnostic": "2.11.0",
-        "@parcel/logger": "2.11.0",
-        "@parcel/markdown-ansi": "2.11.0",
-        "@parcel/rust": "2.11.0",
+        "@parcel/codeframe": "2.12.0",
+        "@parcel/diagnostic": "2.12.0",
+        "@parcel/logger": "2.12.0",
+        "@parcel/markdown-ansi": "2.12.0",
+        "@parcel/rust": "2.12.0",
         "@parcel/source-map": "^2.1.1",
         "chalk": "^4.1.0",
         "nullthrows": "^1.1.1"
@@ -3923,16 +1978,16 @@
       }
     },
     "node_modules/@parcel/workers": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@parcel/workers/-/workers-2.11.0.tgz",
-      "integrity": "sha512-wjybqdSy6Nk0N9iBGsFcp7739W2zvx0WGfVxPVShqhz46pIkPOiFF/iSn+kFu5EmMKTRWeUif42+a6rRZ7pCnQ==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/workers/-/workers-2.12.0.tgz",
+      "integrity": "sha512-zv5We5Jmb+ZWXlU6A+AufyjY4oZckkxsZ8J4dvyWL0W8IQvGO1JB4FGeryyttzQv3RM3OxcN/BpTGPiDG6keBw==",
       "dev": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.11.0",
-        "@parcel/logger": "2.11.0",
-        "@parcel/profiler": "2.11.0",
-        "@parcel/types": "2.11.0",
-        "@parcel/utils": "2.11.0",
+        "@parcel/diagnostic": "2.12.0",
+        "@parcel/logger": "2.12.0",
+        "@parcel/profiler": "2.12.0",
+        "@parcel/types": "2.12.0",
+        "@parcel/utils": "2.12.0",
         "nullthrows": "^1.1.1"
       },
       "engines": {
@@ -3943,7 +1998,7 @@
         "url": "https://opencollective.com/parcel"
       },
       "peerDependencies": {
-        "@parcel/core": "^2.11.0"
+        "@parcel/core": "^2.12.0"
       }
     },
     "node_modules/@swc/core": {
@@ -4740,18 +2795,6 @@
       "dev": true,
       "engines": {
         "node": ">=6.0"
-      }
-    },
-    "node_modules/cli-progress": {
-      "version": "3.12.0",
-      "resolved": "https://registry.npmjs.org/cli-progress/-/cli-progress-3.12.0.tgz",
-      "integrity": "sha512-tRkV3HJ1ASwm19THiiLIXLO7Im7wlTuKnvkYaTkyoAPefqjNg7W7DHKUlGRxy9vxDvbyCYQkQozvptuMkGCg8A==",
-      "dev": true,
-      "dependencies": {
-        "string-width": "^4.2.3"
-      },
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/clipboard": {
@@ -6220,9 +4263,9 @@
       }
     },
     "node_modules/lightningcss": {
-      "version": "1.22.1",
-      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.22.1.tgz",
-      "integrity": "sha512-Fy45PhibiNXkm0cK5FJCbfO8Y6jUpD/YcHf/BtuI+jvYYqSXKF4muk61jjE8YxCR9y+hDYIWSzHTc+bwhDE6rQ==",
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.24.1.tgz",
+      "integrity": "sha512-kUpHOLiH5GB0ERSv4pxqlL0RYKnOXtgGtVe7shDGfhS0AZ4D1ouKFYAcLcZhql8aMspDNzaUCumGHZ78tb2fTg==",
       "dev": true,
       "dependencies": {
         "detect-libc": "^1.0.3"
@@ -6235,21 +4278,21 @@
         "url": "https://opencollective.com/parcel"
       },
       "optionalDependencies": {
-        "lightningcss-darwin-arm64": "1.22.1",
-        "lightningcss-darwin-x64": "1.22.1",
-        "lightningcss-freebsd-x64": "1.22.1",
-        "lightningcss-linux-arm-gnueabihf": "1.22.1",
-        "lightningcss-linux-arm64-gnu": "1.22.1",
-        "lightningcss-linux-arm64-musl": "1.22.1",
-        "lightningcss-linux-x64-gnu": "1.22.1",
-        "lightningcss-linux-x64-musl": "1.22.1",
-        "lightningcss-win32-x64-msvc": "1.22.1"
+        "lightningcss-darwin-arm64": "1.24.1",
+        "lightningcss-darwin-x64": "1.24.1",
+        "lightningcss-freebsd-x64": "1.24.1",
+        "lightningcss-linux-arm-gnueabihf": "1.24.1",
+        "lightningcss-linux-arm64-gnu": "1.24.1",
+        "lightningcss-linux-arm64-musl": "1.24.1",
+        "lightningcss-linux-x64-gnu": "1.24.1",
+        "lightningcss-linux-x64-musl": "1.24.1",
+        "lightningcss-win32-x64-msvc": "1.24.1"
       }
     },
     "node_modules/lightningcss-darwin-arm64": {
-      "version": "1.22.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.22.1.tgz",
-      "integrity": "sha512-ldvElu+R0QimNTjsKpaZkUv3zf+uefzLy/R1R19jtgOfSRM+zjUCUgDhfEDRmVqJtMwYsdhMI2aJtJChPC6Osg==",
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.24.1.tgz",
+      "integrity": "sha512-1jQ12jBy+AE/73uGQWGSafK5GoWgmSiIQOGhSEXiFJSZxzV+OXIx+a9h2EYHxdJfX864M+2TAxWPWb0Vv+8y4w==",
       "cpu": [
         "arm64"
       ],
@@ -6267,9 +4310,9 @@
       }
     },
     "node_modules/lightningcss-darwin-x64": {
-      "version": "1.22.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.22.1.tgz",
-      "integrity": "sha512-5p2rnlVTv6Gpw4PlTLq925nTVh+HFh4MpegX8dPDYJae+NFVjQ67gY7O6iHIzQjLipDiYejFF0yHrhjU3XgLBQ==",
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.24.1.tgz",
+      "integrity": "sha512-R4R1d7VVdq2mG4igMU+Di8GPf0b64ZLnYVkubYnGG0Qxq1KaXQtAzcLI43EkpnoWvB/kUg8JKCWH4S13NfiLcQ==",
       "cpu": [
         "x64"
       ],
@@ -6287,9 +4330,9 @@
       }
     },
     "node_modules/lightningcss-freebsd-x64": {
-      "version": "1.22.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.22.1.tgz",
-      "integrity": "sha512-1FaBtcFrZqB2hkFbAxY//Pnp8koThvyB6AhjbdVqKD4/pu13Rl91fKt2N9qyeQPUt3xy7ORUvSO+dPk3J6EjXg==",
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.24.1.tgz",
+      "integrity": "sha512-z6NberUUw5ALES6Ixn2shmjRRrM1cmEn1ZQPiM5IrZ6xHHL5a1lPin9pRv+w6eWfcrEo+qGG6R9XfJrpuY3e4g==",
       "cpu": [
         "x64"
       ],
@@ -6307,9 +4350,9 @@
       }
     },
     "node_modules/lightningcss-linux-arm-gnueabihf": {
-      "version": "1.22.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.22.1.tgz",
-      "integrity": "sha512-6rub98tYGfE5I5j0BP8t/2d4BZyu1S7Iz9vUkm0H26snAFHYxLfj3RbQn0xHHIePSetjLnhcg3QlfwUAkD/FYg==",
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.24.1.tgz",
+      "integrity": "sha512-NLQLnBQW/0sSg74qLNI8F8QKQXkNg4/ukSTa+XhtkO7v3BnK19TS1MfCbDHt+TTdSgNEBv0tubRuapcKho2EWw==",
       "cpu": [
         "arm"
       ],
@@ -6327,9 +4370,9 @@
       }
     },
     "node_modules/lightningcss-linux-arm64-gnu": {
-      "version": "1.22.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.22.1.tgz",
-      "integrity": "sha512-nYO5qGtb/1kkTZu3FeTiM+2B2TAb7m2DkLCTgQIs2bk2o9aEs7I96fwySKcoHWQAiQDGR9sMux9vkV4KQXqPaQ==",
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.24.1.tgz",
+      "integrity": "sha512-AQxWU8c9E9JAjAi4Qw9CvX2tDIPjgzCTrZCSXKELfs4mCwzxRkHh2RCxX8sFK19RyJoJAjA/Kw8+LMNRHS5qEg==",
       "cpu": [
         "arm64"
       ],
@@ -6347,9 +4390,9 @@
       }
     },
     "node_modules/lightningcss-linux-arm64-musl": {
-      "version": "1.22.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.22.1.tgz",
-      "integrity": "sha512-MCV6RuRpzXbunvzwY644iz8cw4oQxvW7oer9xPkdadYqlEyiJJ6wl7FyJOH7Q6ZYH4yjGAUCvxDBxPbnDu9ZVg==",
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.24.1.tgz",
+      "integrity": "sha512-JCgH/SrNrhqsguUA0uJUM1PvN5+dVuzPIlXcoWDHSv2OU/BWlj2dUYr3XNzEw748SmNZPfl2NjQrAdzaPOn1lA==",
       "cpu": [
         "arm64"
       ],
@@ -6367,9 +4410,9 @@
       }
     },
     "node_modules/lightningcss-linux-x64-gnu": {
-      "version": "1.22.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.22.1.tgz",
-      "integrity": "sha512-RjNgpdM20VUXgV7us/VmlO3Vn2ZRiDnc3/bUxCVvySZWPiVPprpqW/QDWuzkGa+NCUf6saAM5CLsZLSxncXJwg==",
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.24.1.tgz",
+      "integrity": "sha512-TYdEsC63bHV0h47aNRGN3RiK7aIeco3/keN4NkoSQ5T8xk09KHuBdySltWAvKLgT8JvR+ayzq8ZHnL1wKWY0rw==",
       "cpu": [
         "x64"
       ],
@@ -6387,9 +4430,9 @@
       }
     },
     "node_modules/lightningcss-linux-x64-musl": {
-      "version": "1.22.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.22.1.tgz",
-      "integrity": "sha512-ZgO4C7Rd6Hv/5MnyY2KxOYmIlzk4rplVolDt3NbkNR8DndnyX0Q5IR4acJWNTBICQ21j3zySzKbcJaiJpk/4YA==",
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.24.1.tgz",
+      "integrity": "sha512-HLfzVik3RToot6pQ2Rgc3JhfZkGi01hFetHt40HrUMoeKitLoqUUT5owM6yTZPTytTUW9ukLBJ1pc3XNMSvlLw==",
       "cpu": [
         "x64"
       ],
@@ -6407,9 +4450,9 @@
       }
     },
     "node_modules/lightningcss-win32-x64-msvc": {
-      "version": "1.22.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.22.1.tgz",
-      "integrity": "sha512-4pozV4eyD0MDET41ZLHAeBo+H04Nm2UEYIk5w/ts40231dRFV7E0cjwbnZvSoc1DXFgecAhiC0L16ruv/ZDCpg==",
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.24.1.tgz",
+      "integrity": "sha512-joEupPjYJ7PjZtDsS5lzALtlAudAbgIBMGJPNeFe5HfdmJXFd13ECmEM+5rXNxYVMRHua2w8132R6ab5Z6K9Ow==",
       "cpu": [
         "x64"
       ],
@@ -6744,22 +4787,22 @@
       "dev": true
     },
     "node_modules/parcel": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/parcel/-/parcel-2.11.0.tgz",
-      "integrity": "sha512-H/RI1/DmuOkL8RuG/EpNPvtzrbF+7jA/R56ydEEm+lqFbYktKB4COR7JXdHkZXRgbSJyimrFB8d0r9+SaRnj0Q==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/parcel/-/parcel-2.12.0.tgz",
+      "integrity": "sha512-W+gxAq7aQ9dJIg/XLKGcRT0cvnStFAQHPaI0pvD0U2l6IVLueUAm3nwN7lkY62zZNmlvNx6jNtE4wlbS+CyqSg==",
       "dev": true,
       "dependencies": {
-        "@parcel/config-default": "2.11.0",
-        "@parcel/core": "2.11.0",
-        "@parcel/diagnostic": "2.11.0",
-        "@parcel/events": "2.11.0",
-        "@parcel/fs": "2.11.0",
-        "@parcel/logger": "2.11.0",
-        "@parcel/package-manager": "2.11.0",
-        "@parcel/reporter-cli": "2.11.0",
-        "@parcel/reporter-dev-server": "2.11.0",
-        "@parcel/reporter-tracer": "2.11.0",
-        "@parcel/utils": "2.11.0",
+        "@parcel/config-default": "2.12.0",
+        "@parcel/core": "2.12.0",
+        "@parcel/diagnostic": "2.12.0",
+        "@parcel/events": "2.12.0",
+        "@parcel/fs": "2.12.0",
+        "@parcel/logger": "2.12.0",
+        "@parcel/package-manager": "2.12.0",
+        "@parcel/reporter-cli": "2.12.0",
+        "@parcel/reporter-dev-server": "2.12.0",
+        "@parcel/reporter-tracer": "2.12.0",
+        "@parcel/utils": "2.12.0",
         "chalk": "^4.1.0",
         "commander": "^7.0.0",
         "get-port": "^4.2.0"
@@ -6793,28 +4836,6 @@
     "node_modules/parcel-resolver-theme": {
       "resolved": "local_modules/parcel-resolver-theme",
       "link": true
-    },
-    "node_modules/parcel/node_modules/@parcel/reporter-cli": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@parcel/reporter-cli/-/reporter-cli-2.11.0.tgz",
-      "integrity": "sha512-hY0iO0f+LifgJHDUIjGQJnxLFSkk2jlbfy+kIaft5oI3/IM+UljecfGO+14XH8mYlqRXXPsT09TJe8ZKQzp4ZQ==",
-      "dev": true,
-      "dependencies": {
-        "@parcel/plugin": "2.11.0",
-        "@parcel/types": "2.11.0",
-        "@parcel/utils": "2.11.0",
-        "chalk": "^4.1.0",
-        "cli-progress": "^3.12.0",
-        "term-size": "^2.2.1"
-      },
-      "engines": {
-        "node": ">= 12.0.0",
-        "parcel": "^2.11.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
     },
     "node_modules/parcel/node_modules/commander": {
       "version": "7.2.0",
@@ -7297,9 +5318,9 @@
       }
     },
     "node_modules/source-map-js": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
-      "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.0.tgz",
+      "integrity": "sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg==",
       "dev": true,
       "optional": true,
       "peer": true,
@@ -7722,65 +5743,13 @@
   },
   "dependencies": {
     "@babel/code-frame": {
-      "version": "7.23.5",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.23.5.tgz",
-      "integrity": "sha512-CgH3s1a96LipHCmSUmYFPwY7MNx8C3avkq7i4Wl3cfa662ldtUe4VM1TPXX70pfmrlWTb6jLqTYrZyT2ZTJBgA==",
+      "version": "7.24.2",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.24.2.tgz",
+      "integrity": "sha512-y5+tLQyV8pg3fsiln67BVLD1P13Eg4lh5RW9mF0zUuvLrv9uIQ4MCL+CRT+FTsBlBjcIan6PGsLcBN0m3ClUyQ==",
       "dev": true,
       "requires": {
-        "@babel/highlight": "^7.23.4",
-        "chalk": "^2.4.2"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-          "dev": true,
-          "requires": {
-            "color-convert": "^1.9.0"
-          }
-        },
-        "chalk": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
-          }
-        },
-        "color-convert": {
-          "version": "1.9.3",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-          "dev": true,
-          "requires": {
-            "color-name": "1.1.3"
-          }
-        },
-        "color-name": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-          "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-          "dev": true
-        },
-        "has-flag": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-          "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^3.0.0"
-          }
-        }
+        "@babel/highlight": "^7.24.2",
+        "picocolors": "^1.0.0"
       }
     },
     "@babel/helper-validator-identifier": {
@@ -7790,14 +5759,15 @@
       "dev": true
     },
     "@babel/highlight": {
-      "version": "7.23.4",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.23.4.tgz",
-      "integrity": "sha512-acGdbYSfp2WheJoJm/EBBBLh/ID8KDc64ISZ9DYtBmC8/Q204PZJLHyzeB5qMzJ5trcOkybd78M4x2KWsUq++A==",
+      "version": "7.24.2",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.24.2.tgz",
+      "integrity": "sha512-Yac1ao4flkTxTteCDZLEvdxg2fZfz1v8M4QpaGypq/WPDqg3ijHYbDfs+LG5hvzSoqaSZ9/Z9lKSP3CjZjv+pA==",
       "dev": true,
       "requires": {
         "@babel/helper-validator-identifier": "^7.22.20",
         "chalk": "^2.4.2",
-        "js-tokens": "^4.0.0"
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.0.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -7963,109 +5933,109 @@
       "optional": true
     },
     "@parcel/bundler-default": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@parcel/bundler-default/-/bundler-default-2.11.0.tgz",
-      "integrity": "sha512-ZIs0865Lp871ZK83k5I9L4DeeE26muNMrHa7j8bvls6fKBJKAn8djrhfU4XOLyziU4aAOobcPwXU0+npWqs52g==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/bundler-default/-/bundler-default-2.12.0.tgz",
+      "integrity": "sha512-3ybN74oYNMKyjD6V20c9Gerdbh7teeNvVMwIoHIQMzuIFT6IGX53PyOLlOKRLbjxMc0TMimQQxIt2eQqxR5LsA==",
       "dev": true,
       "requires": {
-        "@parcel/diagnostic": "2.11.0",
-        "@parcel/graph": "3.1.0",
-        "@parcel/plugin": "2.11.0",
-        "@parcel/rust": "2.11.0",
-        "@parcel/utils": "2.11.0",
+        "@parcel/diagnostic": "2.12.0",
+        "@parcel/graph": "3.2.0",
+        "@parcel/plugin": "2.12.0",
+        "@parcel/rust": "2.12.0",
+        "@parcel/utils": "2.12.0",
         "nullthrows": "^1.1.1"
       }
     },
     "@parcel/cache": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@parcel/cache/-/cache-2.11.0.tgz",
-      "integrity": "sha512-RSSkGNjO00lJPyftzaC9eaNVs4jMjPSAm0VJNWQ9JSm2n4A9BzQtTFAt1vhJOzzW1UsQvvBge9DdfkB7a2gIOw==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/cache/-/cache-2.12.0.tgz",
+      "integrity": "sha512-FX5ZpTEkxvq/yvWklRHDESVRz+c7sLTXgFuzz6uEnBcXV38j6dMSikflNpHA6q/L4GKkCqRywm9R6XQwhwIMyw==",
       "dev": true,
       "requires": {
-        "@parcel/fs": "2.11.0",
-        "@parcel/logger": "2.11.0",
-        "@parcel/utils": "2.11.0",
+        "@parcel/fs": "2.12.0",
+        "@parcel/logger": "2.12.0",
+        "@parcel/utils": "2.12.0",
         "lmdb": "2.8.5"
       }
     },
     "@parcel/codeframe": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@parcel/codeframe/-/codeframe-2.11.0.tgz",
-      "integrity": "sha512-YHs9g/i5af/sd/JrWAojU9YFbKffcJ3Tx2EJaK0ME8OJsye91UaI/3lxSUYLmJG9e4WLNJtqci8V5FBMz//ZPg==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/codeframe/-/codeframe-2.12.0.tgz",
+      "integrity": "sha512-v2VmneILFiHZJTxPiR7GEF1wey1/IXPdZMcUlNXBiPZyWDfcuNgGGVQkx/xW561rULLIvDPharOMdxz5oHOKQg==",
       "dev": true,
       "requires": {
         "chalk": "^4.1.0"
       }
     },
     "@parcel/compressor-raw": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@parcel/compressor-raw/-/compressor-raw-2.11.0.tgz",
-      "integrity": "sha512-RArhBPRTCfz77soX2IECH09NUd76UBWujXiPRcXGPIHK+C3L1cRuzsNcA39QeSb3thz3b99JcozMJ1nkC2Bsgw==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/compressor-raw/-/compressor-raw-2.12.0.tgz",
+      "integrity": "sha512-h41Q3X7ZAQ9wbQ2csP8QGrwepasLZdXiuEdpUryDce6rF9ZiHoJ97MRpdLxOhOPyASTw/xDgE1xyaPQr0Q3f5A==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.11.0"
+        "@parcel/plugin": "2.12.0"
       }
     },
     "@parcel/config-default": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@parcel/config-default/-/config-default-2.11.0.tgz",
-      "integrity": "sha512-1e2+qcZkm5/0f4eI20p/DemcYiSxq9d/eyjpTXA7PulJaHbL1wonwUAuy3mvnAvDnLOJmAk/obDVgX1ZfxMGtg==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/config-default/-/config-default-2.12.0.tgz",
+      "integrity": "sha512-dPNe2n9eEsKRc1soWIY0yToMUPirPIa2QhxcCB3Z5RjpDGIXm0pds+BaiqY6uGLEEzsjhRO0ujd4v2Rmm0vuFg==",
       "dev": true,
       "requires": {
-        "@parcel/bundler-default": "2.11.0",
-        "@parcel/compressor-raw": "2.11.0",
-        "@parcel/namer-default": "2.11.0",
-        "@parcel/optimizer-css": "2.11.0",
-        "@parcel/optimizer-htmlnano": "2.11.0",
-        "@parcel/optimizer-image": "2.11.0",
-        "@parcel/optimizer-svgo": "2.11.0",
-        "@parcel/optimizer-swc": "2.11.0",
-        "@parcel/packager-css": "2.11.0",
-        "@parcel/packager-html": "2.11.0",
-        "@parcel/packager-js": "2.11.0",
-        "@parcel/packager-raw": "2.11.0",
-        "@parcel/packager-svg": "2.11.0",
-        "@parcel/packager-wasm": "2.11.0",
-        "@parcel/reporter-dev-server": "2.11.0",
-        "@parcel/resolver-default": "2.11.0",
-        "@parcel/runtime-browser-hmr": "2.11.0",
-        "@parcel/runtime-js": "2.11.0",
-        "@parcel/runtime-react-refresh": "2.11.0",
-        "@parcel/runtime-service-worker": "2.11.0",
-        "@parcel/transformer-babel": "2.11.0",
-        "@parcel/transformer-css": "2.11.0",
-        "@parcel/transformer-html": "2.11.0",
-        "@parcel/transformer-image": "2.11.0",
-        "@parcel/transformer-js": "2.11.0",
-        "@parcel/transformer-json": "2.11.0",
-        "@parcel/transformer-postcss": "2.11.0",
-        "@parcel/transformer-posthtml": "2.11.0",
-        "@parcel/transformer-raw": "2.11.0",
-        "@parcel/transformer-react-refresh-wrap": "2.11.0",
-        "@parcel/transformer-svg": "2.11.0"
+        "@parcel/bundler-default": "2.12.0",
+        "@parcel/compressor-raw": "2.12.0",
+        "@parcel/namer-default": "2.12.0",
+        "@parcel/optimizer-css": "2.12.0",
+        "@parcel/optimizer-htmlnano": "2.12.0",
+        "@parcel/optimizer-image": "2.12.0",
+        "@parcel/optimizer-svgo": "2.12.0",
+        "@parcel/optimizer-swc": "2.12.0",
+        "@parcel/packager-css": "2.12.0",
+        "@parcel/packager-html": "2.12.0",
+        "@parcel/packager-js": "2.12.0",
+        "@parcel/packager-raw": "2.12.0",
+        "@parcel/packager-svg": "2.12.0",
+        "@parcel/packager-wasm": "2.12.0",
+        "@parcel/reporter-dev-server": "2.12.0",
+        "@parcel/resolver-default": "2.12.0",
+        "@parcel/runtime-browser-hmr": "2.12.0",
+        "@parcel/runtime-js": "2.12.0",
+        "@parcel/runtime-react-refresh": "2.12.0",
+        "@parcel/runtime-service-worker": "2.12.0",
+        "@parcel/transformer-babel": "2.12.0",
+        "@parcel/transformer-css": "2.12.0",
+        "@parcel/transformer-html": "2.12.0",
+        "@parcel/transformer-image": "2.12.0",
+        "@parcel/transformer-js": "2.12.0",
+        "@parcel/transformer-json": "2.12.0",
+        "@parcel/transformer-postcss": "2.12.0",
+        "@parcel/transformer-posthtml": "2.12.0",
+        "@parcel/transformer-raw": "2.12.0",
+        "@parcel/transformer-react-refresh-wrap": "2.12.0",
+        "@parcel/transformer-svg": "2.12.0"
       }
     },
     "@parcel/core": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@parcel/core/-/core-2.11.0.tgz",
-      "integrity": "sha512-Npe0S6hVaqWEwRL+HI7gtOYOaoE5bJQZTgUDhsDoppWbau51jOlRYOZTXuvRK/jxXnze4/S1sdM24xBYAQ5qkw==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/core/-/core-2.12.0.tgz",
+      "integrity": "sha512-s+6pwEj+GfKf7vqGUzN9iSEPueUssCCQrCBUlcAfKrJe0a22hTUCjewpB0I7lNrCIULt8dkndD+sMdOrXsRl6Q==",
       "dev": true,
       "requires": {
         "@mischnic/json-sourcemap": "^0.1.0",
-        "@parcel/cache": "2.11.0",
-        "@parcel/diagnostic": "2.11.0",
-        "@parcel/events": "2.11.0",
-        "@parcel/fs": "2.11.0",
-        "@parcel/graph": "3.1.0",
-        "@parcel/logger": "2.11.0",
-        "@parcel/package-manager": "2.11.0",
-        "@parcel/plugin": "2.11.0",
-        "@parcel/profiler": "2.11.0",
-        "@parcel/rust": "2.11.0",
+        "@parcel/cache": "2.12.0",
+        "@parcel/diagnostic": "2.12.0",
+        "@parcel/events": "2.12.0",
+        "@parcel/fs": "2.12.0",
+        "@parcel/graph": "3.2.0",
+        "@parcel/logger": "2.12.0",
+        "@parcel/package-manager": "2.12.0",
+        "@parcel/plugin": "2.12.0",
+        "@parcel/profiler": "2.12.0",
+        "@parcel/rust": "2.12.0",
         "@parcel/source-map": "^2.1.1",
-        "@parcel/types": "2.11.0",
-        "@parcel/utils": "2.11.0",
-        "@parcel/workers": "2.11.0",
+        "@parcel/types": "2.12.0",
+        "@parcel/utils": "2.12.0",
+        "@parcel/workers": "2.12.0",
         "abortcontroller-polyfill": "^1.1.9",
         "base-x": "^3.0.8",
         "browserslist": "^4.6.6",
@@ -8090,9 +6060,9 @@
       }
     },
     "@parcel/diagnostic": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@parcel/diagnostic/-/diagnostic-2.11.0.tgz",
-      "integrity": "sha512-4dJmOXVL5YGGQRRsQosQbSRONBcboB71mSwaeaEgz3pPdq9QXVPLACkGe/jTXSqa3OnAHu3g5vQLpE1g5xqBqw==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/diagnostic/-/diagnostic-2.12.0.tgz",
+      "integrity": "sha512-8f1NOsSFK+F4AwFCKynyIu9Kr/uWHC+SywAv4oS6Bv3Acig0gtwUjugk0C9UaB8ztBZiW5TQZhw+uPZn9T/lJA==",
       "dev": true,
       "requires": {
         "@mischnic/json-sourcemap": "^0.1.0",
@@ -8100,82 +6070,82 @@
       }
     },
     "@parcel/events": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@parcel/events/-/events-2.11.0.tgz",
-      "integrity": "sha512-K6SOjOrQsz1GdNl2qKBktq7KJ3Q3yxK8WXdmQYo10wG39dr051xtMb38aqieTp4eVhL8Yaq2iJgGkdr11fuBnA==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/events/-/events-2.12.0.tgz",
+      "integrity": "sha512-nmAAEIKLjW1kB2cUbCYSmZOGbnGj8wCzhqnK727zCCWaA25ogzAtt657GPOeFyqW77KyosU728Tl63Fc8hphIA==",
       "dev": true
     },
     "@parcel/fs": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@parcel/fs/-/fs-2.11.0.tgz",
-      "integrity": "sha512-zWckdnnovdrgdFX4QYuQV4bbKCsh6IYCkmwaB4yp47rhw1MP0lkBINLt4yFPHBxWXOpElCfxjL+z69c9xJQRBQ==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/fs/-/fs-2.12.0.tgz",
+      "integrity": "sha512-NnFkuvou1YBtPOhTdZr44WN7I60cGyly2wpHzqRl62yhObyi1KvW0SjwOMa0QGNcBOIzp4G0CapoZ93hD0RG5Q==",
       "dev": true,
       "requires": {
-        "@parcel/rust": "2.11.0",
-        "@parcel/types": "2.11.0",
-        "@parcel/utils": "2.11.0",
+        "@parcel/rust": "2.12.0",
+        "@parcel/types": "2.12.0",
+        "@parcel/utils": "2.12.0",
         "@parcel/watcher": "^2.0.7",
-        "@parcel/workers": "2.11.0"
+        "@parcel/workers": "2.12.0"
       }
     },
     "@parcel/graph": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@parcel/graph/-/graph-3.1.0.tgz",
-      "integrity": "sha512-d1dTW5C7A52HgDtoXlyvlET1ypSlmIxSIZOJ1xp3R9L9hgo3h1u3jHNyaoTe/WPkGVe2QnFxh0h+UibVJhu9vg==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@parcel/graph/-/graph-3.2.0.tgz",
+      "integrity": "sha512-xlrmCPqy58D4Fg5umV7bpwDx5Vyt7MlnQPxW68vae5+BA4GSWetfZt+Cs5dtotMG2oCHzZxhIPt7YZ7NRyQzLA==",
       "dev": true,
       "requires": {
         "nullthrows": "^1.1.1"
       }
     },
     "@parcel/logger": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.11.0.tgz",
-      "integrity": "sha512-HtMEdCq3LKnvv4T2CIskcqlf2gpBvHMm3pkeUFB/hc/7hW/hE1k6/HA2VOQvc0tBsaMpmEx7PCrfrH56usQSyA==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.12.0.tgz",
+      "integrity": "sha512-cJ7Paqa7/9VJ7C+KwgJlwMqTQBOjjn71FbKk0G07hydUEBISU2aDfmc/52o60ErL9l+vXB26zTrIBanbxS8rVg==",
       "dev": true,
       "requires": {
-        "@parcel/diagnostic": "2.11.0",
-        "@parcel/events": "2.11.0"
+        "@parcel/diagnostic": "2.12.0",
+        "@parcel/events": "2.12.0"
       }
     },
     "@parcel/markdown-ansi": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@parcel/markdown-ansi/-/markdown-ansi-2.11.0.tgz",
-      "integrity": "sha512-YA60EWbXi6cLOIzcwRC2wijotPauOGQbUi0vSbu0O6/mjQ68kWCMGz0hwZjDRQcPypQVJEIvTgMymLbvumxwhg==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/markdown-ansi/-/markdown-ansi-2.12.0.tgz",
+      "integrity": "sha512-WZz3rzL8k0H3WR4qTHX6Ic8DlEs17keO9gtD4MNGyMNQbqQEvQ61lWJaIH0nAtgEetu0SOITiVqdZrb8zx/M7w==",
       "dev": true,
       "requires": {
         "chalk": "^4.1.0"
       }
     },
     "@parcel/namer-default": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@parcel/namer-default/-/namer-default-2.11.0.tgz",
-      "integrity": "sha512-DEwBSKSClg4DA2xAWimYkw9bFi7MFb9TdT7/TYZStMTsfYHPWOyyjGR7aVr3Ra4wNb+XX6g4rR41yp3HD6KO7A==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/namer-default/-/namer-default-2.12.0.tgz",
+      "integrity": "sha512-9DNKPDHWgMnMtqqZIMiEj/R9PNWW16lpnlHjwK3ciRlMPgjPJ8+UNc255teZODhX0T17GOzPdGbU/O/xbxVPzA==",
       "dev": true,
       "requires": {
-        "@parcel/diagnostic": "2.11.0",
-        "@parcel/plugin": "2.11.0",
+        "@parcel/diagnostic": "2.12.0",
+        "@parcel/plugin": "2.12.0",
         "nullthrows": "^1.1.1"
       }
     },
     "@parcel/node-resolver-core": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@parcel/node-resolver-core/-/node-resolver-core-3.2.0.tgz",
-      "integrity": "sha512-XJRSxCkNbGFWjfmwFdcQZ/qlzWZd35qLtvLz2va8euGL7M5OMEQOv7dsvEhl0R+CC2zcnfFzZwxk78q6ezs8AQ==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@parcel/node-resolver-core/-/node-resolver-core-3.3.0.tgz",
+      "integrity": "sha512-rhPW9DYPEIqQBSlYzz3S0AjXxjN6Ub2yS6tzzsW/4S3Gpsgk/uEq4ZfxPvoPf/6TgZndVxmKwpmxaKtGMmf3cA==",
       "dev": true,
       "requires": {
         "@mischnic/json-sourcemap": "^0.1.0",
-        "@parcel/diagnostic": "2.11.0",
-        "@parcel/fs": "2.11.0",
-        "@parcel/rust": "2.11.0",
-        "@parcel/utils": "2.11.0",
+        "@parcel/diagnostic": "2.12.0",
+        "@parcel/fs": "2.12.0",
+        "@parcel/rust": "2.12.0",
+        "@parcel/utils": "2.12.0",
         "nullthrows": "^1.1.1",
         "semver": "^7.5.2"
       },
       "dependencies": {
         "semver": {
-          "version": "7.5.4",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-          "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+          "version": "7.6.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+          "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
           "dev": true,
           "requires": {
             "lru-cache": "^6.0.0"
@@ -8184,27 +6154,27 @@
       }
     },
     "@parcel/optimizer-css": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@parcel/optimizer-css/-/optimizer-css-2.11.0.tgz",
-      "integrity": "sha512-bV97PRxshHV3dMwOpLRgcP1QNhrVWh6VVDfm2gmWULpvsjoykcPS6vrCFksY5CpQsSvNHqJBzQjWS8FubUI76w==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/optimizer-css/-/optimizer-css-2.12.0.tgz",
+      "integrity": "sha512-ifbcC97fRzpruTjaa8axIFeX4MjjSIlQfem3EJug3L2AVqQUXnM1XO8L0NaXGNLTW2qnh1ZjIJ7vXT/QhsphsA==",
       "dev": true,
       "requires": {
-        "@parcel/diagnostic": "2.11.0",
-        "@parcel/plugin": "2.11.0",
+        "@parcel/diagnostic": "2.12.0",
+        "@parcel/plugin": "2.12.0",
         "@parcel/source-map": "^2.1.1",
-        "@parcel/utils": "2.11.0",
+        "@parcel/utils": "2.12.0",
         "browserslist": "^4.6.6",
         "lightningcss": "^1.22.1",
         "nullthrows": "^1.1.1"
       }
     },
     "@parcel/optimizer-htmlnano": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@parcel/optimizer-htmlnano/-/optimizer-htmlnano-2.11.0.tgz",
-      "integrity": "sha512-c20pz4EFF5DNFmqYgptlIj49eT6xjGLkDTdHH3RRzxKovuSXWfYSPs3GED3ZsjVuQyjNQif+/MAk9547F7hrdQ==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/optimizer-htmlnano/-/optimizer-htmlnano-2.12.0.tgz",
+      "integrity": "sha512-MfPMeCrT8FYiOrpFHVR+NcZQlXAptK2r4nGJjfT+ndPBhEEZp4yyL7n1y7HfX9geg5altc4WTb4Gug7rCoW8VQ==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.11.0",
+        "@parcel/plugin": "2.12.0",
         "htmlnano": "^2.0.0",
         "nullthrows": "^1.1.1",
         "posthtml": "^0.16.5",
@@ -8273,27 +6243,27 @@
       }
     },
     "@parcel/optimizer-image": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@parcel/optimizer-image/-/optimizer-image-2.11.0.tgz",
-      "integrity": "sha512-jCaJww5QFG2GuNzYW8nlSW+Ea+Cv47TRnOPJNquFIajgfTLJ5ddsWbaNal0GQsL8yNiCBKWd1AV4W0RH9tG0Jg==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/optimizer-image/-/optimizer-image-2.12.0.tgz",
+      "integrity": "sha512-bo1O7raeAIbRU5nmNVtx8divLW9Xqn0c57GVNGeAK4mygnQoqHqRZ0mR9uboh64pxv6ijXZHPhKvU9HEpjPjBQ==",
       "dev": true,
       "requires": {
-        "@parcel/diagnostic": "2.11.0",
-        "@parcel/plugin": "2.11.0",
-        "@parcel/rust": "2.11.0",
-        "@parcel/utils": "2.11.0",
-        "@parcel/workers": "2.11.0"
+        "@parcel/diagnostic": "2.12.0",
+        "@parcel/plugin": "2.12.0",
+        "@parcel/rust": "2.12.0",
+        "@parcel/utils": "2.12.0",
+        "@parcel/workers": "2.12.0"
       }
     },
     "@parcel/optimizer-svgo": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@parcel/optimizer-svgo/-/optimizer-svgo-2.11.0.tgz",
-      "integrity": "sha512-TQpvfBhjV2IsuFHXUolbDS6XWB3DDR2rYTlqlA8LMmuOY7jQd9Bnkl4JnapzWm/bRuzRlzdGjjVCPGL8iShFvA==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/optimizer-svgo/-/optimizer-svgo-2.12.0.tgz",
+      "integrity": "sha512-Kyli+ZZXnoonnbeRQdoWwee9Bk2jm/49xvnfb+2OO8NN0d41lblBoRhOyFiScRnJrw7eVl1Xrz7NTkXCIO7XFQ==",
       "dev": true,
       "requires": {
-        "@parcel/diagnostic": "2.11.0",
-        "@parcel/plugin": "2.11.0",
-        "@parcel/utils": "2.11.0",
+        "@parcel/diagnostic": "2.12.0",
+        "@parcel/plugin": "2.12.0",
+        "@parcel/utils": "2.12.0",
         "svgo": "^2.4.0"
       },
       "dependencies": {
@@ -8359,39 +6329,40 @@
       }
     },
     "@parcel/optimizer-swc": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@parcel/optimizer-swc/-/optimizer-swc-2.11.0.tgz",
-      "integrity": "sha512-ftf42F3JyZxJb6nnLlgNGyNQ273YOla4dFGH/tWC8iTwObHUpWe7cMbCGcrSJBvAlsLkZfLpFNAXFxUgxdKyHQ==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/optimizer-swc/-/optimizer-swc-2.12.0.tgz",
+      "integrity": "sha512-iBi6LZB3lm6WmbXfzi8J3DCVPmn4FN2lw7DGXxUXu7MouDPVWfTsM6U/5TkSHJRNRogZ2gqy5q9g34NPxHbJcw==",
       "dev": true,
       "requires": {
-        "@parcel/diagnostic": "2.11.0",
-        "@parcel/plugin": "2.11.0",
+        "@parcel/diagnostic": "2.12.0",
+        "@parcel/plugin": "2.12.0",
         "@parcel/source-map": "^2.1.1",
-        "@parcel/utils": "2.11.0",
+        "@parcel/utils": "2.12.0",
         "@swc/core": "^1.3.36",
         "nullthrows": "^1.1.1"
       }
     },
     "@parcel/package-manager": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@parcel/package-manager/-/package-manager-2.11.0.tgz",
-      "integrity": "sha512-QzdsrUYlAwIzb8by7WJjqYnbR1MoMKWbtE1MXUeYsZbFusV8B6pOH+lwqNJKS/BFtddZMRPYFueZS2N2fwzjig==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/package-manager/-/package-manager-2.12.0.tgz",
+      "integrity": "sha512-0nvAezcjPx9FT+hIL+LS1jb0aohwLZXct7jAh7i0MLMtehOi0z1Sau+QpgMlA9rfEZZ1LIeFdnZZwqSy7Ccspw==",
       "dev": true,
       "requires": {
-        "@parcel/diagnostic": "2.11.0",
-        "@parcel/fs": "2.11.0",
-        "@parcel/logger": "2.11.0",
-        "@parcel/node-resolver-core": "3.2.0",
-        "@parcel/types": "2.11.0",
-        "@parcel/utils": "2.11.0",
-        "@parcel/workers": "2.11.0",
+        "@parcel/diagnostic": "2.12.0",
+        "@parcel/fs": "2.12.0",
+        "@parcel/logger": "2.12.0",
+        "@parcel/node-resolver-core": "3.3.0",
+        "@parcel/types": "2.12.0",
+        "@parcel/utils": "2.12.0",
+        "@parcel/workers": "2.12.0",
+        "@swc/core": "^1.3.36",
         "semver": "^7.5.2"
       },
       "dependencies": {
         "semver": {
-          "version": "7.5.4",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-          "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+          "version": "7.6.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+          "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
           "dev": true,
           "requires": {
             "lru-cache": "^6.0.0"
@@ -8400,94 +6371,95 @@
       }
     },
     "@parcel/packager-css": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@parcel/packager-css/-/packager-css-2.11.0.tgz",
-      "integrity": "sha512-AyIxsp4eL8c22vp2oO2hSRnr3hSVNkARNZc9DG6uXxCc2Is5tUEX0I4PwxWnAx0EI44l+3zX/o414zT8yV9wwQ==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/packager-css/-/packager-css-2.12.0.tgz",
+      "integrity": "sha512-j3a/ODciaNKD19IYdWJT+TP+tnhhn5koBGBWWtrKSu0UxWpnezIGZetit3eE+Y9+NTePalMkvpIlit2eDhvfJA==",
       "dev": true,
       "requires": {
-        "@parcel/diagnostic": "2.11.0",
-        "@parcel/plugin": "2.11.0",
+        "@parcel/diagnostic": "2.12.0",
+        "@parcel/plugin": "2.12.0",
         "@parcel/source-map": "^2.1.1",
-        "@parcel/utils": "2.11.0",
+        "@parcel/utils": "2.12.0",
+        "lightningcss": "^1.22.1",
         "nullthrows": "^1.1.1"
       }
     },
     "@parcel/packager-html": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@parcel/packager-html/-/packager-html-2.11.0.tgz",
-      "integrity": "sha512-ho5AQ70naTV8IqkKIbKtK+jsXQ5TJfFgtBvmJlyB3YydRMbIc+3g4G0xgIvf15V4uCMw9Md0Sv1W65nQXHPQoA==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/packager-html/-/packager-html-2.12.0.tgz",
+      "integrity": "sha512-PpvGB9hFFe+19NXGz2ApvPrkA9GwEqaDAninT+3pJD57OVBaxB8U+HN4a5LICKxjUppPPqmrLb6YPbD65IX4RA==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.11.0",
-        "@parcel/types": "2.11.0",
-        "@parcel/utils": "2.11.0",
+        "@parcel/plugin": "2.12.0",
+        "@parcel/types": "2.12.0",
+        "@parcel/utils": "2.12.0",
         "nullthrows": "^1.1.1",
         "posthtml": "^0.16.5"
       }
     },
     "@parcel/packager-js": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@parcel/packager-js/-/packager-js-2.11.0.tgz",
-      "integrity": "sha512-SxjCsd0xQfg5H73YtVJj9VOpr9s0rwMsSoeykjkatbkEla9NsZajsUkd/bfYf+/0WvEKOrB8oUBo15HkGOgKug==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/packager-js/-/packager-js-2.12.0.tgz",
+      "integrity": "sha512-viMF+FszITRRr8+2iJyk+4ruGiL27Y6AF7hQ3xbJfzqnmbOhGFtLTQwuwhOLqN/mWR2VKdgbLpZSarWaO3yAMg==",
       "dev": true,
       "requires": {
-        "@parcel/diagnostic": "2.11.0",
-        "@parcel/plugin": "2.11.0",
-        "@parcel/rust": "2.11.0",
+        "@parcel/diagnostic": "2.12.0",
+        "@parcel/plugin": "2.12.0",
+        "@parcel/rust": "2.12.0",
         "@parcel/source-map": "^2.1.1",
-        "@parcel/types": "2.11.0",
-        "@parcel/utils": "2.11.0",
+        "@parcel/types": "2.12.0",
+        "@parcel/utils": "2.12.0",
         "globals": "^13.2.0",
         "nullthrows": "^1.1.1"
       }
     },
     "@parcel/packager-raw": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@parcel/packager-raw/-/packager-raw-2.11.0.tgz",
-      "integrity": "sha512-2/0JQ8DZrz7cVNXwD6OYoUUtSSnlr4dsz8ZkpFDKsBJhvMHtC78Sq+1EDixDGOMiUcalSEjNsoHtkpq9uNh+Xw==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/packager-raw/-/packager-raw-2.12.0.tgz",
+      "integrity": "sha512-tJZqFbHqP24aq1F+OojFbQIc09P/u8HAW5xfndCrFnXpW4wTgM3p03P0xfw3gnNq+TtxHJ8c3UFE5LnXNNKhYA==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.11.0"
+        "@parcel/plugin": "2.12.0"
       }
     },
     "@parcel/packager-svg": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@parcel/packager-svg/-/packager-svg-2.11.0.tgz",
-      "integrity": "sha512-2wQBkzLwcaWFGWz8TP+bgsXgiueWPzrjKsWugWdDfq0FbXh8XVeR/599qnus3RFHZy4cH6L6yq/7zxcljtxK8A==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/packager-svg/-/packager-svg-2.12.0.tgz",
+      "integrity": "sha512-ldaGiacGb2lLqcXas97k8JiZRbAnNREmcvoY2W2dvW4loVuDT9B9fU777mbV6zODpcgcHWsLL3lYbJ5Lt3y9cg==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.11.0",
-        "@parcel/types": "2.11.0",
-        "@parcel/utils": "2.11.0",
+        "@parcel/plugin": "2.12.0",
+        "@parcel/types": "2.12.0",
+        "@parcel/utils": "2.12.0",
         "posthtml": "^0.16.4"
       }
     },
     "@parcel/packager-wasm": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@parcel/packager-wasm/-/packager-wasm-2.11.0.tgz",
-      "integrity": "sha512-tTy4EbDXeeiZ0oB7L2FWaHSD1mbmYZP6R5HXqkvc5dECGUKPU5Jz6ek2C5AM+HfQdQLKXPQ/Xw3eJnI/AmctVg==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/packager-wasm/-/packager-wasm-2.12.0.tgz",
+      "integrity": "sha512-fYqZzIqO9fGYveeImzF8ll6KRo2LrOXfD+2Y5U3BiX/wp9wv17dz50QLDQm9hmTcKGWxK4yWqKQh+Evp/fae7A==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.11.0"
+        "@parcel/plugin": "2.12.0"
       }
     },
     "@parcel/plugin": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@parcel/plugin/-/plugin-2.11.0.tgz",
-      "integrity": "sha512-9npuKBlhnPn7oeUpLJGecceg16GkXbvzbr6MNSZiHhkx3IBeITHQXlZnp2zAjUOFreNsYOfifwEF2S4KsARfBQ==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/plugin/-/plugin-2.12.0.tgz",
+      "integrity": "sha512-nc/uRA8DiMoe4neBbzV6kDndh/58a4wQuGKw5oEoIwBCHUvE2W8ZFSu7ollSXUGRzfacTt4NdY8TwS73ScWZ+g==",
       "dev": true,
       "requires": {
-        "@parcel/types": "2.11.0"
+        "@parcel/types": "2.12.0"
       }
     },
     "@parcel/profiler": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@parcel/profiler/-/profiler-2.11.0.tgz",
-      "integrity": "sha512-s10SS09prOdwnaAcjK8M5zO8o+zPJJW5oOqXPNdf6KH4NGD/ue7iOk2xM8QLw6ulSwxE7NDt++lyfW3AXgCZwg==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/profiler/-/profiler-2.12.0.tgz",
+      "integrity": "sha512-q53fvl5LDcFYzMUtSusUBZSjQrKjMlLEBgKeQHFwkimwR1mgoseaDBDuNz0XvmzDzF1UelJ02TUKCGacU8W2qA==",
       "dev": true,
       "requires": {
-        "@parcel/diagnostic": "2.11.0",
-        "@parcel/events": "2.11.0",
+        "@parcel/diagnostic": "2.12.0",
+        "@parcel/events": "2.12.0",
         "chrome-trace-event": "^1.0.2"
       }
     },
@@ -8502,316 +6474,89 @@
         "@parcel/utils": "2.12.0",
         "chalk": "^4.1.0",
         "term-size": "^2.2.1"
-      },
-      "dependencies": {
-        "@parcel/cache": {
-          "version": "2.12.0",
-          "resolved": "https://registry.npmjs.org/@parcel/cache/-/cache-2.12.0.tgz",
-          "integrity": "sha512-FX5ZpTEkxvq/yvWklRHDESVRz+c7sLTXgFuzz6uEnBcXV38j6dMSikflNpHA6q/L4GKkCqRywm9R6XQwhwIMyw==",
-          "dev": true,
-          "requires": {
-            "@parcel/fs": "2.12.0",
-            "@parcel/logger": "2.12.0",
-            "@parcel/utils": "2.12.0",
-            "lmdb": "2.8.5"
-          }
-        },
-        "@parcel/codeframe": {
-          "version": "2.12.0",
-          "resolved": "https://registry.npmjs.org/@parcel/codeframe/-/codeframe-2.12.0.tgz",
-          "integrity": "sha512-v2VmneILFiHZJTxPiR7GEF1wey1/IXPdZMcUlNXBiPZyWDfcuNgGGVQkx/xW561rULLIvDPharOMdxz5oHOKQg==",
-          "dev": true,
-          "requires": {
-            "chalk": "^4.1.0"
-          }
-        },
-        "@parcel/core": {
-          "version": "2.12.0",
-          "resolved": "https://registry.npmjs.org/@parcel/core/-/core-2.12.0.tgz",
-          "integrity": "sha512-s+6pwEj+GfKf7vqGUzN9iSEPueUssCCQrCBUlcAfKrJe0a22hTUCjewpB0I7lNrCIULt8dkndD+sMdOrXsRl6Q==",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "@mischnic/json-sourcemap": "^0.1.0",
-            "@parcel/cache": "2.12.0",
-            "@parcel/diagnostic": "2.12.0",
-            "@parcel/events": "2.12.0",
-            "@parcel/fs": "2.12.0",
-            "@parcel/graph": "3.2.0",
-            "@parcel/logger": "2.12.0",
-            "@parcel/package-manager": "2.12.0",
-            "@parcel/plugin": "2.12.0",
-            "@parcel/profiler": "2.12.0",
-            "@parcel/rust": "2.12.0",
-            "@parcel/source-map": "^2.1.1",
-            "@parcel/types": "2.12.0",
-            "@parcel/utils": "2.12.0",
-            "@parcel/workers": "2.12.0",
-            "abortcontroller-polyfill": "^1.1.9",
-            "base-x": "^3.0.8",
-            "browserslist": "^4.6.6",
-            "clone": "^2.1.1",
-            "dotenv": "^7.0.0",
-            "dotenv-expand": "^5.1.0",
-            "json5": "^2.2.0",
-            "msgpackr": "^1.9.9",
-            "nullthrows": "^1.1.1",
-            "semver": "^7.5.2"
-          }
-        },
-        "@parcel/diagnostic": {
-          "version": "2.12.0",
-          "resolved": "https://registry.npmjs.org/@parcel/diagnostic/-/diagnostic-2.12.0.tgz",
-          "integrity": "sha512-8f1NOsSFK+F4AwFCKynyIu9Kr/uWHC+SywAv4oS6Bv3Acig0gtwUjugk0C9UaB8ztBZiW5TQZhw+uPZn9T/lJA==",
-          "dev": true,
-          "requires": {
-            "@mischnic/json-sourcemap": "^0.1.0",
-            "nullthrows": "^1.1.1"
-          }
-        },
-        "@parcel/events": {
-          "version": "2.12.0",
-          "resolved": "https://registry.npmjs.org/@parcel/events/-/events-2.12.0.tgz",
-          "integrity": "sha512-nmAAEIKLjW1kB2cUbCYSmZOGbnGj8wCzhqnK727zCCWaA25ogzAtt657GPOeFyqW77KyosU728Tl63Fc8hphIA==",
-          "dev": true
-        },
-        "@parcel/fs": {
-          "version": "2.12.0",
-          "resolved": "https://registry.npmjs.org/@parcel/fs/-/fs-2.12.0.tgz",
-          "integrity": "sha512-NnFkuvou1YBtPOhTdZr44WN7I60cGyly2wpHzqRl62yhObyi1KvW0SjwOMa0QGNcBOIzp4G0CapoZ93hD0RG5Q==",
-          "dev": true,
-          "requires": {
-            "@parcel/rust": "2.12.0",
-            "@parcel/types": "2.12.0",
-            "@parcel/utils": "2.12.0",
-            "@parcel/watcher": "^2.0.7",
-            "@parcel/workers": "2.12.0"
-          }
-        },
-        "@parcel/graph": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/@parcel/graph/-/graph-3.2.0.tgz",
-          "integrity": "sha512-xlrmCPqy58D4Fg5umV7bpwDx5Vyt7MlnQPxW68vae5+BA4GSWetfZt+Cs5dtotMG2oCHzZxhIPt7YZ7NRyQzLA==",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "nullthrows": "^1.1.1"
-          }
-        },
-        "@parcel/logger": {
-          "version": "2.12.0",
-          "resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.12.0.tgz",
-          "integrity": "sha512-cJ7Paqa7/9VJ7C+KwgJlwMqTQBOjjn71FbKk0G07hydUEBISU2aDfmc/52o60ErL9l+vXB26zTrIBanbxS8rVg==",
-          "dev": true,
-          "requires": {
-            "@parcel/diagnostic": "2.12.0",
-            "@parcel/events": "2.12.0"
-          }
-        },
-        "@parcel/markdown-ansi": {
-          "version": "2.12.0",
-          "resolved": "https://registry.npmjs.org/@parcel/markdown-ansi/-/markdown-ansi-2.12.0.tgz",
-          "integrity": "sha512-WZz3rzL8k0H3WR4qTHX6Ic8DlEs17keO9gtD4MNGyMNQbqQEvQ61lWJaIH0nAtgEetu0SOITiVqdZrb8zx/M7w==",
-          "dev": true,
-          "requires": {
-            "chalk": "^4.1.0"
-          }
-        },
-        "@parcel/node-resolver-core": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/@parcel/node-resolver-core/-/node-resolver-core-3.3.0.tgz",
-          "integrity": "sha512-rhPW9DYPEIqQBSlYzz3S0AjXxjN6Ub2yS6tzzsW/4S3Gpsgk/uEq4ZfxPvoPf/6TgZndVxmKwpmxaKtGMmf3cA==",
-          "dev": true,
-          "requires": {
-            "@mischnic/json-sourcemap": "^0.1.0",
-            "@parcel/diagnostic": "2.12.0",
-            "@parcel/fs": "2.12.0",
-            "@parcel/rust": "2.12.0",
-            "@parcel/utils": "2.12.0",
-            "nullthrows": "^1.1.1",
-            "semver": "^7.5.2"
-          }
-        },
-        "@parcel/package-manager": {
-          "version": "2.12.0",
-          "resolved": "https://registry.npmjs.org/@parcel/package-manager/-/package-manager-2.12.0.tgz",
-          "integrity": "sha512-0nvAezcjPx9FT+hIL+LS1jb0aohwLZXct7jAh7i0MLMtehOi0z1Sau+QpgMlA9rfEZZ1LIeFdnZZwqSy7Ccspw==",
-          "dev": true,
-          "requires": {
-            "@parcel/diagnostic": "2.12.0",
-            "@parcel/fs": "2.12.0",
-            "@parcel/logger": "2.12.0",
-            "@parcel/node-resolver-core": "3.3.0",
-            "@parcel/types": "2.12.0",
-            "@parcel/utils": "2.12.0",
-            "@parcel/workers": "2.12.0",
-            "@swc/core": "^1.3.36",
-            "semver": "^7.5.2"
-          }
-        },
-        "@parcel/plugin": {
-          "version": "2.12.0",
-          "resolved": "https://registry.npmjs.org/@parcel/plugin/-/plugin-2.12.0.tgz",
-          "integrity": "sha512-nc/uRA8DiMoe4neBbzV6kDndh/58a4wQuGKw5oEoIwBCHUvE2W8ZFSu7ollSXUGRzfacTt4NdY8TwS73ScWZ+g==",
-          "dev": true,
-          "requires": {
-            "@parcel/types": "2.12.0"
-          }
-        },
-        "@parcel/profiler": {
-          "version": "2.12.0",
-          "resolved": "https://registry.npmjs.org/@parcel/profiler/-/profiler-2.12.0.tgz",
-          "integrity": "sha512-q53fvl5LDcFYzMUtSusUBZSjQrKjMlLEBgKeQHFwkimwR1mgoseaDBDuNz0XvmzDzF1UelJ02TUKCGacU8W2qA==",
-          "dev": true,
-          "requires": {
-            "@parcel/diagnostic": "2.12.0",
-            "@parcel/events": "2.12.0",
-            "chrome-trace-event": "^1.0.2"
-          }
-        },
-        "@parcel/rust": {
-          "version": "2.12.0",
-          "resolved": "https://registry.npmjs.org/@parcel/rust/-/rust-2.12.0.tgz",
-          "integrity": "sha512-005cldMdFZFDPOjbDVEXcINQ3wT4vrxvSavRWI3Az0e3E18exO/x/mW9f648KtXugOXMAqCEqhFHcXECL9nmMw==",
-          "dev": true
-        },
-        "@parcel/types": {
-          "version": "2.12.0",
-          "resolved": "https://registry.npmjs.org/@parcel/types/-/types-2.12.0.tgz",
-          "integrity": "sha512-8zAFiYNCwNTQcglIObyNwKfRYQK5ELlL13GuBOrSMxueUiI5ylgsGbTS1N7J3dAGZixHO8KhHGv5a71FILn9rQ==",
-          "dev": true,
-          "requires": {
-            "@parcel/cache": "2.12.0",
-            "@parcel/diagnostic": "2.12.0",
-            "@parcel/fs": "2.12.0",
-            "@parcel/package-manager": "2.12.0",
-            "@parcel/source-map": "^2.1.1",
-            "@parcel/workers": "2.12.0",
-            "utility-types": "^3.10.0"
-          }
-        },
-        "@parcel/utils": {
-          "version": "2.12.0",
-          "resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.12.0.tgz",
-          "integrity": "sha512-z1JhLuZ8QmDaYoEIuUCVZlhcFrS7LMfHrb2OCRui5SQFntRWBH2fNM6H/fXXUkT9SkxcuFP2DUA6/m4+Gkz72g==",
-          "dev": true,
-          "requires": {
-            "@parcel/codeframe": "2.12.0",
-            "@parcel/diagnostic": "2.12.0",
-            "@parcel/logger": "2.12.0",
-            "@parcel/markdown-ansi": "2.12.0",
-            "@parcel/rust": "2.12.0",
-            "@parcel/source-map": "^2.1.1",
-            "chalk": "^4.1.0",
-            "nullthrows": "^1.1.1"
-          }
-        },
-        "@parcel/workers": {
-          "version": "2.12.0",
-          "resolved": "https://registry.npmjs.org/@parcel/workers/-/workers-2.12.0.tgz",
-          "integrity": "sha512-zv5We5Jmb+ZWXlU6A+AufyjY4oZckkxsZ8J4dvyWL0W8IQvGO1JB4FGeryyttzQv3RM3OxcN/BpTGPiDG6keBw==",
-          "dev": true,
-          "requires": {
-            "@parcel/diagnostic": "2.12.0",
-            "@parcel/logger": "2.12.0",
-            "@parcel/profiler": "2.12.0",
-            "@parcel/types": "2.12.0",
-            "@parcel/utils": "2.12.0",
-            "nullthrows": "^1.1.1"
-          }
-        },
-        "semver": {
-          "version": "7.6.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
-          "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
-          "dev": true,
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
-        }
       }
     },
     "@parcel/reporter-dev-server": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@parcel/reporter-dev-server/-/reporter-dev-server-2.11.0.tgz",
-      "integrity": "sha512-T4ue1+oLFNdcd9maw8QWQuxzOS2kX2jOrSvYKwYd9oGnqiAr1rpiHYYKJhHng+PF5ybwWkj8dUJfGh2NoQysJA==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/reporter-dev-server/-/reporter-dev-server-2.12.0.tgz",
+      "integrity": "sha512-tIcDqRvAPAttRlTV28dHcbWT5K2r/MBFks7nM4nrEDHWtnrCwimkDmZTc1kD8QOCCjGVwRHcQybpHvxfwol6GA==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.11.0",
-        "@parcel/utils": "2.11.0"
+        "@parcel/plugin": "2.12.0",
+        "@parcel/utils": "2.12.0"
       }
     },
     "@parcel/reporter-tracer": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@parcel/reporter-tracer/-/reporter-tracer-2.11.0.tgz",
-      "integrity": "sha512-33q4ftO26OPWHkUpEm0bzzSjW2kHEh6q/JFePwf8W6APTQVruj4mV46+Fh6rxX42ixs92K/QoiE0gYgWZQVDHA==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/reporter-tracer/-/reporter-tracer-2.12.0.tgz",
+      "integrity": "sha512-g8rlu9GxB8Ut/F8WGx4zidIPQ4pcYFjU9bZO+fyRIPrSUFH2bKijCnbZcr4ntqzDGx74hwD6cCG4DBoleq2UlQ==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.11.0",
-        "@parcel/utils": "2.11.0",
+        "@parcel/plugin": "2.12.0",
+        "@parcel/utils": "2.12.0",
         "chrome-trace-event": "^1.0.3",
         "nullthrows": "^1.1.1"
       }
     },
     "@parcel/resolver-default": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@parcel/resolver-default/-/resolver-default-2.11.0.tgz",
-      "integrity": "sha512-suZNN2lE5W48LPTwAbG7gnj1IeubkCVEm0XspWXcXUtCzglimNJ8PVVBGx171o5CqDpdbGF3AqHjG9N3uOwXag==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/resolver-default/-/resolver-default-2.12.0.tgz",
+      "integrity": "sha512-uuhbajTax37TwCxu7V98JtRLiT6hzE4VYSu5B7Qkauy14/WFt2dz6GOUXPgVsED569/hkxebPx3KCMtZW6cHHA==",
       "dev": true,
       "requires": {
-        "@parcel/node-resolver-core": "3.2.0",
-        "@parcel/plugin": "2.11.0"
+        "@parcel/node-resolver-core": "3.3.0",
+        "@parcel/plugin": "2.12.0"
       }
     },
     "@parcel/runtime-browser-hmr": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@parcel/runtime-browser-hmr/-/runtime-browser-hmr-2.11.0.tgz",
-      "integrity": "sha512-uVwNBtoLMrlPHLvRS05BVhLseduMOpZT36yiIjS0YSBJcC6/otI9AY7ZiDPYmrB5xTqM0R+D554JhPaJHCuocw==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/runtime-browser-hmr/-/runtime-browser-hmr-2.12.0.tgz",
+      "integrity": "sha512-4ZLp2FWyD32r0GlTulO3+jxgsA3oO1P1b5oO2IWuWilfhcJH5LTiazpL5YdusUjtNn9PGN6QLAWfxmzRIfM+Ow==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.11.0",
-        "@parcel/utils": "2.11.0"
+        "@parcel/plugin": "2.12.0",
+        "@parcel/utils": "2.12.0"
       }
     },
     "@parcel/runtime-js": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@parcel/runtime-js/-/runtime-js-2.11.0.tgz",
-      "integrity": "sha512-fH3nJoexINz7s4cDzp0Vjsx0k1pMYSa5ch38LbbNqCKTermy0pS0zZuvgfLfHFFP+AMRpFQenrF7h7N3bgDmHw==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/runtime-js/-/runtime-js-2.12.0.tgz",
+      "integrity": "sha512-sBerP32Z1crX5PfLNGDSXSdqzlllM++GVnVQVeM7DgMKS8JIFG3VLi28YkX+dYYGtPypm01JoIHCkvwiZEcQJg==",
       "dev": true,
       "requires": {
-        "@parcel/diagnostic": "2.11.0",
-        "@parcel/plugin": "2.11.0",
-        "@parcel/utils": "2.11.0",
+        "@parcel/diagnostic": "2.12.0",
+        "@parcel/plugin": "2.12.0",
+        "@parcel/utils": "2.12.0",
         "nullthrows": "^1.1.1"
       }
     },
     "@parcel/runtime-react-refresh": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@parcel/runtime-react-refresh/-/runtime-react-refresh-2.11.0.tgz",
-      "integrity": "sha512-Kfnc7gLjhoephLMnjABrkIkzVfzPrpJlxiJFIleY2Fm57YhmCfKsEYxm3lHOutNaYl1VArW0LKClPH/VHG9vfQ==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/runtime-react-refresh/-/runtime-react-refresh-2.12.0.tgz",
+      "integrity": "sha512-SCHkcczJIDFTFdLTzrHTkQ0aTrX3xH6jrA4UsCBL6ji61+w+ohy4jEEe9qCgJVXhnJfGLE43HNXek+0MStX+Mw==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.11.0",
-        "@parcel/utils": "2.11.0",
+        "@parcel/plugin": "2.12.0",
+        "@parcel/utils": "2.12.0",
         "react-error-overlay": "6.0.9",
         "react-refresh": "^0.9.0"
       }
     },
     "@parcel/runtime-service-worker": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@parcel/runtime-service-worker/-/runtime-service-worker-2.11.0.tgz",
-      "integrity": "sha512-c8MaSpSbXIKuN5sA/g4UsrsH1BtBZ6Em+eSxt9AYbdPtWrW+qwCioNVZj9lugBRUzDMjVfJz0yK59nS42hABvw==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/runtime-service-worker/-/runtime-service-worker-2.12.0.tgz",
+      "integrity": "sha512-BXuMBsfiwpIEnssn+jqfC3jkgbS8oxeo3C7xhSQsuSv+AF2FwY3O3AO1c1RBskEW3XrBLNINOJujroNw80VTKA==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.11.0",
-        "@parcel/utils": "2.11.0",
+        "@parcel/plugin": "2.12.0",
+        "@parcel/utils": "2.12.0",
         "nullthrows": "^1.1.1"
       }
     },
     "@parcel/rust": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@parcel/rust/-/rust-2.11.0.tgz",
-      "integrity": "sha512-UkLWdHOD8Md2YmJDPsqd3yIs9chhdl/ATfV/B/xdPKGmqtNouYpDCRlq+WxMt3mLoYgHEg9UwrWLTebo2rr2iQ==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/rust/-/rust-2.12.0.tgz",
+      "integrity": "sha512-005cldMdFZFDPOjbDVEXcINQ3wT4vrxvSavRWI3Az0e3E18exO/x/mW9f648KtXugOXMAqCEqhFHcXECL9nmMw==",
       "dev": true
     },
     "@parcel/source-map": {
@@ -8824,15 +6569,15 @@
       }
     },
     "@parcel/transformer-babel": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-babel/-/transformer-babel-2.11.0.tgz",
-      "integrity": "sha512-WKGblnp7r426VG+cpeQzc6dj/30EoUaYwyl4OEaigQSJizyuPWTBWTz6FUw+ih1/sg37h+D1BIh9C2FsVzpzbw==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-babel/-/transformer-babel-2.12.0.tgz",
+      "integrity": "sha512-zQaBfOnf/l8rPxYGnsk/ufh/0EuqvmnxafjBIpKZ//j6rGylw5JCqXSb1QvvAqRYruKeccxGv7+HrxpqKU6V4A==",
       "dev": true,
       "requires": {
-        "@parcel/diagnostic": "2.11.0",
-        "@parcel/plugin": "2.11.0",
+        "@parcel/diagnostic": "2.12.0",
+        "@parcel/plugin": "2.12.0",
         "@parcel/source-map": "^2.1.1",
-        "@parcel/utils": "2.11.0",
+        "@parcel/utils": "2.12.0",
         "browserslist": "^4.6.6",
         "json5": "^2.2.0",
         "nullthrows": "^1.1.1",
@@ -8840,9 +6585,9 @@
       },
       "dependencies": {
         "semver": {
-          "version": "7.5.4",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-          "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+          "version": "7.6.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+          "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
           "dev": true,
           "requires": {
             "lru-cache": "^6.0.0"
@@ -8851,29 +6596,29 @@
       }
     },
     "@parcel/transformer-css": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-css/-/transformer-css-2.11.0.tgz",
-      "integrity": "sha512-nFmBulF/ErNoafO87JbVrBavjBMNwE/kahbCRVxc2Mvlphz4F4lBW4eDRS5l4xBqFJaNkHr9R55ehLBBilF4Jw==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-css/-/transformer-css-2.12.0.tgz",
+      "integrity": "sha512-vXhOqoAlQGATYyQ433Z1DXKmiKmzOAUmKysbYH3FD+LKEKLMEl/pA14goqp00TW+A/EjtSKKyeMyHlMIIUqj4Q==",
       "dev": true,
       "requires": {
-        "@parcel/diagnostic": "2.11.0",
-        "@parcel/plugin": "2.11.0",
+        "@parcel/diagnostic": "2.12.0",
+        "@parcel/plugin": "2.12.0",
         "@parcel/source-map": "^2.1.1",
-        "@parcel/utils": "2.11.0",
+        "@parcel/utils": "2.12.0",
         "browserslist": "^4.6.6",
         "lightningcss": "^1.22.1",
         "nullthrows": "^1.1.1"
       }
     },
     "@parcel/transformer-html": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-html/-/transformer-html-2.11.0.tgz",
-      "integrity": "sha512-90vp7mbvvfqPr9XIINpMcELtywj56f1bxfOkLQgWU1bm22H0FT3i5dqdac++2My0IGDvMwhAEjQfbn4pA579NQ==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-html/-/transformer-html-2.12.0.tgz",
+      "integrity": "sha512-5jW4dFFBlYBvIQk4nrH62rfA/G/KzVzEDa6S+Nne0xXhglLjkm64Ci9b/d4tKZfuGWUbpm2ASAq8skti/nfpXw==",
       "dev": true,
       "requires": {
-        "@parcel/diagnostic": "2.11.0",
-        "@parcel/plugin": "2.11.0",
-        "@parcel/rust": "2.11.0",
+        "@parcel/diagnostic": "2.12.0",
+        "@parcel/plugin": "2.12.0",
+        "@parcel/rust": "2.12.0",
         "nullthrows": "^1.1.1",
         "posthtml": "^0.16.5",
         "posthtml-parser": "^0.10.1",
@@ -8883,9 +6628,9 @@
       },
       "dependencies": {
         "semver": {
-          "version": "7.5.4",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-          "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+          "version": "7.6.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+          "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
           "dev": true,
           "requires": {
             "lru-cache": "^6.0.0"
@@ -8894,29 +6639,29 @@
       }
     },
     "@parcel/transformer-image": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-image/-/transformer-image-2.11.0.tgz",
-      "integrity": "sha512-QiZj18UHf3lVFsi65Vz8YbS3ydx9Pe9x8ktMxE1oh9qpznN8lD7gE/Z9DxuTZB84EZ9pKytKwcv5WGXP25xIFg==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-image/-/transformer-image-2.12.0.tgz",
+      "integrity": "sha512-8hXrGm2IRII49R7lZ0RpmNk27EhcsH+uNKsvxuMpXPuEnWgC/ha/IrjaI29xCng1uGur74bJF43NUSQhR4aTdw==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.11.0",
-        "@parcel/utils": "2.11.0",
-        "@parcel/workers": "2.11.0",
+        "@parcel/plugin": "2.12.0",
+        "@parcel/utils": "2.12.0",
+        "@parcel/workers": "2.12.0",
         "nullthrows": "^1.1.1"
       }
     },
     "@parcel/transformer-js": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-js/-/transformer-js-2.11.0.tgz",
-      "integrity": "sha512-G1sv0n8/fJqHqwUs0iVnVdmRY0Kh8kWaDkuWcU/GJBHMGhUnLXKdNwxX2Av9UdBL14bU1nTINfr9qOfnQotXWg==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-js/-/transformer-js-2.12.0.tgz",
+      "integrity": "sha512-OSZpOu+FGDbC/xivu24v092D9w6EGytB3vidwbdiJ2FaPgfV7rxS0WIUjH4I0OcvHAcitArRXL0a3+HrNTdQQw==",
       "dev": true,
       "requires": {
-        "@parcel/diagnostic": "2.11.0",
-        "@parcel/plugin": "2.11.0",
-        "@parcel/rust": "2.11.0",
+        "@parcel/diagnostic": "2.12.0",
+        "@parcel/plugin": "2.12.0",
+        "@parcel/rust": "2.12.0",
         "@parcel/source-map": "^2.1.1",
-        "@parcel/utils": "2.11.0",
-        "@parcel/workers": "2.11.0",
+        "@parcel/utils": "2.12.0",
+        "@parcel/workers": "2.12.0",
         "@swc/helpers": "^0.5.0",
         "browserslist": "^4.6.6",
         "nullthrows": "^1.1.1",
@@ -8925,9 +6670,9 @@
       },
       "dependencies": {
         "semver": {
-          "version": "7.5.4",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-          "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+          "version": "7.6.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+          "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
           "dev": true,
           "requires": {
             "lru-cache": "^6.0.0"
@@ -8936,12 +6681,12 @@
       }
     },
     "@parcel/transformer-json": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-json/-/transformer-json-2.11.0.tgz",
-      "integrity": "sha512-Wt/wgSBaRWmPL4gpvjkV0bCBRxFOtsuLNzsm8vYA5poxTFhuLY+AoyQ8S2+xXU4VxwBfdppfIr2Ny3SwGs8xbQ==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-json/-/transformer-json-2.12.0.tgz",
+      "integrity": "sha512-Utv64GLRCQILK5r0KFs4o7I41ixMPllwOLOhkdjJKvf1hZmN6WqfOmB1YLbWS/y5Zb/iB52DU2pWZm96vLFQZQ==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.11.0",
+        "@parcel/plugin": "2.12.0",
         "json5": "^2.2.0"
       }
     },
@@ -8954,224 +6699,24 @@
         "@parcel/plugin": "2.12.0",
         "@parcel/source-map": "^2.1.1",
         "less": "^4.1.1"
+      }
+    },
+    "@parcel/transformer-postcss": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-postcss/-/transformer-postcss-2.12.0.tgz",
+      "integrity": "sha512-FZqn+oUtiLfPOn67EZxPpBkfdFiTnF4iwiXPqvst3XI8H+iC+yNgzmtJkunOOuylpYY6NOU5jT8d7saqWSDv2Q==",
+      "dev": true,
+      "requires": {
+        "@parcel/diagnostic": "2.12.0",
+        "@parcel/plugin": "2.12.0",
+        "@parcel/rust": "2.12.0",
+        "@parcel/utils": "2.12.0",
+        "clone": "^2.1.1",
+        "nullthrows": "^1.1.1",
+        "postcss-value-parser": "^4.2.0",
+        "semver": "^7.5.2"
       },
       "dependencies": {
-        "@parcel/cache": {
-          "version": "2.12.0",
-          "resolved": "https://registry.npmjs.org/@parcel/cache/-/cache-2.12.0.tgz",
-          "integrity": "sha512-FX5ZpTEkxvq/yvWklRHDESVRz+c7sLTXgFuzz6uEnBcXV38j6dMSikflNpHA6q/L4GKkCqRywm9R6XQwhwIMyw==",
-          "dev": true,
-          "requires": {
-            "@parcel/fs": "2.12.0",
-            "@parcel/logger": "2.12.0",
-            "@parcel/utils": "2.12.0",
-            "lmdb": "2.8.5"
-          }
-        },
-        "@parcel/codeframe": {
-          "version": "2.12.0",
-          "resolved": "https://registry.npmjs.org/@parcel/codeframe/-/codeframe-2.12.0.tgz",
-          "integrity": "sha512-v2VmneILFiHZJTxPiR7GEF1wey1/IXPdZMcUlNXBiPZyWDfcuNgGGVQkx/xW561rULLIvDPharOMdxz5oHOKQg==",
-          "dev": true,
-          "requires": {
-            "chalk": "^4.1.0"
-          }
-        },
-        "@parcel/core": {
-          "version": "2.12.0",
-          "resolved": "https://registry.npmjs.org/@parcel/core/-/core-2.12.0.tgz",
-          "integrity": "sha512-s+6pwEj+GfKf7vqGUzN9iSEPueUssCCQrCBUlcAfKrJe0a22hTUCjewpB0I7lNrCIULt8dkndD+sMdOrXsRl6Q==",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "@mischnic/json-sourcemap": "^0.1.0",
-            "@parcel/cache": "2.12.0",
-            "@parcel/diagnostic": "2.12.0",
-            "@parcel/events": "2.12.0",
-            "@parcel/fs": "2.12.0",
-            "@parcel/graph": "3.2.0",
-            "@parcel/logger": "2.12.0",
-            "@parcel/package-manager": "2.12.0",
-            "@parcel/plugin": "2.12.0",
-            "@parcel/profiler": "2.12.0",
-            "@parcel/rust": "2.12.0",
-            "@parcel/source-map": "^2.1.1",
-            "@parcel/types": "2.12.0",
-            "@parcel/utils": "2.12.0",
-            "@parcel/workers": "2.12.0",
-            "abortcontroller-polyfill": "^1.1.9",
-            "base-x": "^3.0.8",
-            "browserslist": "^4.6.6",
-            "clone": "^2.1.1",
-            "dotenv": "^7.0.0",
-            "dotenv-expand": "^5.1.0",
-            "json5": "^2.2.0",
-            "msgpackr": "^1.9.9",
-            "nullthrows": "^1.1.1",
-            "semver": "^7.5.2"
-          }
-        },
-        "@parcel/diagnostic": {
-          "version": "2.12.0",
-          "resolved": "https://registry.npmjs.org/@parcel/diagnostic/-/diagnostic-2.12.0.tgz",
-          "integrity": "sha512-8f1NOsSFK+F4AwFCKynyIu9Kr/uWHC+SywAv4oS6Bv3Acig0gtwUjugk0C9UaB8ztBZiW5TQZhw+uPZn9T/lJA==",
-          "dev": true,
-          "requires": {
-            "@mischnic/json-sourcemap": "^0.1.0",
-            "nullthrows": "^1.1.1"
-          }
-        },
-        "@parcel/events": {
-          "version": "2.12.0",
-          "resolved": "https://registry.npmjs.org/@parcel/events/-/events-2.12.0.tgz",
-          "integrity": "sha512-nmAAEIKLjW1kB2cUbCYSmZOGbnGj8wCzhqnK727zCCWaA25ogzAtt657GPOeFyqW77KyosU728Tl63Fc8hphIA==",
-          "dev": true
-        },
-        "@parcel/fs": {
-          "version": "2.12.0",
-          "resolved": "https://registry.npmjs.org/@parcel/fs/-/fs-2.12.0.tgz",
-          "integrity": "sha512-NnFkuvou1YBtPOhTdZr44WN7I60cGyly2wpHzqRl62yhObyi1KvW0SjwOMa0QGNcBOIzp4G0CapoZ93hD0RG5Q==",
-          "dev": true,
-          "requires": {
-            "@parcel/rust": "2.12.0",
-            "@parcel/types": "2.12.0",
-            "@parcel/utils": "2.12.0",
-            "@parcel/watcher": "^2.0.7",
-            "@parcel/workers": "2.12.0"
-          }
-        },
-        "@parcel/graph": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/@parcel/graph/-/graph-3.2.0.tgz",
-          "integrity": "sha512-xlrmCPqy58D4Fg5umV7bpwDx5Vyt7MlnQPxW68vae5+BA4GSWetfZt+Cs5dtotMG2oCHzZxhIPt7YZ7NRyQzLA==",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "nullthrows": "^1.1.1"
-          }
-        },
-        "@parcel/logger": {
-          "version": "2.12.0",
-          "resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.12.0.tgz",
-          "integrity": "sha512-cJ7Paqa7/9VJ7C+KwgJlwMqTQBOjjn71FbKk0G07hydUEBISU2aDfmc/52o60ErL9l+vXB26zTrIBanbxS8rVg==",
-          "dev": true,
-          "requires": {
-            "@parcel/diagnostic": "2.12.0",
-            "@parcel/events": "2.12.0"
-          }
-        },
-        "@parcel/markdown-ansi": {
-          "version": "2.12.0",
-          "resolved": "https://registry.npmjs.org/@parcel/markdown-ansi/-/markdown-ansi-2.12.0.tgz",
-          "integrity": "sha512-WZz3rzL8k0H3WR4qTHX6Ic8DlEs17keO9gtD4MNGyMNQbqQEvQ61lWJaIH0nAtgEetu0SOITiVqdZrb8zx/M7w==",
-          "dev": true,
-          "requires": {
-            "chalk": "^4.1.0"
-          }
-        },
-        "@parcel/node-resolver-core": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/@parcel/node-resolver-core/-/node-resolver-core-3.3.0.tgz",
-          "integrity": "sha512-rhPW9DYPEIqQBSlYzz3S0AjXxjN6Ub2yS6tzzsW/4S3Gpsgk/uEq4ZfxPvoPf/6TgZndVxmKwpmxaKtGMmf3cA==",
-          "dev": true,
-          "requires": {
-            "@mischnic/json-sourcemap": "^0.1.0",
-            "@parcel/diagnostic": "2.12.0",
-            "@parcel/fs": "2.12.0",
-            "@parcel/rust": "2.12.0",
-            "@parcel/utils": "2.12.0",
-            "nullthrows": "^1.1.1",
-            "semver": "^7.5.2"
-          }
-        },
-        "@parcel/package-manager": {
-          "version": "2.12.0",
-          "resolved": "https://registry.npmjs.org/@parcel/package-manager/-/package-manager-2.12.0.tgz",
-          "integrity": "sha512-0nvAezcjPx9FT+hIL+LS1jb0aohwLZXct7jAh7i0MLMtehOi0z1Sau+QpgMlA9rfEZZ1LIeFdnZZwqSy7Ccspw==",
-          "dev": true,
-          "requires": {
-            "@parcel/diagnostic": "2.12.0",
-            "@parcel/fs": "2.12.0",
-            "@parcel/logger": "2.12.0",
-            "@parcel/node-resolver-core": "3.3.0",
-            "@parcel/types": "2.12.0",
-            "@parcel/utils": "2.12.0",
-            "@parcel/workers": "2.12.0",
-            "@swc/core": "^1.3.36",
-            "semver": "^7.5.2"
-          }
-        },
-        "@parcel/plugin": {
-          "version": "2.12.0",
-          "resolved": "https://registry.npmjs.org/@parcel/plugin/-/plugin-2.12.0.tgz",
-          "integrity": "sha512-nc/uRA8DiMoe4neBbzV6kDndh/58a4wQuGKw5oEoIwBCHUvE2W8ZFSu7ollSXUGRzfacTt4NdY8TwS73ScWZ+g==",
-          "dev": true,
-          "requires": {
-            "@parcel/types": "2.12.0"
-          }
-        },
-        "@parcel/profiler": {
-          "version": "2.12.0",
-          "resolved": "https://registry.npmjs.org/@parcel/profiler/-/profiler-2.12.0.tgz",
-          "integrity": "sha512-q53fvl5LDcFYzMUtSusUBZSjQrKjMlLEBgKeQHFwkimwR1mgoseaDBDuNz0XvmzDzF1UelJ02TUKCGacU8W2qA==",
-          "dev": true,
-          "requires": {
-            "@parcel/diagnostic": "2.12.0",
-            "@parcel/events": "2.12.0",
-            "chrome-trace-event": "^1.0.2"
-          }
-        },
-        "@parcel/rust": {
-          "version": "2.12.0",
-          "resolved": "https://registry.npmjs.org/@parcel/rust/-/rust-2.12.0.tgz",
-          "integrity": "sha512-005cldMdFZFDPOjbDVEXcINQ3wT4vrxvSavRWI3Az0e3E18exO/x/mW9f648KtXugOXMAqCEqhFHcXECL9nmMw==",
-          "dev": true
-        },
-        "@parcel/types": {
-          "version": "2.12.0",
-          "resolved": "https://registry.npmjs.org/@parcel/types/-/types-2.12.0.tgz",
-          "integrity": "sha512-8zAFiYNCwNTQcglIObyNwKfRYQK5ELlL13GuBOrSMxueUiI5ylgsGbTS1N7J3dAGZixHO8KhHGv5a71FILn9rQ==",
-          "dev": true,
-          "requires": {
-            "@parcel/cache": "2.12.0",
-            "@parcel/diagnostic": "2.12.0",
-            "@parcel/fs": "2.12.0",
-            "@parcel/package-manager": "2.12.0",
-            "@parcel/source-map": "^2.1.1",
-            "@parcel/workers": "2.12.0",
-            "utility-types": "^3.10.0"
-          }
-        },
-        "@parcel/utils": {
-          "version": "2.12.0",
-          "resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.12.0.tgz",
-          "integrity": "sha512-z1JhLuZ8QmDaYoEIuUCVZlhcFrS7LMfHrb2OCRui5SQFntRWBH2fNM6H/fXXUkT9SkxcuFP2DUA6/m4+Gkz72g==",
-          "dev": true,
-          "requires": {
-            "@parcel/codeframe": "2.12.0",
-            "@parcel/diagnostic": "2.12.0",
-            "@parcel/logger": "2.12.0",
-            "@parcel/markdown-ansi": "2.12.0",
-            "@parcel/rust": "2.12.0",
-            "@parcel/source-map": "^2.1.1",
-            "chalk": "^4.1.0",
-            "nullthrows": "^1.1.1"
-          }
-        },
-        "@parcel/workers": {
-          "version": "2.12.0",
-          "resolved": "https://registry.npmjs.org/@parcel/workers/-/workers-2.12.0.tgz",
-          "integrity": "sha512-zv5We5Jmb+ZWXlU6A+AufyjY4oZckkxsZ8J4dvyWL0W8IQvGO1JB4FGeryyttzQv3RM3OxcN/BpTGPiDG6keBw==",
-          "dev": true,
-          "requires": {
-            "@parcel/diagnostic": "2.12.0",
-            "@parcel/logger": "2.12.0",
-            "@parcel/profiler": "2.12.0",
-            "@parcel/types": "2.12.0",
-            "@parcel/utils": "2.12.0",
-            "nullthrows": "^1.1.1"
-          }
-        },
         "semver": {
           "version": "7.6.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
@@ -9183,41 +6728,14 @@
         }
       }
     },
-    "@parcel/transformer-postcss": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-postcss/-/transformer-postcss-2.11.0.tgz",
-      "integrity": "sha512-Ugy8XHBaUptGotsvwzq7gPCvkCopTIqqZ0JZ40Jmy9slGms8wnx06pNHA1Be/RcJwkJ2TbSu+7ncZdgmP5x5GQ==",
-      "dev": true,
-      "requires": {
-        "@parcel/diagnostic": "2.11.0",
-        "@parcel/plugin": "2.11.0",
-        "@parcel/rust": "2.11.0",
-        "@parcel/utils": "2.11.0",
-        "clone": "^2.1.1",
-        "nullthrows": "^1.1.1",
-        "postcss-value-parser": "^4.2.0",
-        "semver": "^7.5.2"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "7.5.4",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-          "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-          "dev": true,
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
-        }
-      }
-    },
     "@parcel/transformer-posthtml": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-posthtml/-/transformer-posthtml-2.11.0.tgz",
-      "integrity": "sha512-dMK4p1RRAoIJEjK/Wz9GOLqwHqdD/VQDhMPk+6sUKp5zf2MhSohUstpp5gKsSZivCM3PS2f8k9rgroacJ/ReuA==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-posthtml/-/transformer-posthtml-2.12.0.tgz",
+      "integrity": "sha512-z6Z7rav/pcaWdeD+2sDUcd0mmNZRUvtHaUGa50Y2mr+poxrKilpsnFMSiWBT+oOqPt7j71jzDvrdnAF4XkCljg==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.11.0",
-        "@parcel/utils": "2.11.0",
+        "@parcel/plugin": "2.12.0",
+        "@parcel/utils": "2.12.0",
         "nullthrows": "^1.1.1",
         "posthtml": "^0.16.5",
         "posthtml-parser": "^0.10.1",
@@ -9226,9 +6744,9 @@
       },
       "dependencies": {
         "semver": {
-          "version": "7.5.4",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-          "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+          "version": "7.6.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+          "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
           "dev": true,
           "requires": {
             "lru-cache": "^6.0.0"
@@ -9237,34 +6755,34 @@
       }
     },
     "@parcel/transformer-raw": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-raw/-/transformer-raw-2.11.0.tgz",
-      "integrity": "sha512-2ltp3TgS+cxEqSM1vk5gDtJrYx4KMuRRtbSgSvkdldyOgPhflnLU3/HRz72hXSNGqYOV0/JN0+ocsfPnqR00ug==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-raw/-/transformer-raw-2.12.0.tgz",
+      "integrity": "sha512-Ht1fQvXxix0NncdnmnXZsa6hra20RXYh1VqhBYZLsDfkvGGFnXIgO03Jqn4Z8MkKoa0tiNbDhpKIeTjyclbBxQ==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.11.0"
+        "@parcel/plugin": "2.12.0"
       }
     },
     "@parcel/transformer-react-refresh-wrap": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-react-refresh-wrap/-/transformer-react-refresh-wrap-2.11.0.tgz",
-      "integrity": "sha512-6pY0CdIgIpXC6XpsDWizf+zLgiuEsJ106HjWLwF7/R72BrvDhLPZ6jRu4UTrnd6bM89KahPw9fZZzjKoA5Efcw==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-react-refresh-wrap/-/transformer-react-refresh-wrap-2.12.0.tgz",
+      "integrity": "sha512-GE8gmP2AZtkpBIV5vSCVhewgOFRhqwdM5Q9jNPOY5PKcM3/Ff0qCqDiTzzGLhk0/VMBrdjssrfZkVx6S/lHdJw==",
       "dev": true,
       "requires": {
-        "@parcel/plugin": "2.11.0",
-        "@parcel/utils": "2.11.0",
+        "@parcel/plugin": "2.12.0",
+        "@parcel/utils": "2.12.0",
         "react-refresh": "^0.9.0"
       }
     },
     "@parcel/transformer-svg": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-svg/-/transformer-svg-2.11.0.tgz",
-      "integrity": "sha512-GrTNi04OoQSXsyrB7FqQPeYREscEXFhIBPkyQ0q7WDG/yYynWljiA0kwITCtMjPfv2EDVks292dvM3EcnERRIA==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-svg/-/transformer-svg-2.12.0.tgz",
+      "integrity": "sha512-cZJqGRJ4JNdYcb+vj94J7PdOuTnwyy45dM9xqbIMH+HSiiIkfrMsdEwYft0GTyFTdsnf+hdHn3tau7Qa5hhX+A==",
       "dev": true,
       "requires": {
-        "@parcel/diagnostic": "2.11.0",
-        "@parcel/plugin": "2.11.0",
-        "@parcel/rust": "2.11.0",
+        "@parcel/diagnostic": "2.12.0",
+        "@parcel/plugin": "2.12.0",
+        "@parcel/rust": "2.12.0",
         "nullthrows": "^1.1.1",
         "posthtml": "^0.16.5",
         "posthtml-parser": "^0.10.1",
@@ -9273,9 +6791,9 @@
       },
       "dependencies": {
         "semver": {
-          "version": "7.5.4",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-          "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+          "version": "7.6.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+          "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
           "dev": true,
           "requires": {
             "lru-cache": "^6.0.0"
@@ -9284,31 +6802,31 @@
       }
     },
     "@parcel/types": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@parcel/types/-/types-2.11.0.tgz",
-      "integrity": "sha512-lN5XlfV9b1s2rli8q1LqsLtu+D4ZwNI3sKmNcL/3tohSfQcF2EgF+MaiANGo9VzXOzoWFHt4dqWjO4OcdyC5tg==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/types/-/types-2.12.0.tgz",
+      "integrity": "sha512-8zAFiYNCwNTQcglIObyNwKfRYQK5ELlL13GuBOrSMxueUiI5ylgsGbTS1N7J3dAGZixHO8KhHGv5a71FILn9rQ==",
       "dev": true,
       "requires": {
-        "@parcel/cache": "2.11.0",
-        "@parcel/diagnostic": "2.11.0",
-        "@parcel/fs": "2.11.0",
-        "@parcel/package-manager": "2.11.0",
+        "@parcel/cache": "2.12.0",
+        "@parcel/diagnostic": "2.12.0",
+        "@parcel/fs": "2.12.0",
+        "@parcel/package-manager": "2.12.0",
         "@parcel/source-map": "^2.1.1",
-        "@parcel/workers": "2.11.0",
+        "@parcel/workers": "2.12.0",
         "utility-types": "^3.10.0"
       }
     },
     "@parcel/utils": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.11.0.tgz",
-      "integrity": "sha512-AcL70cXlIyE7eQdvjQbYxegN5l+skqvlJllxTWg4YkIZe9p8Gmv74jLAeLWh5F+IGl5WRn0TSy9JhNJjIMQGwQ==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.12.0.tgz",
+      "integrity": "sha512-z1JhLuZ8QmDaYoEIuUCVZlhcFrS7LMfHrb2OCRui5SQFntRWBH2fNM6H/fXXUkT9SkxcuFP2DUA6/m4+Gkz72g==",
       "dev": true,
       "requires": {
-        "@parcel/codeframe": "2.11.0",
-        "@parcel/diagnostic": "2.11.0",
-        "@parcel/logger": "2.11.0",
-        "@parcel/markdown-ansi": "2.11.0",
-        "@parcel/rust": "2.11.0",
+        "@parcel/codeframe": "2.12.0",
+        "@parcel/diagnostic": "2.12.0",
+        "@parcel/logger": "2.12.0",
+        "@parcel/markdown-ansi": "2.12.0",
+        "@parcel/rust": "2.12.0",
         "@parcel/source-map": "^2.1.1",
         "chalk": "^4.1.0",
         "nullthrows": "^1.1.1"
@@ -9423,16 +6941,16 @@
       "optional": true
     },
     "@parcel/workers": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@parcel/workers/-/workers-2.11.0.tgz",
-      "integrity": "sha512-wjybqdSy6Nk0N9iBGsFcp7739W2zvx0WGfVxPVShqhz46pIkPOiFF/iSn+kFu5EmMKTRWeUif42+a6rRZ7pCnQ==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@parcel/workers/-/workers-2.12.0.tgz",
+      "integrity": "sha512-zv5We5Jmb+ZWXlU6A+AufyjY4oZckkxsZ8J4dvyWL0W8IQvGO1JB4FGeryyttzQv3RM3OxcN/BpTGPiDG6keBw==",
       "dev": true,
       "requires": {
-        "@parcel/diagnostic": "2.11.0",
-        "@parcel/logger": "2.11.0",
-        "@parcel/profiler": "2.11.0",
-        "@parcel/types": "2.11.0",
-        "@parcel/utils": "2.11.0",
+        "@parcel/diagnostic": "2.12.0",
+        "@parcel/logger": "2.12.0",
+        "@parcel/profiler": "2.12.0",
+        "@parcel/types": "2.12.0",
+        "@parcel/utils": "2.12.0",
         "nullthrows": "^1.1.1"
       }
     },
@@ -10019,15 +7537,6 @@
       "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.3.tgz",
       "integrity": "sha512-p3KULyQg4S7NIHixdwbGX+nFHkoBiA4YQmyWtjb8XngSKV124nJmRysgAeujbUVb15vh+RvFUfCPqU7rXk+hZg==",
       "dev": true
-    },
-    "cli-progress": {
-      "version": "3.12.0",
-      "resolved": "https://registry.npmjs.org/cli-progress/-/cli-progress-3.12.0.tgz",
-      "integrity": "sha512-tRkV3HJ1ASwm19THiiLIXLO7Im7wlTuKnvkYaTkyoAPefqjNg7W7DHKUlGRxy9vxDvbyCYQkQozvptuMkGCg8A==",
-      "dev": true,
-      "requires": {
-        "string-width": "^4.2.3"
-      }
     },
     "clipboard": {
       "version": "2.0.11",
@@ -11185,83 +8694,83 @@
       }
     },
     "lightningcss": {
-      "version": "1.22.1",
-      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.22.1.tgz",
-      "integrity": "sha512-Fy45PhibiNXkm0cK5FJCbfO8Y6jUpD/YcHf/BtuI+jvYYqSXKF4muk61jjE8YxCR9y+hDYIWSzHTc+bwhDE6rQ==",
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.24.1.tgz",
+      "integrity": "sha512-kUpHOLiH5GB0ERSv4pxqlL0RYKnOXtgGtVe7shDGfhS0AZ4D1ouKFYAcLcZhql8aMspDNzaUCumGHZ78tb2fTg==",
       "dev": true,
       "requires": {
         "detect-libc": "^1.0.3",
-        "lightningcss-darwin-arm64": "1.22.1",
-        "lightningcss-darwin-x64": "1.22.1",
-        "lightningcss-freebsd-x64": "1.22.1",
-        "lightningcss-linux-arm-gnueabihf": "1.22.1",
-        "lightningcss-linux-arm64-gnu": "1.22.1",
-        "lightningcss-linux-arm64-musl": "1.22.1",
-        "lightningcss-linux-x64-gnu": "1.22.1",
-        "lightningcss-linux-x64-musl": "1.22.1",
-        "lightningcss-win32-x64-msvc": "1.22.1"
+        "lightningcss-darwin-arm64": "1.24.1",
+        "lightningcss-darwin-x64": "1.24.1",
+        "lightningcss-freebsd-x64": "1.24.1",
+        "lightningcss-linux-arm-gnueabihf": "1.24.1",
+        "lightningcss-linux-arm64-gnu": "1.24.1",
+        "lightningcss-linux-arm64-musl": "1.24.1",
+        "lightningcss-linux-x64-gnu": "1.24.1",
+        "lightningcss-linux-x64-musl": "1.24.1",
+        "lightningcss-win32-x64-msvc": "1.24.1"
       }
     },
     "lightningcss-darwin-arm64": {
-      "version": "1.22.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.22.1.tgz",
-      "integrity": "sha512-ldvElu+R0QimNTjsKpaZkUv3zf+uefzLy/R1R19jtgOfSRM+zjUCUgDhfEDRmVqJtMwYsdhMI2aJtJChPC6Osg==",
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.24.1.tgz",
+      "integrity": "sha512-1jQ12jBy+AE/73uGQWGSafK5GoWgmSiIQOGhSEXiFJSZxzV+OXIx+a9h2EYHxdJfX864M+2TAxWPWb0Vv+8y4w==",
       "dev": true,
       "optional": true
     },
     "lightningcss-darwin-x64": {
-      "version": "1.22.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.22.1.tgz",
-      "integrity": "sha512-5p2rnlVTv6Gpw4PlTLq925nTVh+HFh4MpegX8dPDYJae+NFVjQ67gY7O6iHIzQjLipDiYejFF0yHrhjU3XgLBQ==",
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.24.1.tgz",
+      "integrity": "sha512-R4R1d7VVdq2mG4igMU+Di8GPf0b64ZLnYVkubYnGG0Qxq1KaXQtAzcLI43EkpnoWvB/kUg8JKCWH4S13NfiLcQ==",
       "dev": true,
       "optional": true
     },
     "lightningcss-freebsd-x64": {
-      "version": "1.22.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.22.1.tgz",
-      "integrity": "sha512-1FaBtcFrZqB2hkFbAxY//Pnp8koThvyB6AhjbdVqKD4/pu13Rl91fKt2N9qyeQPUt3xy7ORUvSO+dPk3J6EjXg==",
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.24.1.tgz",
+      "integrity": "sha512-z6NberUUw5ALES6Ixn2shmjRRrM1cmEn1ZQPiM5IrZ6xHHL5a1lPin9pRv+w6eWfcrEo+qGG6R9XfJrpuY3e4g==",
       "dev": true,
       "optional": true
     },
     "lightningcss-linux-arm-gnueabihf": {
-      "version": "1.22.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.22.1.tgz",
-      "integrity": "sha512-6rub98tYGfE5I5j0BP8t/2d4BZyu1S7Iz9vUkm0H26snAFHYxLfj3RbQn0xHHIePSetjLnhcg3QlfwUAkD/FYg==",
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.24.1.tgz",
+      "integrity": "sha512-NLQLnBQW/0sSg74qLNI8F8QKQXkNg4/ukSTa+XhtkO7v3BnK19TS1MfCbDHt+TTdSgNEBv0tubRuapcKho2EWw==",
       "dev": true,
       "optional": true
     },
     "lightningcss-linux-arm64-gnu": {
-      "version": "1.22.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.22.1.tgz",
-      "integrity": "sha512-nYO5qGtb/1kkTZu3FeTiM+2B2TAb7m2DkLCTgQIs2bk2o9aEs7I96fwySKcoHWQAiQDGR9sMux9vkV4KQXqPaQ==",
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.24.1.tgz",
+      "integrity": "sha512-AQxWU8c9E9JAjAi4Qw9CvX2tDIPjgzCTrZCSXKELfs4mCwzxRkHh2RCxX8sFK19RyJoJAjA/Kw8+LMNRHS5qEg==",
       "dev": true,
       "optional": true
     },
     "lightningcss-linux-arm64-musl": {
-      "version": "1.22.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.22.1.tgz",
-      "integrity": "sha512-MCV6RuRpzXbunvzwY644iz8cw4oQxvW7oer9xPkdadYqlEyiJJ6wl7FyJOH7Q6ZYH4yjGAUCvxDBxPbnDu9ZVg==",
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.24.1.tgz",
+      "integrity": "sha512-JCgH/SrNrhqsguUA0uJUM1PvN5+dVuzPIlXcoWDHSv2OU/BWlj2dUYr3XNzEw748SmNZPfl2NjQrAdzaPOn1lA==",
       "dev": true,
       "optional": true
     },
     "lightningcss-linux-x64-gnu": {
-      "version": "1.22.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.22.1.tgz",
-      "integrity": "sha512-RjNgpdM20VUXgV7us/VmlO3Vn2ZRiDnc3/bUxCVvySZWPiVPprpqW/QDWuzkGa+NCUf6saAM5CLsZLSxncXJwg==",
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.24.1.tgz",
+      "integrity": "sha512-TYdEsC63bHV0h47aNRGN3RiK7aIeco3/keN4NkoSQ5T8xk09KHuBdySltWAvKLgT8JvR+ayzq8ZHnL1wKWY0rw==",
       "dev": true,
       "optional": true
     },
     "lightningcss-linux-x64-musl": {
-      "version": "1.22.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.22.1.tgz",
-      "integrity": "sha512-ZgO4C7Rd6Hv/5MnyY2KxOYmIlzk4rplVolDt3NbkNR8DndnyX0Q5IR4acJWNTBICQ21j3zySzKbcJaiJpk/4YA==",
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.24.1.tgz",
+      "integrity": "sha512-HLfzVik3RToot6pQ2Rgc3JhfZkGi01hFetHt40HrUMoeKitLoqUUT5owM6yTZPTytTUW9ukLBJ1pc3XNMSvlLw==",
       "dev": true,
       "optional": true
     },
     "lightningcss-win32-x64-msvc": {
-      "version": "1.22.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.22.1.tgz",
-      "integrity": "sha512-4pozV4eyD0MDET41ZLHAeBo+H04Nm2UEYIk5w/ts40231dRFV7E0cjwbnZvSoc1DXFgecAhiC0L16ruv/ZDCpg==",
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.24.1.tgz",
+      "integrity": "sha512-joEupPjYJ7PjZtDsS5lzALtlAudAbgIBMGJPNeFe5HfdmJXFd13ECmEM+5rXNxYVMRHua2w8132R6ab5Z6K9Ow==",
       "dev": true,
       "optional": true
     },
@@ -11516,41 +9025,27 @@
       "dev": true
     },
     "parcel": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/parcel/-/parcel-2.11.0.tgz",
-      "integrity": "sha512-H/RI1/DmuOkL8RuG/EpNPvtzrbF+7jA/R56ydEEm+lqFbYktKB4COR7JXdHkZXRgbSJyimrFB8d0r9+SaRnj0Q==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/parcel/-/parcel-2.12.0.tgz",
+      "integrity": "sha512-W+gxAq7aQ9dJIg/XLKGcRT0cvnStFAQHPaI0pvD0U2l6IVLueUAm3nwN7lkY62zZNmlvNx6jNtE4wlbS+CyqSg==",
       "dev": true,
       "requires": {
-        "@parcel/config-default": "2.11.0",
-        "@parcel/core": "2.11.0",
-        "@parcel/diagnostic": "2.11.0",
-        "@parcel/events": "2.11.0",
-        "@parcel/fs": "2.11.0",
-        "@parcel/logger": "2.11.0",
-        "@parcel/package-manager": "2.11.0",
-        "@parcel/reporter-cli": "2.11.0",
-        "@parcel/reporter-dev-server": "2.11.0",
-        "@parcel/reporter-tracer": "2.11.0",
-        "@parcel/utils": "2.11.0",
+        "@parcel/config-default": "2.12.0",
+        "@parcel/core": "2.12.0",
+        "@parcel/diagnostic": "2.12.0",
+        "@parcel/events": "2.12.0",
+        "@parcel/fs": "2.12.0",
+        "@parcel/logger": "2.12.0",
+        "@parcel/package-manager": "2.12.0",
+        "@parcel/reporter-cli": "2.12.0",
+        "@parcel/reporter-dev-server": "2.12.0",
+        "@parcel/reporter-tracer": "2.12.0",
+        "@parcel/utils": "2.12.0",
         "chalk": "^4.1.0",
         "commander": "^7.0.0",
         "get-port": "^4.2.0"
       },
       "dependencies": {
-        "@parcel/reporter-cli": {
-          "version": "2.11.0",
-          "resolved": "https://registry.npmjs.org/@parcel/reporter-cli/-/reporter-cli-2.11.0.tgz",
-          "integrity": "sha512-hY0iO0f+LifgJHDUIjGQJnxLFSkk2jlbfy+kIaft5oI3/IM+UljecfGO+14XH8mYlqRXXPsT09TJe8ZKQzp4ZQ==",
-          "dev": true,
-          "requires": {
-            "@parcel/plugin": "2.11.0",
-            "@parcel/types": "2.11.0",
-            "@parcel/utils": "2.11.0",
-            "chalk": "^4.1.0",
-            "cli-progress": "^3.12.0",
-            "term-size": "^2.2.1"
-          }
-        },
         "commander": {
           "version": "7.2.0",
           "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
@@ -11571,761 +9066,9 @@
     "parcel-resolver-theme": {
       "version": "file:local_modules/parcel-resolver-theme",
       "requires": {
-        "@parcel/diagnostic": "^2.11.0",
+        "@parcel/diagnostic": "^2.12.0",
         "@parcel/plugin": "^2.12.0",
         "parcel": "^2.12.0"
-      },
-      "dependencies": {
-        "@parcel/bundler-default": {
-          "version": "2.12.0",
-          "resolved": "https://registry.npmjs.org/@parcel/bundler-default/-/bundler-default-2.12.0.tgz",
-          "integrity": "sha512-3ybN74oYNMKyjD6V20c9Gerdbh7teeNvVMwIoHIQMzuIFT6IGX53PyOLlOKRLbjxMc0TMimQQxIt2eQqxR5LsA==",
-          "dev": true,
-          "requires": {
-            "@parcel/diagnostic": "2.12.0",
-            "@parcel/graph": "3.2.0",
-            "@parcel/plugin": "2.12.0",
-            "@parcel/rust": "2.12.0",
-            "@parcel/utils": "2.12.0",
-            "nullthrows": "^1.1.1"
-          }
-        },
-        "@parcel/cache": {
-          "version": "2.12.0",
-          "resolved": "https://registry.npmjs.org/@parcel/cache/-/cache-2.12.0.tgz",
-          "integrity": "sha512-FX5ZpTEkxvq/yvWklRHDESVRz+c7sLTXgFuzz6uEnBcXV38j6dMSikflNpHA6q/L4GKkCqRywm9R6XQwhwIMyw==",
-          "dev": true,
-          "requires": {
-            "@parcel/fs": "2.12.0",
-            "@parcel/logger": "2.12.0",
-            "@parcel/utils": "2.12.0",
-            "lmdb": "2.8.5"
-          }
-        },
-        "@parcel/codeframe": {
-          "version": "2.12.0",
-          "resolved": "https://registry.npmjs.org/@parcel/codeframe/-/codeframe-2.12.0.tgz",
-          "integrity": "sha512-v2VmneILFiHZJTxPiR7GEF1wey1/IXPdZMcUlNXBiPZyWDfcuNgGGVQkx/xW561rULLIvDPharOMdxz5oHOKQg==",
-          "dev": true,
-          "requires": {
-            "chalk": "^4.1.0"
-          }
-        },
-        "@parcel/compressor-raw": {
-          "version": "2.12.0",
-          "resolved": "https://registry.npmjs.org/@parcel/compressor-raw/-/compressor-raw-2.12.0.tgz",
-          "integrity": "sha512-h41Q3X7ZAQ9wbQ2csP8QGrwepasLZdXiuEdpUryDce6rF9ZiHoJ97MRpdLxOhOPyASTw/xDgE1xyaPQr0Q3f5A==",
-          "dev": true,
-          "requires": {
-            "@parcel/plugin": "2.12.0"
-          }
-        },
-        "@parcel/config-default": {
-          "version": "2.12.0",
-          "resolved": "https://registry.npmjs.org/@parcel/config-default/-/config-default-2.12.0.tgz",
-          "integrity": "sha512-dPNe2n9eEsKRc1soWIY0yToMUPirPIa2QhxcCB3Z5RjpDGIXm0pds+BaiqY6uGLEEzsjhRO0ujd4v2Rmm0vuFg==",
-          "dev": true,
-          "requires": {
-            "@parcel/bundler-default": "2.12.0",
-            "@parcel/compressor-raw": "2.12.0",
-            "@parcel/namer-default": "2.12.0",
-            "@parcel/optimizer-css": "2.12.0",
-            "@parcel/optimizer-htmlnano": "2.12.0",
-            "@parcel/optimizer-image": "2.12.0",
-            "@parcel/optimizer-svgo": "2.12.0",
-            "@parcel/optimizer-swc": "2.12.0",
-            "@parcel/packager-css": "2.12.0",
-            "@parcel/packager-html": "2.12.0",
-            "@parcel/packager-js": "2.12.0",
-            "@parcel/packager-raw": "2.12.0",
-            "@parcel/packager-svg": "2.12.0",
-            "@parcel/packager-wasm": "2.12.0",
-            "@parcel/reporter-dev-server": "2.12.0",
-            "@parcel/resolver-default": "2.12.0",
-            "@parcel/runtime-browser-hmr": "2.12.0",
-            "@parcel/runtime-js": "2.12.0",
-            "@parcel/runtime-react-refresh": "2.12.0",
-            "@parcel/runtime-service-worker": "2.12.0",
-            "@parcel/transformer-babel": "2.12.0",
-            "@parcel/transformer-css": "2.12.0",
-            "@parcel/transformer-html": "2.12.0",
-            "@parcel/transformer-image": "2.12.0",
-            "@parcel/transformer-js": "2.12.0",
-            "@parcel/transformer-json": "2.12.0",
-            "@parcel/transformer-postcss": "2.12.0",
-            "@parcel/transformer-posthtml": "2.12.0",
-            "@parcel/transformer-raw": "2.12.0",
-            "@parcel/transformer-react-refresh-wrap": "2.12.0",
-            "@parcel/transformer-svg": "2.12.0"
-          }
-        },
-        "@parcel/core": {
-          "version": "2.12.0",
-          "resolved": "https://registry.npmjs.org/@parcel/core/-/core-2.12.0.tgz",
-          "integrity": "sha512-s+6pwEj+GfKf7vqGUzN9iSEPueUssCCQrCBUlcAfKrJe0a22hTUCjewpB0I7lNrCIULt8dkndD+sMdOrXsRl6Q==",
-          "dev": true,
-          "requires": {
-            "@mischnic/json-sourcemap": "^0.1.0",
-            "@parcel/cache": "2.12.0",
-            "@parcel/diagnostic": "2.12.0",
-            "@parcel/events": "2.12.0",
-            "@parcel/fs": "2.12.0",
-            "@parcel/graph": "3.2.0",
-            "@parcel/logger": "2.12.0",
-            "@parcel/package-manager": "2.12.0",
-            "@parcel/plugin": "2.12.0",
-            "@parcel/profiler": "2.12.0",
-            "@parcel/rust": "2.12.0",
-            "@parcel/source-map": "^2.1.1",
-            "@parcel/types": "2.12.0",
-            "@parcel/utils": "2.12.0",
-            "@parcel/workers": "2.12.0",
-            "abortcontroller-polyfill": "^1.1.9",
-            "base-x": "^3.0.8",
-            "browserslist": "^4.6.6",
-            "clone": "^2.1.1",
-            "dotenv": "^7.0.0",
-            "dotenv-expand": "^5.1.0",
-            "json5": "^2.2.0",
-            "msgpackr": "^1.9.9",
-            "nullthrows": "^1.1.1",
-            "semver": "^7.5.2"
-          }
-        },
-        "@parcel/diagnostic": {
-          "version": "2.12.0",
-          "resolved": "https://registry.npmjs.org/@parcel/diagnostic/-/diagnostic-2.12.0.tgz",
-          "integrity": "sha512-8f1NOsSFK+F4AwFCKynyIu9Kr/uWHC+SywAv4oS6Bv3Acig0gtwUjugk0C9UaB8ztBZiW5TQZhw+uPZn9T/lJA==",
-          "dev": true,
-          "requires": {
-            "@mischnic/json-sourcemap": "^0.1.0",
-            "nullthrows": "^1.1.1"
-          }
-        },
-        "@parcel/events": {
-          "version": "2.12.0",
-          "resolved": "https://registry.npmjs.org/@parcel/events/-/events-2.12.0.tgz",
-          "integrity": "sha512-nmAAEIKLjW1kB2cUbCYSmZOGbnGj8wCzhqnK727zCCWaA25ogzAtt657GPOeFyqW77KyosU728Tl63Fc8hphIA==",
-          "dev": true
-        },
-        "@parcel/fs": {
-          "version": "2.12.0",
-          "resolved": "https://registry.npmjs.org/@parcel/fs/-/fs-2.12.0.tgz",
-          "integrity": "sha512-NnFkuvou1YBtPOhTdZr44WN7I60cGyly2wpHzqRl62yhObyi1KvW0SjwOMa0QGNcBOIzp4G0CapoZ93hD0RG5Q==",
-          "dev": true,
-          "requires": {
-            "@parcel/rust": "2.12.0",
-            "@parcel/types": "2.12.0",
-            "@parcel/utils": "2.12.0",
-            "@parcel/watcher": "^2.0.7",
-            "@parcel/workers": "2.12.0"
-          }
-        },
-        "@parcel/graph": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/@parcel/graph/-/graph-3.2.0.tgz",
-          "integrity": "sha512-xlrmCPqy58D4Fg5umV7bpwDx5Vyt7MlnQPxW68vae5+BA4GSWetfZt+Cs5dtotMG2oCHzZxhIPt7YZ7NRyQzLA==",
-          "dev": true,
-          "requires": {
-            "nullthrows": "^1.1.1"
-          }
-        },
-        "@parcel/logger": {
-          "version": "2.12.0",
-          "resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.12.0.tgz",
-          "integrity": "sha512-cJ7Paqa7/9VJ7C+KwgJlwMqTQBOjjn71FbKk0G07hydUEBISU2aDfmc/52o60ErL9l+vXB26zTrIBanbxS8rVg==",
-          "dev": true,
-          "requires": {
-            "@parcel/diagnostic": "2.12.0",
-            "@parcel/events": "2.12.0"
-          }
-        },
-        "@parcel/markdown-ansi": {
-          "version": "2.12.0",
-          "resolved": "https://registry.npmjs.org/@parcel/markdown-ansi/-/markdown-ansi-2.12.0.tgz",
-          "integrity": "sha512-WZz3rzL8k0H3WR4qTHX6Ic8DlEs17keO9gtD4MNGyMNQbqQEvQ61lWJaIH0nAtgEetu0SOITiVqdZrb8zx/M7w==",
-          "dev": true,
-          "requires": {
-            "chalk": "^4.1.0"
-          }
-        },
-        "@parcel/namer-default": {
-          "version": "2.12.0",
-          "resolved": "https://registry.npmjs.org/@parcel/namer-default/-/namer-default-2.12.0.tgz",
-          "integrity": "sha512-9DNKPDHWgMnMtqqZIMiEj/R9PNWW16lpnlHjwK3ciRlMPgjPJ8+UNc255teZODhX0T17GOzPdGbU/O/xbxVPzA==",
-          "dev": true,
-          "requires": {
-            "@parcel/diagnostic": "2.12.0",
-            "@parcel/plugin": "2.12.0",
-            "nullthrows": "^1.1.1"
-          }
-        },
-        "@parcel/node-resolver-core": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/@parcel/node-resolver-core/-/node-resolver-core-3.3.0.tgz",
-          "integrity": "sha512-rhPW9DYPEIqQBSlYzz3S0AjXxjN6Ub2yS6tzzsW/4S3Gpsgk/uEq4ZfxPvoPf/6TgZndVxmKwpmxaKtGMmf3cA==",
-          "dev": true,
-          "requires": {
-            "@mischnic/json-sourcemap": "^0.1.0",
-            "@parcel/diagnostic": "2.12.0",
-            "@parcel/fs": "2.12.0",
-            "@parcel/rust": "2.12.0",
-            "@parcel/utils": "2.12.0",
-            "nullthrows": "^1.1.1",
-            "semver": "^7.5.2"
-          }
-        },
-        "@parcel/optimizer-css": {
-          "version": "2.12.0",
-          "resolved": "https://registry.npmjs.org/@parcel/optimizer-css/-/optimizer-css-2.12.0.tgz",
-          "integrity": "sha512-ifbcC97fRzpruTjaa8axIFeX4MjjSIlQfem3EJug3L2AVqQUXnM1XO8L0NaXGNLTW2qnh1ZjIJ7vXT/QhsphsA==",
-          "dev": true,
-          "requires": {
-            "@parcel/diagnostic": "2.12.0",
-            "@parcel/plugin": "2.12.0",
-            "@parcel/source-map": "^2.1.1",
-            "@parcel/utils": "2.12.0",
-            "browserslist": "^4.6.6",
-            "lightningcss": "^1.22.1",
-            "nullthrows": "^1.1.1"
-          }
-        },
-        "@parcel/optimizer-htmlnano": {
-          "version": "2.12.0",
-          "resolved": "https://registry.npmjs.org/@parcel/optimizer-htmlnano/-/optimizer-htmlnano-2.12.0.tgz",
-          "integrity": "sha512-MfPMeCrT8FYiOrpFHVR+NcZQlXAptK2r4nGJjfT+ndPBhEEZp4yyL7n1y7HfX9geg5altc4WTb4Gug7rCoW8VQ==",
-          "dev": true,
-          "requires": {
-            "@parcel/plugin": "2.12.0",
-            "htmlnano": "^2.0.0",
-            "nullthrows": "^1.1.1",
-            "posthtml": "^0.16.5",
-            "svgo": "^2.4.0"
-          }
-        },
-        "@parcel/optimizer-image": {
-          "version": "2.12.0",
-          "resolved": "https://registry.npmjs.org/@parcel/optimizer-image/-/optimizer-image-2.12.0.tgz",
-          "integrity": "sha512-bo1O7raeAIbRU5nmNVtx8divLW9Xqn0c57GVNGeAK4mygnQoqHqRZ0mR9uboh64pxv6ijXZHPhKvU9HEpjPjBQ==",
-          "dev": true,
-          "requires": {
-            "@parcel/diagnostic": "2.12.0",
-            "@parcel/plugin": "2.12.0",
-            "@parcel/rust": "2.12.0",
-            "@parcel/utils": "2.12.0",
-            "@parcel/workers": "2.12.0"
-          }
-        },
-        "@parcel/optimizer-svgo": {
-          "version": "2.12.0",
-          "resolved": "https://registry.npmjs.org/@parcel/optimizer-svgo/-/optimizer-svgo-2.12.0.tgz",
-          "integrity": "sha512-Kyli+ZZXnoonnbeRQdoWwee9Bk2jm/49xvnfb+2OO8NN0d41lblBoRhOyFiScRnJrw7eVl1Xrz7NTkXCIO7XFQ==",
-          "dev": true,
-          "requires": {
-            "@parcel/diagnostic": "2.12.0",
-            "@parcel/plugin": "2.12.0",
-            "@parcel/utils": "2.12.0",
-            "svgo": "^2.4.0"
-          }
-        },
-        "@parcel/optimizer-swc": {
-          "version": "2.12.0",
-          "resolved": "https://registry.npmjs.org/@parcel/optimizer-swc/-/optimizer-swc-2.12.0.tgz",
-          "integrity": "sha512-iBi6LZB3lm6WmbXfzi8J3DCVPmn4FN2lw7DGXxUXu7MouDPVWfTsM6U/5TkSHJRNRogZ2gqy5q9g34NPxHbJcw==",
-          "dev": true,
-          "requires": {
-            "@parcel/diagnostic": "2.12.0",
-            "@parcel/plugin": "2.12.0",
-            "@parcel/source-map": "^2.1.1",
-            "@parcel/utils": "2.12.0",
-            "@swc/core": "^1.3.36",
-            "nullthrows": "^1.1.1"
-          }
-        },
-        "@parcel/package-manager": {
-          "version": "2.12.0",
-          "resolved": "https://registry.npmjs.org/@parcel/package-manager/-/package-manager-2.12.0.tgz",
-          "integrity": "sha512-0nvAezcjPx9FT+hIL+LS1jb0aohwLZXct7jAh7i0MLMtehOi0z1Sau+QpgMlA9rfEZZ1LIeFdnZZwqSy7Ccspw==",
-          "dev": true,
-          "requires": {
-            "@parcel/diagnostic": "2.12.0",
-            "@parcel/fs": "2.12.0",
-            "@parcel/logger": "2.12.0",
-            "@parcel/node-resolver-core": "3.3.0",
-            "@parcel/types": "2.12.0",
-            "@parcel/utils": "2.12.0",
-            "@parcel/workers": "2.12.0",
-            "@swc/core": "^1.3.36",
-            "semver": "^7.5.2"
-          }
-        },
-        "@parcel/packager-css": {
-          "version": "2.12.0",
-          "resolved": "https://registry.npmjs.org/@parcel/packager-css/-/packager-css-2.12.0.tgz",
-          "integrity": "sha512-j3a/ODciaNKD19IYdWJT+TP+tnhhn5koBGBWWtrKSu0UxWpnezIGZetit3eE+Y9+NTePalMkvpIlit2eDhvfJA==",
-          "dev": true,
-          "requires": {
-            "@parcel/diagnostic": "2.12.0",
-            "@parcel/plugin": "2.12.0",
-            "@parcel/source-map": "^2.1.1",
-            "@parcel/utils": "2.12.0",
-            "lightningcss": "^1.22.1",
-            "nullthrows": "^1.1.1"
-          }
-        },
-        "@parcel/packager-html": {
-          "version": "2.12.0",
-          "resolved": "https://registry.npmjs.org/@parcel/packager-html/-/packager-html-2.12.0.tgz",
-          "integrity": "sha512-PpvGB9hFFe+19NXGz2ApvPrkA9GwEqaDAninT+3pJD57OVBaxB8U+HN4a5LICKxjUppPPqmrLb6YPbD65IX4RA==",
-          "dev": true,
-          "requires": {
-            "@parcel/plugin": "2.12.0",
-            "@parcel/types": "2.12.0",
-            "@parcel/utils": "2.12.0",
-            "nullthrows": "^1.1.1",
-            "posthtml": "^0.16.5"
-          }
-        },
-        "@parcel/packager-js": {
-          "version": "2.12.0",
-          "resolved": "https://registry.npmjs.org/@parcel/packager-js/-/packager-js-2.12.0.tgz",
-          "integrity": "sha512-viMF+FszITRRr8+2iJyk+4ruGiL27Y6AF7hQ3xbJfzqnmbOhGFtLTQwuwhOLqN/mWR2VKdgbLpZSarWaO3yAMg==",
-          "dev": true,
-          "requires": {
-            "@parcel/diagnostic": "2.12.0",
-            "@parcel/plugin": "2.12.0",
-            "@parcel/rust": "2.12.0",
-            "@parcel/source-map": "^2.1.1",
-            "@parcel/types": "2.12.0",
-            "@parcel/utils": "2.12.0",
-            "globals": "^13.2.0",
-            "nullthrows": "^1.1.1"
-          }
-        },
-        "@parcel/packager-raw": {
-          "version": "2.12.0",
-          "resolved": "https://registry.npmjs.org/@parcel/packager-raw/-/packager-raw-2.12.0.tgz",
-          "integrity": "sha512-tJZqFbHqP24aq1F+OojFbQIc09P/u8HAW5xfndCrFnXpW4wTgM3p03P0xfw3gnNq+TtxHJ8c3UFE5LnXNNKhYA==",
-          "dev": true,
-          "requires": {
-            "@parcel/plugin": "2.12.0"
-          }
-        },
-        "@parcel/packager-svg": {
-          "version": "2.12.0",
-          "resolved": "https://registry.npmjs.org/@parcel/packager-svg/-/packager-svg-2.12.0.tgz",
-          "integrity": "sha512-ldaGiacGb2lLqcXas97k8JiZRbAnNREmcvoY2W2dvW4loVuDT9B9fU777mbV6zODpcgcHWsLL3lYbJ5Lt3y9cg==",
-          "dev": true,
-          "requires": {
-            "@parcel/plugin": "2.12.0",
-            "@parcel/types": "2.12.0",
-            "@parcel/utils": "2.12.0",
-            "posthtml": "^0.16.4"
-          }
-        },
-        "@parcel/packager-wasm": {
-          "version": "2.12.0",
-          "resolved": "https://registry.npmjs.org/@parcel/packager-wasm/-/packager-wasm-2.12.0.tgz",
-          "integrity": "sha512-fYqZzIqO9fGYveeImzF8ll6KRo2LrOXfD+2Y5U3BiX/wp9wv17dz50QLDQm9hmTcKGWxK4yWqKQh+Evp/fae7A==",
-          "dev": true,
-          "requires": {
-            "@parcel/plugin": "2.12.0"
-          }
-        },
-        "@parcel/plugin": {
-          "version": "2.12.0",
-          "resolved": "https://registry.npmjs.org/@parcel/plugin/-/plugin-2.12.0.tgz",
-          "integrity": "sha512-nc/uRA8DiMoe4neBbzV6kDndh/58a4wQuGKw5oEoIwBCHUvE2W8ZFSu7ollSXUGRzfacTt4NdY8TwS73ScWZ+g==",
-          "dev": true,
-          "requires": {
-            "@parcel/types": "2.12.0"
-          }
-        },
-        "@parcel/profiler": {
-          "version": "2.12.0",
-          "resolved": "https://registry.npmjs.org/@parcel/profiler/-/profiler-2.12.0.tgz",
-          "integrity": "sha512-q53fvl5LDcFYzMUtSusUBZSjQrKjMlLEBgKeQHFwkimwR1mgoseaDBDuNz0XvmzDzF1UelJ02TUKCGacU8W2qA==",
-          "dev": true,
-          "requires": {
-            "@parcel/diagnostic": "2.12.0",
-            "@parcel/events": "2.12.0",
-            "chrome-trace-event": "^1.0.2"
-          }
-        },
-        "@parcel/reporter-dev-server": {
-          "version": "2.12.0",
-          "resolved": "https://registry.npmjs.org/@parcel/reporter-dev-server/-/reporter-dev-server-2.12.0.tgz",
-          "integrity": "sha512-tIcDqRvAPAttRlTV28dHcbWT5K2r/MBFks7nM4nrEDHWtnrCwimkDmZTc1kD8QOCCjGVwRHcQybpHvxfwol6GA==",
-          "dev": true,
-          "requires": {
-            "@parcel/plugin": "2.12.0",
-            "@parcel/utils": "2.12.0"
-          }
-        },
-        "@parcel/reporter-tracer": {
-          "version": "2.12.0",
-          "resolved": "https://registry.npmjs.org/@parcel/reporter-tracer/-/reporter-tracer-2.12.0.tgz",
-          "integrity": "sha512-g8rlu9GxB8Ut/F8WGx4zidIPQ4pcYFjU9bZO+fyRIPrSUFH2bKijCnbZcr4ntqzDGx74hwD6cCG4DBoleq2UlQ==",
-          "dev": true,
-          "requires": {
-            "@parcel/plugin": "2.12.0",
-            "@parcel/utils": "2.12.0",
-            "chrome-trace-event": "^1.0.3",
-            "nullthrows": "^1.1.1"
-          }
-        },
-        "@parcel/resolver-default": {
-          "version": "2.12.0",
-          "resolved": "https://registry.npmjs.org/@parcel/resolver-default/-/resolver-default-2.12.0.tgz",
-          "integrity": "sha512-uuhbajTax37TwCxu7V98JtRLiT6hzE4VYSu5B7Qkauy14/WFt2dz6GOUXPgVsED569/hkxebPx3KCMtZW6cHHA==",
-          "dev": true,
-          "requires": {
-            "@parcel/node-resolver-core": "3.3.0",
-            "@parcel/plugin": "2.12.0"
-          }
-        },
-        "@parcel/runtime-browser-hmr": {
-          "version": "2.12.0",
-          "resolved": "https://registry.npmjs.org/@parcel/runtime-browser-hmr/-/runtime-browser-hmr-2.12.0.tgz",
-          "integrity": "sha512-4ZLp2FWyD32r0GlTulO3+jxgsA3oO1P1b5oO2IWuWilfhcJH5LTiazpL5YdusUjtNn9PGN6QLAWfxmzRIfM+Ow==",
-          "dev": true,
-          "requires": {
-            "@parcel/plugin": "2.12.0",
-            "@parcel/utils": "2.12.0"
-          }
-        },
-        "@parcel/runtime-js": {
-          "version": "2.12.0",
-          "resolved": "https://registry.npmjs.org/@parcel/runtime-js/-/runtime-js-2.12.0.tgz",
-          "integrity": "sha512-sBerP32Z1crX5PfLNGDSXSdqzlllM++GVnVQVeM7DgMKS8JIFG3VLi28YkX+dYYGtPypm01JoIHCkvwiZEcQJg==",
-          "dev": true,
-          "requires": {
-            "@parcel/diagnostic": "2.12.0",
-            "@parcel/plugin": "2.12.0",
-            "@parcel/utils": "2.12.0",
-            "nullthrows": "^1.1.1"
-          }
-        },
-        "@parcel/runtime-react-refresh": {
-          "version": "2.12.0",
-          "resolved": "https://registry.npmjs.org/@parcel/runtime-react-refresh/-/runtime-react-refresh-2.12.0.tgz",
-          "integrity": "sha512-SCHkcczJIDFTFdLTzrHTkQ0aTrX3xH6jrA4UsCBL6ji61+w+ohy4jEEe9qCgJVXhnJfGLE43HNXek+0MStX+Mw==",
-          "dev": true,
-          "requires": {
-            "@parcel/plugin": "2.12.0",
-            "@parcel/utils": "2.12.0",
-            "react-error-overlay": "6.0.9",
-            "react-refresh": "^0.9.0"
-          }
-        },
-        "@parcel/runtime-service-worker": {
-          "version": "2.12.0",
-          "resolved": "https://registry.npmjs.org/@parcel/runtime-service-worker/-/runtime-service-worker-2.12.0.tgz",
-          "integrity": "sha512-BXuMBsfiwpIEnssn+jqfC3jkgbS8oxeo3C7xhSQsuSv+AF2FwY3O3AO1c1RBskEW3XrBLNINOJujroNw80VTKA==",
-          "dev": true,
-          "requires": {
-            "@parcel/plugin": "2.12.0",
-            "@parcel/utils": "2.12.0",
-            "nullthrows": "^1.1.1"
-          }
-        },
-        "@parcel/rust": {
-          "version": "2.12.0",
-          "resolved": "https://registry.npmjs.org/@parcel/rust/-/rust-2.12.0.tgz",
-          "integrity": "sha512-005cldMdFZFDPOjbDVEXcINQ3wT4vrxvSavRWI3Az0e3E18exO/x/mW9f648KtXugOXMAqCEqhFHcXECL9nmMw==",
-          "dev": true
-        },
-        "@parcel/transformer-babel": {
-          "version": "2.12.0",
-          "resolved": "https://registry.npmjs.org/@parcel/transformer-babel/-/transformer-babel-2.12.0.tgz",
-          "integrity": "sha512-zQaBfOnf/l8rPxYGnsk/ufh/0EuqvmnxafjBIpKZ//j6rGylw5JCqXSb1QvvAqRYruKeccxGv7+HrxpqKU6V4A==",
-          "dev": true,
-          "requires": {
-            "@parcel/diagnostic": "2.12.0",
-            "@parcel/plugin": "2.12.0",
-            "@parcel/source-map": "^2.1.1",
-            "@parcel/utils": "2.12.0",
-            "browserslist": "^4.6.6",
-            "json5": "^2.2.0",
-            "nullthrows": "^1.1.1",
-            "semver": "^7.5.2"
-          }
-        },
-        "@parcel/transformer-css": {
-          "version": "2.12.0",
-          "resolved": "https://registry.npmjs.org/@parcel/transformer-css/-/transformer-css-2.12.0.tgz",
-          "integrity": "sha512-vXhOqoAlQGATYyQ433Z1DXKmiKmzOAUmKysbYH3FD+LKEKLMEl/pA14goqp00TW+A/EjtSKKyeMyHlMIIUqj4Q==",
-          "dev": true,
-          "requires": {
-            "@parcel/diagnostic": "2.12.0",
-            "@parcel/plugin": "2.12.0",
-            "@parcel/source-map": "^2.1.1",
-            "@parcel/utils": "2.12.0",
-            "browserslist": "^4.6.6",
-            "lightningcss": "^1.22.1",
-            "nullthrows": "^1.1.1"
-          }
-        },
-        "@parcel/transformer-html": {
-          "version": "2.12.0",
-          "resolved": "https://registry.npmjs.org/@parcel/transformer-html/-/transformer-html-2.12.0.tgz",
-          "integrity": "sha512-5jW4dFFBlYBvIQk4nrH62rfA/G/KzVzEDa6S+Nne0xXhglLjkm64Ci9b/d4tKZfuGWUbpm2ASAq8skti/nfpXw==",
-          "dev": true,
-          "requires": {
-            "@parcel/diagnostic": "2.12.0",
-            "@parcel/plugin": "2.12.0",
-            "@parcel/rust": "2.12.0",
-            "nullthrows": "^1.1.1",
-            "posthtml": "^0.16.5",
-            "posthtml-parser": "^0.10.1",
-            "posthtml-render": "^3.0.0",
-            "semver": "^7.5.2",
-            "srcset": "4"
-          }
-        },
-        "@parcel/transformer-image": {
-          "version": "2.12.0",
-          "resolved": "https://registry.npmjs.org/@parcel/transformer-image/-/transformer-image-2.12.0.tgz",
-          "integrity": "sha512-8hXrGm2IRII49R7lZ0RpmNk27EhcsH+uNKsvxuMpXPuEnWgC/ha/IrjaI29xCng1uGur74bJF43NUSQhR4aTdw==",
-          "dev": true,
-          "requires": {
-            "@parcel/plugin": "2.12.0",
-            "@parcel/utils": "2.12.0",
-            "@parcel/workers": "2.12.0",
-            "nullthrows": "^1.1.1"
-          }
-        },
-        "@parcel/transformer-js": {
-          "version": "2.12.0",
-          "resolved": "https://registry.npmjs.org/@parcel/transformer-js/-/transformer-js-2.12.0.tgz",
-          "integrity": "sha512-OSZpOu+FGDbC/xivu24v092D9w6EGytB3vidwbdiJ2FaPgfV7rxS0WIUjH4I0OcvHAcitArRXL0a3+HrNTdQQw==",
-          "dev": true,
-          "requires": {
-            "@parcel/diagnostic": "2.12.0",
-            "@parcel/plugin": "2.12.0",
-            "@parcel/rust": "2.12.0",
-            "@parcel/source-map": "^2.1.1",
-            "@parcel/utils": "2.12.0",
-            "@parcel/workers": "2.12.0",
-            "@swc/helpers": "^0.5.0",
-            "browserslist": "^4.6.6",
-            "nullthrows": "^1.1.1",
-            "regenerator-runtime": "^0.13.7",
-            "semver": "^7.5.2"
-          }
-        },
-        "@parcel/transformer-json": {
-          "version": "2.12.0",
-          "resolved": "https://registry.npmjs.org/@parcel/transformer-json/-/transformer-json-2.12.0.tgz",
-          "integrity": "sha512-Utv64GLRCQILK5r0KFs4o7I41ixMPllwOLOhkdjJKvf1hZmN6WqfOmB1YLbWS/y5Zb/iB52DU2pWZm96vLFQZQ==",
-          "dev": true,
-          "requires": {
-            "@parcel/plugin": "2.12.0",
-            "json5": "^2.2.0"
-          }
-        },
-        "@parcel/transformer-postcss": {
-          "version": "2.12.0",
-          "resolved": "https://registry.npmjs.org/@parcel/transformer-postcss/-/transformer-postcss-2.12.0.tgz",
-          "integrity": "sha512-FZqn+oUtiLfPOn67EZxPpBkfdFiTnF4iwiXPqvst3XI8H+iC+yNgzmtJkunOOuylpYY6NOU5jT8d7saqWSDv2Q==",
-          "dev": true,
-          "requires": {
-            "@parcel/diagnostic": "2.12.0",
-            "@parcel/plugin": "2.12.0",
-            "@parcel/rust": "2.12.0",
-            "@parcel/utils": "2.12.0",
-            "clone": "^2.1.1",
-            "nullthrows": "^1.1.1",
-            "postcss-value-parser": "^4.2.0",
-            "semver": "^7.5.2"
-          }
-        },
-        "@parcel/transformer-posthtml": {
-          "version": "2.12.0",
-          "resolved": "https://registry.npmjs.org/@parcel/transformer-posthtml/-/transformer-posthtml-2.12.0.tgz",
-          "integrity": "sha512-z6Z7rav/pcaWdeD+2sDUcd0mmNZRUvtHaUGa50Y2mr+poxrKilpsnFMSiWBT+oOqPt7j71jzDvrdnAF4XkCljg==",
-          "dev": true,
-          "requires": {
-            "@parcel/plugin": "2.12.0",
-            "@parcel/utils": "2.12.0",
-            "nullthrows": "^1.1.1",
-            "posthtml": "^0.16.5",
-            "posthtml-parser": "^0.10.1",
-            "posthtml-render": "^3.0.0",
-            "semver": "^7.5.2"
-          }
-        },
-        "@parcel/transformer-raw": {
-          "version": "2.12.0",
-          "resolved": "https://registry.npmjs.org/@parcel/transformer-raw/-/transformer-raw-2.12.0.tgz",
-          "integrity": "sha512-Ht1fQvXxix0NncdnmnXZsa6hra20RXYh1VqhBYZLsDfkvGGFnXIgO03Jqn4Z8MkKoa0tiNbDhpKIeTjyclbBxQ==",
-          "dev": true,
-          "requires": {
-            "@parcel/plugin": "2.12.0"
-          }
-        },
-        "@parcel/transformer-react-refresh-wrap": {
-          "version": "2.12.0",
-          "resolved": "https://registry.npmjs.org/@parcel/transformer-react-refresh-wrap/-/transformer-react-refresh-wrap-2.12.0.tgz",
-          "integrity": "sha512-GE8gmP2AZtkpBIV5vSCVhewgOFRhqwdM5Q9jNPOY5PKcM3/Ff0qCqDiTzzGLhk0/VMBrdjssrfZkVx6S/lHdJw==",
-          "dev": true,
-          "requires": {
-            "@parcel/plugin": "2.12.0",
-            "@parcel/utils": "2.12.0",
-            "react-refresh": "^0.9.0"
-          }
-        },
-        "@parcel/transformer-svg": {
-          "version": "2.12.0",
-          "resolved": "https://registry.npmjs.org/@parcel/transformer-svg/-/transformer-svg-2.12.0.tgz",
-          "integrity": "sha512-cZJqGRJ4JNdYcb+vj94J7PdOuTnwyy45dM9xqbIMH+HSiiIkfrMsdEwYft0GTyFTdsnf+hdHn3tau7Qa5hhX+A==",
-          "dev": true,
-          "requires": {
-            "@parcel/diagnostic": "2.12.0",
-            "@parcel/plugin": "2.12.0",
-            "@parcel/rust": "2.12.0",
-            "nullthrows": "^1.1.1",
-            "posthtml": "^0.16.5",
-            "posthtml-parser": "^0.10.1",
-            "posthtml-render": "^3.0.0",
-            "semver": "^7.5.2"
-          }
-        },
-        "@parcel/types": {
-          "version": "2.12.0",
-          "resolved": "https://registry.npmjs.org/@parcel/types/-/types-2.12.0.tgz",
-          "integrity": "sha512-8zAFiYNCwNTQcglIObyNwKfRYQK5ELlL13GuBOrSMxueUiI5ylgsGbTS1N7J3dAGZixHO8KhHGv5a71FILn9rQ==",
-          "dev": true,
-          "requires": {
-            "@parcel/cache": "2.12.0",
-            "@parcel/diagnostic": "2.12.0",
-            "@parcel/fs": "2.12.0",
-            "@parcel/package-manager": "2.12.0",
-            "@parcel/source-map": "^2.1.1",
-            "@parcel/workers": "2.12.0",
-            "utility-types": "^3.10.0"
-          }
-        },
-        "@parcel/utils": {
-          "version": "2.12.0",
-          "resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.12.0.tgz",
-          "integrity": "sha512-z1JhLuZ8QmDaYoEIuUCVZlhcFrS7LMfHrb2OCRui5SQFntRWBH2fNM6H/fXXUkT9SkxcuFP2DUA6/m4+Gkz72g==",
-          "dev": true,
-          "requires": {
-            "@parcel/codeframe": "2.12.0",
-            "@parcel/diagnostic": "2.12.0",
-            "@parcel/logger": "2.12.0",
-            "@parcel/markdown-ansi": "2.12.0",
-            "@parcel/rust": "2.12.0",
-            "@parcel/source-map": "^2.1.1",
-            "chalk": "^4.1.0",
-            "nullthrows": "^1.1.1"
-          }
-        },
-        "@parcel/workers": {
-          "version": "2.12.0",
-          "resolved": "https://registry.npmjs.org/@parcel/workers/-/workers-2.12.0.tgz",
-          "integrity": "sha512-zv5We5Jmb+ZWXlU6A+AufyjY4oZckkxsZ8J4dvyWL0W8IQvGO1JB4FGeryyttzQv3RM3OxcN/BpTGPiDG6keBw==",
-          "dev": true,
-          "requires": {
-            "@parcel/diagnostic": "2.12.0",
-            "@parcel/logger": "2.12.0",
-            "@parcel/profiler": "2.12.0",
-            "@parcel/types": "2.12.0",
-            "@parcel/utils": "2.12.0",
-            "nullthrows": "^1.1.1"
-          }
-        },
-        "commander": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
-          "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
-          "dev": true
-        },
-        "css-select": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/css-select/-/css-select-4.3.0.tgz",
-          "integrity": "sha512-wPpOYtnsVontu2mODhA19JrqWxNsfdatRKd64kmpRbQgh1KtItko5sTnEpPdpSaJszTOhEMlF/RPz28qj4HqhQ==",
-          "dev": true,
-          "requires": {
-            "boolbase": "^1.0.0",
-            "css-what": "^6.0.1",
-            "domhandler": "^4.3.1",
-            "domutils": "^2.8.0",
-            "nth-check": "^2.0.1"
-          }
-        },
-        "css-tree": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.1.3.tgz",
-          "integrity": "sha512-tRpdppF7TRazZrjJ6v3stzv93qxRcSsFmW6cX0Zm2NVKpxE1WV1HblnghVv9TreireHkqI/VDEsfolRF1p6y7Q==",
-          "dev": true,
-          "requires": {
-            "mdn-data": "2.0.14",
-            "source-map": "^0.6.1"
-          }
-        },
-        "csso": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/csso/-/csso-4.2.0.tgz",
-          "integrity": "sha512-wvlcdIbf6pwKEk7vHj8/Bkc0B4ylXZruLvOgs9doS5eOsOpuodOV2zJChSpkp+pRpYQLQMeF04nr3Z68Sta9jA==",
-          "dev": true,
-          "requires": {
-            "css-tree": "^1.1.2"
-          }
-        },
-        "mdn-data": {
-          "version": "2.0.14",
-          "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.14.tgz",
-          "integrity": "sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow==",
-          "dev": true
-        },
-        "parcel": {
-          "version": "2.12.0",
-          "resolved": "https://registry.npmjs.org/parcel/-/parcel-2.12.0.tgz",
-          "integrity": "sha512-W+gxAq7aQ9dJIg/XLKGcRT0cvnStFAQHPaI0pvD0U2l6IVLueUAm3nwN7lkY62zZNmlvNx6jNtE4wlbS+CyqSg==",
-          "dev": true,
-          "requires": {
-            "@parcel/config-default": "2.12.0",
-            "@parcel/core": "2.12.0",
-            "@parcel/diagnostic": "2.12.0",
-            "@parcel/events": "2.12.0",
-            "@parcel/fs": "2.12.0",
-            "@parcel/logger": "2.12.0",
-            "@parcel/package-manager": "2.12.0",
-            "@parcel/reporter-cli": "2.12.0",
-            "@parcel/reporter-dev-server": "2.12.0",
-            "@parcel/reporter-tracer": "2.12.0",
-            "@parcel/utils": "2.12.0",
-            "chalk": "^4.1.0",
-            "commander": "^7.0.0",
-            "get-port": "^4.2.0"
-          }
-        },
-        "semver": {
-          "version": "7.6.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
-          "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
-          "dev": true,
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
-        },
-        "svgo": {
-          "version": "2.8.0",
-          "resolved": "https://registry.npmjs.org/svgo/-/svgo-2.8.0.tgz",
-          "integrity": "sha512-+N/Q9kV1+F+UeWYoSiULYo4xYSDQlTgb+ayMobAXPwMnLvop7oxKMo9OzIrX5x3eS4L4f2UHhc9axXwY8DpChg==",
-          "dev": true,
-          "requires": {
-            "@trysound/sax": "0.2.0",
-            "commander": "^7.2.0",
-            "css-select": "^4.1.3",
-            "css-tree": "^1.1.3",
-            "csso": "^4.2.0",
-            "picocolors": "^1.0.0",
-            "stable": "^0.1.8"
-          }
-        }
       }
     },
     "parent-module": {
@@ -12720,9 +9463,9 @@
       "dev": true
     },
     "source-map-js": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
-      "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.0.tgz",
+      "integrity": "sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg==",
       "dev": true,
       "optional": true,
       "peer": true

--- a/app/package.json
+++ b/app/package.json
@@ -23,8 +23,8 @@
     "@parcel/reporter-cli": "^2.12.0",
     "@parcel/transformer-less": "^2.12.0",
     "copyfiles": "^2.4.1",
-    "parcel": "^2.11.0",
-    "@parcel/plugin": "^2.11.0",
+    "parcel": "^2.12.0",
+    "@parcel/plugin": "^2.12.0",
     "parcel-resolver-ignore": "^2.2.0",
     "parcel-resolver-theme": "file:local_modules/parcel-resolver-theme",
     "process": "^0.11.10"


### PR DESCRIPTION
issue : 
Parcel build fails with below output

```shell
[INFO] @parcel/package-manager: Could not find module "@parcel/transformer-less" satisfying 2.11.0.
[INFO]   /root/HAL_TEST/console/app/package.json:24:5
[INFO]     23 |     "@parcel/reporter-cli": "^2.12.0",
[INFO]   > 24 |     "@parcel/transformer-less": "^2.12.0",
[INFO]   >    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ Found this conflicting local requirement.
[INFO]     25 |     "copyfiles": "^2.4.1",
[INFO]     26 |     "parcel": "^2.11.0",
``` 

cause :
According to the dependency of @parcel/transformer-less, the version of @parcel/plugin is specified as 2.12.0.

fix :
Upgrade parcel version from 2.11.0 to 2.12.0

result :
Build goes well

report:
https://issues.redhat.com/browse/HAL-1972