### PR TITLE
HAL-1984: fix id generation from proprietary strings

### DIFF
--- a/app/src/main/java/org/jboss/hal/client/accesscontrol/AccessControlTokens.java
+++ b/app/src/main/java/org/jboss/hal/client/accesscontrol/AccessControlTokens.java
@@ -23,19 +23,16 @@ import org.jboss.hal.core.finder.FinderPath;
 import org.jboss.hal.core.mvp.Places;
 import org.jboss.hal.meta.token.NameTokens;
 import org.jboss.hal.resources.Ids;
-import org.jboss.hal.resources.Resources;
 
 import com.gwtplatform.mvp.shared.proxy.PlaceRequest;
 
 public class AccessControlTokens {
 
     private final Places places;
-    private final Resources resources;
 
     @Inject
-    public AccessControlTokens(final Places places, final Resources resources) {
+    public AccessControlTokens(final Places places) {
         this.places = places;
-        this.resources = resources;
     }
 
     public String principal(Principal principal) {
@@ -50,26 +47,28 @@ public class AccessControlTokens {
         String browseByItemId;
         String principalColumnId;
         if (principal.getType() == Principal.Type.USER) {
-            browseByItemId = Ids.asId(resources.constants().users());
+            browseByItemId = Ids.ACCESS_CONTROL_BROWSE_BY_USERS;
             principalColumnId = Ids.USER;
         } else {
-            browseByItemId = Ids.asId(resources.constants().groups());
+            browseByItemId = Ids.ACCESS_CONTROL_BROWSE_BY_GROUPS;
             principalColumnId = Ids.GROUP;
         }
 
-        return new FinderPath()
-                .append(Ids.ACCESS_CONTROL_BROWSE_BY, browseByItemId)
-                .append(principalColumnId, principal.getId());
+        return getPath(browseByItemId, principalColumnId, principal.getId());
     }
 
     private FinderPath rolePath(Role role) {
-        return new FinderPath()
-                .append(Ids.ACCESS_CONTROL_BROWSE_BY, Ids.asId(resources.constants().roles()))
-                .append(Ids.ROLE, role.getId());
+        return getPath(Ids.ACCESS_CONTROL_BROWSE_BY_ROLES, Ids.ROLE, role.getId());
     }
 
     private String token(FinderPath path) {
         PlaceRequest placeRequest = places.finderPlace(NameTokens.ACCESS_CONTROL, path).build();
         return places.historyToken(placeRequest);
+    }
+
+    private FinderPath getPath(String browseById, String typeId, String name) {
+        return new FinderPath()
+                .append(Ids.ACCESS_CONTROL_BROWSE_BY, browseById)
+                .append(typeId, name);
     }
 }

--- a/app/src/main/java/org/jboss/hal/client/deployment/BrowseByColumn.java
+++ b/app/src/main/java/org/jboss/hal/client/deployment/BrowseByColumn.java
@@ -55,7 +55,7 @@ public class BrowseByColumn extends StaticItemColumn {
     public BrowseByColumn(Finder finder, Resources resources) {
         super(finder, Ids.DEPLOYMENT_BROWSE_BY, resources.constants().browseBy(),
                 Arrays.asList(
-                        new StaticItem.Builder(resources.constants().contentRepository())
+                        new StaticItem.Builder(Names.CONTENT_REPOSITORY)
                                 .onPreview(new ContentRepositoryPreview(resources))
                                 .nextColumn(Ids.CONTENT)
                                 .build(),

--- a/app/src/main/java/org/jboss/hal/client/deployment/ServerGroupDeploymentPreview.java
+++ b/app/src/main/java/org/jboss/hal/client/deployment/ServerGroupDeploymentPreview.java
@@ -99,7 +99,7 @@ class ServerGroupDeploymentPreview extends DeploymentPreview<ServerGroupDeployme
         }
         attributes.append(model -> {
             PlaceRequest placeRequest = places.finderPlace(NameTokens.DEPLOYMENTS, new FinderPath()
-                    .append(Ids.DEPLOYMENT_BROWSE_BY, Ids.asId(resources.constants().contentRepository()))
+                    .append(Ids.DEPLOYMENT_BROWSE_BY, Ids.asId(Names.CONTENT_REPOSITORY))
                     .append(Ids.CONTENT, Strings.sanitize(Ids.content(model.getName()))))
                     .build();
             return new PreviewAttribute(resources.constants().providedBy(), model.getName(),

--- a/app/src/main/java/org/jboss/hal/client/homepage/TourSetup.java
+++ b/app/src/main/java/org/jboss/hal/client/homepage/TourSetup.java
@@ -135,7 +135,7 @@ class TourSetup {
         // place requests for domain mode
         PlaceRequest deploymentsContentRepository = places.finderPlace(NameTokens.DEPLOYMENTS,
                 new FinderPath().append(Ids.DEPLOYMENT_BROWSE_BY,
-                        Ids.asId(resources.constants().contentRepository())))
+                        Ids.asId(Names.CONTENT_REPOSITORY)))
                 .build();
         PlaceRequest profiles = places.finderPlace(NameTokens.CONFIGURATION,
                 new FinderPath().append(Ids.CONFIGURATION, Ids.asId(Names.PROFILES))).build();

--- a/core/src/main/java/org/jboss/hal/core/finder/FinderPathFactory.java
+++ b/core/src/main/java/org/jboss/hal/core/finder/FinderPathFactory.java
@@ -78,7 +78,7 @@ public class FinderPathFactory {
             return deployment(content);
         } else {
             return new FinderPath()
-                    .append(Ids.DEPLOYMENT_BROWSE_BY, Ids.asId(resources.constants().contentRepository()),
+                    .append(Ids.DEPLOYMENT_BROWSE_BY, Ids.asId(Names.CONTENT_REPOSITORY),
                             resources.constants().browseBy(), resources.constants().contentRepository())
                     .append(Ids.CONTENT, Ids.content(content),
                             resources.constants().content(), content);

--- a/resources/src/main/java/org/jboss/hal/resources/Names.java
+++ b/resources/src/main/java/org/jboss/hal/resources/Names.java
@@ -77,6 +77,7 @@ public interface Names {
     String CONSUMERS = "Consumers";
     String CONSOLE_ACCESS_LOG = "Console Access Log";
     String CONSOLE_ACTION_HANDLER = "Console ActionHandler";
+    String CONTENT_REPOSITORY = "Content Repository";
     String CONTEXT = "Context";
     String CONTEXT_ROOT = "Context Root";
     String CONTEXT_ROOTS = "Context Roots";


### PR DESCRIPTION
Issue: [HAL-1984](https://issues.redhat.com/browse/HAL-1984)

Changed the ids to not use localized strings. This completely prevented content-repository from being accessible in locales that aren't using the Latin alphabet. The access control was working but the links were causing visual issues. e.g. items not being correctly highlighted (this was happening even with English locale).