### PR TITLE
HAL-1985: fix description processing for nested attributes

### DIFF
--- a/app/src/main/java/org/jboss/hal/client/configuration/subsystem/datasource/wizard/DriverStep.java
+++ b/app/src/main/java/org/jboss/hal/client/configuration/subsystem/datasource/wizard/DriverStep.java
@@ -39,7 +39,6 @@ import com.google.common.collect.Maps;
 import elemental2.dom.HTMLElement;
 
 import static org.jboss.hal.dmr.ModelDescriptionConstants.ACCESS_TYPE;
-import static org.jboss.hal.dmr.ModelDescriptionConstants.ATTRIBUTES;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.DRIVER_CLASS;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.DRIVER_CLASS_NAME;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.DRIVER_NAME;
@@ -86,15 +85,15 @@ class DriverStep extends WizardStep<Context, State> {
 
     private Metadata adjustMetadata(Metadata metadata) {
         ModelNode newAttributes = new ModelNode();
-        for (Property property : metadata.getDescription().get(ATTRIBUTES).asPropertyList()) {
+        for (Property property : metadata.getDescription().attributes()) {
             ModelNode value = property.getValue().clone();
             value.get(ACCESS_TYPE).set(READ_WRITE);
             value.get(NILLABLE).set(!DRIVER_XA_DATASOURCE_CLASS_NAME.equals(property.getName()));
             newAttributes.get(property.getName()).set(value);
         }
 
-        metadata.getDescription().remove(ATTRIBUTES);
-        metadata.getDescription().get(ATTRIBUTES).set(newAttributes);
+        metadata.getDescription().attributes().clear();
+        metadata.getDescription().attributes().addAll(newAttributes.asPropertyList());
         return metadata;
     }
 

--- a/app/src/main/java/org/jboss/hal/client/configuration/subsystem/datasource/wizard/PropertiesStep.java
+++ b/app/src/main/java/org/jboss/hal/client/configuration/subsystem/datasource/wizard/PropertiesStep.java
@@ -48,7 +48,6 @@ import static org.jboss.hal.client.configuration.subsystem.datasource.JdbcDriver
 import static org.jboss.hal.dmr.ModelDescriptionConstants.DRIVER_NAME;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.VALUE;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.XA_DATASOURCE_CLASS;
-import static org.jboss.hal.dmr.ModelNodeHelper.failSafeGet;
 import static org.jboss.hal.flow.Flow.sequential;
 
 class PropertiesStep extends WizardStep<Context, State> {
@@ -76,10 +75,9 @@ class PropertiesStep extends WizardStep<Context, State> {
         dummy = new ModelNode().setEmptyObject();
         propertiesItem = new PropertiesItem(VALUE);
         propertiesItem.setRequired(true);
-        ModelNode propertiesDescription = failSafeGet(metadata.getDescription(),
-                "attributes/value/description"); // NON-NLS
+        String propertiesDescription = metadata.getDescription().attributes().description(VALUE);
         form = new ModelNodeForm.Builder<>(Ids.DATA_SOURCE_PROPERTIES_FORM, Metadata.empty())
-                .unboundFormItem(propertiesItem, 0, SafeHtmlUtils.fromString(propertiesDescription.asString()))
+                .unboundFormItem(propertiesItem, 0, SafeHtmlUtils.fromString(propertiesDescription))
                 .build();
         propsAutoComplete = new StaticAutoComplete(Collections.emptyList());
         propertiesItem.registerSuggestHandler(propsAutoComplete);

--- a/app/src/main/java/org/jboss/hal/client/configuration/subsystem/elytron/OtherSettingsPresenter.java
+++ b/app/src/main/java/org/jboss/hal/client/configuration/subsystem/elytron/OtherSettingsPresenter.java
@@ -113,7 +113,6 @@ import static org.jboss.hal.client.configuration.subsystem.elytron.AddressTempla
 import static org.jboss.hal.client.configuration.subsystem.elytron.AddressTemplates.TRUST_MANAGER_ADDRESS;
 import static org.jboss.hal.client.configuration.subsystem.elytron.ElytronResource.SYSLOG_AUDIT_LOG;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.ALIAS;
-import static org.jboss.hal.dmr.ModelDescriptionConstants.ATTRIBUTES;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.CAPABILITY_REFERENCE;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.CHILD_TYPE;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.CLASS_NAME;
@@ -122,7 +121,6 @@ import static org.jboss.hal.dmr.ModelDescriptionConstants.CREATE;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.CREDENTIAL_REFERENCE;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.CREDENTIAL_STORE;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.DEFAULT_REALM;
-import static org.jboss.hal.dmr.ModelDescriptionConstants.DESCRIPTION;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.EXPRESSION;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.FLAG;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.INDEX;
@@ -319,7 +317,7 @@ public class OtherSettingsPresenter extends MbuiPresenter<OtherSettingsPresenter
     void addCredentialStore() {
         Metadata metadata = metadataRegistry.lookup(CREDENTIAL_STORE_TEMPLATE);
         SafeHtml typeHelp = SafeHtmlUtils.fromString(
-                metadata.getDescription().get(ATTRIBUTES).get(TYPE).get(DESCRIPTION).asString());
+                metadata.getDescription().attributes().description(TYPE));
         Metadata crMetadata = metadata.forComplexAttribute(CREDENTIAL_REFERENCE, true);
         crMetadata.copyComplexAttributeAttributes(asList(STORE, ALIAS, TYPE, CLEAR_TEXT), metadata);
         TextBoxItem typeItem = new TextBoxItem("type-", resources.constants().type());
@@ -393,9 +391,7 @@ public class OtherSettingsPresenter extends MbuiPresenter<OtherSettingsPresenter
         Metadata metadata = metadataRegistry.lookup(SECURITY_DOMAIN_TEMPLATE);
         // emulate capability-reference on default-realm
         String capabilityReference = metadata.getDescription()
-                .findAttribute(ATTRIBUTES + "/" + REALMS + "/" + VALUE_TYPE, REALM)
-                .getValue()
-                .get(CAPABILITY_REFERENCE)
+                .attributes().get(REALMS).get(VALUE_TYPE, REALM, CAPABILITY_REFERENCE)
                 .asString();
 
         String id = Ids.build(Ids.ELYTRON_SECURITY_DOMAIN, Ids.ADD);
@@ -441,12 +437,7 @@ public class OtherSettingsPresenter extends MbuiPresenter<OtherSettingsPresenter
         String crTypeLabel = new LabelBuilder().label(crType);
         TextBoxItem crTypeItem = new TextBoxItem(crType, crTypeLabel);
         SafeHtml crTypeItemHelp = SafeHtmlUtils.fromString(metadata.getDescription()
-                .get(ATTRIBUTES)
-                .get(CREDENTIAL_REFERENCE)
-                .get(VALUE_TYPE)
-                .get(TYPE)
-                .get(DESCRIPTION)
-                .asString());
+                .attributes().description(CREDENTIAL_REFERENCE + "." + TYPE));
 
         ModelNodeForm<ModelNode> form = new ModelNodeForm.Builder<>(id, metadata)
                 .addOnly()

--- a/app/src/main/java/org/jboss/hal/client/configuration/subsystem/elytron/RealmsPresenter.java
+++ b/app/src/main/java/org/jboss/hal/client/configuration/subsystem/elytron/RealmsPresenter.java
@@ -79,7 +79,6 @@ import static org.jboss.hal.client.configuration.subsystem.elytron.AddressTempla
 import static org.jboss.hal.client.configuration.subsystem.elytron.AddressTemplates.SIMPLE_REGEX_REALM_MAPPER_ADDRESS;
 import static org.jboss.hal.client.configuration.subsystem.elytron.AddressTemplates.TOKEN_REALM_ADDRESS;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.ALLOW_BLANK_PASSWORD;
-import static org.jboss.hal.dmr.ModelDescriptionConstants.ATTRIBUTES;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.ATTRIBUTE_MAPPING;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.DIRECT_VERIFICATION;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.DIR_CONTEXT;
@@ -421,7 +420,7 @@ public class RealmsPresenter extends MbuiPresenter<RealmsPresenter.MyView, Realm
         Metadata metadata = metadataRegistry.lookup(LDAP_REALM_TEMPLATE)
                 .forComplexAttribute(IDENTITY_MAPPING)
                 .forComplexAttribute(complexAttribute);
-        boolean requiredAttributes = !metadata.getDescription().getRequiredAttributes(ATTRIBUTES).isEmpty();
+        boolean requiredAttributes = !metadata.getDescription().attributes().required().isEmpty();
         ModelNodeForm.Builder<ModelNode> builder = new ModelNodeForm.Builder<>(id, metadata)
                 .addOnly();
         if (requiredAttributes) {

--- a/app/src/main/java/org/jboss/hal/client/configuration/subsystem/infinispan/CacheContainerColumn.java
+++ b/app/src/main/java/org/jboss/hal/client/configuration/subsystem/infinispan/CacheContainerColumn.java
@@ -74,9 +74,7 @@ import static org.jboss.hal.dmr.ModelDescriptionConstants.CACHE_CONTAINER;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.DEFAULT_CACHE;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.DEFAULT_REMOTE_CLUSTER;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.NAME;
-import static org.jboss.hal.dmr.ModelDescriptionConstants.OPERATIONS;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.REMOTE_CACHE_CONTAINER;
-import static org.jboss.hal.dmr.ModelDescriptionConstants.REQUEST_PROPERTIES;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.RESULT;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.SOCKET_BINDINGS;
 import static org.jboss.hal.dmr.ModelNodeHelper.failSafeGet;
@@ -225,11 +223,8 @@ public class CacheContainerColumn extends FinderColumn<CacheContainer> {
         Metadata rcMetadata = metadataRegistry.lookup(REMOTE_CLUSTER_TEMPLATE);
 
         // add nested 'socket-bindings' attribute from 'remote-cluster' resource to top level metadata
-        String path = OPERATIONS + "/" + ADD + "/" + REQUEST_PROPERTIES;
-        Property socketBindingsDescription = rcMetadata.getDescription().findAttribute(path, SOCKET_BINDINGS);
-        failSafeGet(rccMetadata.getDescription(), path)
-                .get(SOCKET_BINDINGS)
-                .set(socketBindingsDescription.getValue());
+        Property socketBindingsDescription = rcMetadata.getDescription().requestProperties().property(SOCKET_BINDINGS);
+        rccMetadata.getDescription().requestProperties().add(socketBindingsDescription);
         ModelNode socketBindingsPermissions = failSafeGet(rcMetadata.getSecurityContext(),
                 ATTRIBUTES + "/" + SOCKET_BINDINGS);
         failSafeGet(rccMetadata.getSecurityContext(), ATTRIBUTES)

--- a/app/src/main/java/org/jboss/hal/client/configuration/subsystem/jca/JcaView.java
+++ b/app/src/main/java/org/jboss/hal/client/configuration/subsystem/jca/JcaView.java
@@ -257,11 +257,10 @@ public class JcaView extends HalViewImpl implements JcaPresenter.MyView {
         Metadata srtMetadata = metadataRegistry.lookup(WORKMANAGER_SRT_TEMPLATE);
 
         // short-running-thread is required for a distributed workmanager
-        Property maxThreadsDesc = srtMetadata.getDescription().findAttribute(ATTRIBUTES, MAX_THREADS);
-        Property queueLengthDesc = srtMetadata.getDescription().findAttribute(ATTRIBUTES, QUEUE_LENGTH);
-        ModelNode addOpDwm = dwmMetadata.getDescription().get(OPERATIONS).get(ADD).get(REQUEST_PROPERTIES);
-        addOpDwm.get(MAX_THREADS).set(maxThreadsDesc.getValue());
-        addOpDwm.get(QUEUE_LENGTH).set(queueLengthDesc.getValue());
+        Property maxThreadsDesc = srtMetadata.getDescription().attributes().property(MAX_THREADS);
+        Property queueLengthDesc = srtMetadata.getDescription().attributes().property(QUEUE_LENGTH);
+        dwmMetadata.getDescription().requestProperties().add(maxThreadsDesc);
+        dwmMetadata.getDescription().requestProperties().add(queueLengthDesc);
         dwmMetadata.makeWritable(MAX_THREADS);
         dwmMetadata.makeWritable(QUEUE_LENGTH);
 

--- a/app/src/main/java/org/jboss/hal/client/configuration/subsystem/messaging/JmsBridgeView.java
+++ b/app/src/main/java/org/jboss/hal/client/configuration/subsystem/messaging/JmsBridgeView.java
@@ -58,7 +58,7 @@ public class JmsBridgeView extends HalViewImpl implements JmsBridgePresenter.MyV
         List<String> attributes = new ArrayList<>();
         List<String> sourceAttrs = new ArrayList<>();
         List<String> targetAttrs = new ArrayList<>();
-        jmsBridgeMetadata.getDescription().getAttributes(ATTRIBUTES).forEach(p -> {
+        jmsBridgeMetadata.getDescription().attributes().forEach(p -> {
             if (p.getName().startsWith(SOURCE)) {
                 sourceAttrs.add(p.getName());
             } else if (p.getName().startsWith(TARGET)) {

--- a/app/src/main/java/org/jboss/hal/client/configuration/subsystem/messaging/ServerView.java
+++ b/app/src/main/java/org/jboss/hal/client/configuration/subsystem/messaging/ServerView.java
@@ -74,7 +74,7 @@ public class ServerView extends HalViewImpl implements ServerPresenter.MyView {
         // there are several attributes with no attribute-group
         // wee add them under "attributes" tab
         List<String> attrs = new ArrayList<>();
-        metadata.getDescription().getAttributes(ATTRIBUTES).forEach(p -> {
+        metadata.getDescription().attributes().forEach(p -> {
             if (!p.getValue().hasDefined("attribute-group")) {
                 attrs.add(p.getName());
             }

--- a/app/src/main/java/org/jboss/hal/client/configuration/subsystem/microprofile/AddConfigSourceWizard.java
+++ b/app/src/main/java/org/jboss/hal/client/configuration/subsystem/microprofile/AddConfigSourceWizard.java
@@ -29,7 +29,6 @@ import org.jboss.hal.core.mbui.dialog.NameItem;
 import org.jboss.hal.core.mbui.form.ModelNodeForm;
 import org.jboss.hal.dmr.ModelNode;
 import org.jboss.hal.dmr.Operation;
-import org.jboss.hal.dmr.Property;
 import org.jboss.hal.dmr.ResourceAddress;
 import org.jboss.hal.dmr.dispatch.Dispatcher;
 import org.jboss.hal.meta.Metadata;
@@ -49,9 +48,7 @@ import static org.jboss.elemento.Elements.p;
 import static org.jboss.elemento.Elements.setVisible;
 import static org.jboss.hal.client.configuration.subsystem.microprofile.AddressTemplates.CONFIG_SOURCE_TEMPLATE;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.ADD;
-import static org.jboss.hal.dmr.ModelDescriptionConstants.ATTRIBUTES;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.CLASS;
-import static org.jboss.hal.dmr.ModelDescriptionConstants.DESCRIPTION;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.DIR;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.MODULE;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.ORDINAL;
@@ -192,11 +189,7 @@ class AddConfigSourceWizard {
                     .build();
             registerAttachable(form);
 
-            Property operation = metadata.getDescription().findOperation(ADD);
-            String description = "";
-            if (operation != null) {
-                description = operation.getValue().get(DESCRIPTION).asString();
-            }
+            String description = metadata.getDescription().operations().description(ADD);
 
             root = div()
                     .add(p().textContent(description))
@@ -293,10 +286,9 @@ class AddConfigSourceWizard {
             id = Ids.build(Ids.MICRO_PROFILE_CONFIG_SOURCE, attribute, Ids.FORM);
             metadata = configSourceMeta;
             description = p().textContent(metadata.getDescription()
-                    .findAttribute(ATTRIBUTES, PROPERTIES)
-                    .getValue()
-                    .get(DESCRIPTION)
-                    .asString()).element();
+                    .attributes()
+                    .description(PROPERTIES))
+                    .element();
             form = new ModelNodeForm.Builder<>(id, configSourceMeta)
                     .include(attribute)
                     .onSave((f, changedValues) -> {
@@ -375,10 +367,7 @@ class AddConfigSourceWizard {
             registerAttachable(form);
 
             String attributeDescription = metadata.getDescription()
-                    .findAttribute(ATTRIBUTES, ORDINAL)
-                    .getValue()
-                    .get(DESCRIPTION)
-                    .asString();
+                    .attributes().description(ORDINAL);
             root = div()
                     .add(p().textContent(attributeDescription))
                     .add(form).element();

--- a/app/src/main/java/org/jboss/hal/client/configuration/subsystem/webservice/ConfigElement.java
+++ b/app/src/main/java/org/jboss/hal/client/configuration/subsystem/webservice/ConfigElement.java
@@ -30,7 +30,6 @@ import org.jboss.hal.core.mbui.form.ModelNodeForm;
 import org.jboss.hal.core.mbui.table.ModelNodeTable;
 import org.jboss.hal.core.mbui.table.TableButtonFactory;
 import org.jboss.hal.core.mvp.HasPresenter;
-import org.jboss.hal.dmr.ModelNode;
 import org.jboss.hal.dmr.NamedNode;
 import org.jboss.hal.dmr.Property;
 import org.jboss.hal.meta.Metadata;
@@ -52,7 +51,6 @@ import static org.jboss.hal.client.configuration.subsystem.webservice.HandlerCha
 import static org.jboss.hal.dmr.ModelDescriptionConstants.NAME;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.PROPERTY;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.VALUE;
-import static org.jboss.hal.dmr.ModelNodeHelper.failSafeGet;
 import static org.jboss.hal.dmr.ModelNodeHelper.failSafePropertyList;
 
 /** Element to configure client and endpoint configurations. */
@@ -83,10 +81,10 @@ class ConfigElement implements IsElement<HTMLElement>, Attachable, HasPresenter<
                 .column(inlineActions)
                 .build();
 
-        ModelNode propertyDescription = failSafeGet(metadata.getDescription(), "children/property/description");
+        String propertyDescription = metadata.getDescription().children().description(PROPERTY);
         propertiesItem = new PropertiesItem(PROPERTY);
         form = new ModelNodeForm.Builder<NamedNode>(Ids.build(configType.baseId, Ids.FORM), metadata)
-                .unboundFormItem(propertiesItem, 0, SafeHtmlUtils.fromString(propertyDescription.asString()))
+                .unboundFormItem(propertiesItem, 0, SafeHtmlUtils.fromString(propertyDescription))
                 .onSave((form, changedValues) -> presenter.saveConfig(form, changedValues, PROPERTY))
                 .prepareReset(form -> presenter.resetConfig(form))
                 .build();

--- a/app/src/main/java/org/jboss/hal/client/deployment/dialog/AddUnmanagedDialog.java
+++ b/app/src/main/java/org/jboss/hal/client/deployment/dialog/AddUnmanagedDialog.java
@@ -21,7 +21,7 @@ import org.jboss.hal.core.mbui.dialog.AddResourceDialog;
 import org.jboss.hal.core.mbui.dialog.NameItem;
 import org.jboss.hal.core.mbui.form.ModelNodeForm;
 import org.jboss.hal.dmr.ModelNode;
-import org.jboss.hal.dmr.ModelNodeHelper;
+import org.jboss.hal.meta.AttributeCollection;
 import org.jboss.hal.meta.Metadata;
 import org.jboss.hal.meta.description.ResourceDescription;
 import org.jboss.hal.resources.Ids;
@@ -35,17 +35,15 @@ public class AddUnmanagedDialog {
     private final AddResourceDialog dialog;
 
     public AddUnmanagedDialog(Metadata metadata, Resources resources, AddResourceDialog.Callback callback) {
-        ModelNode rp = ModelNodeHelper.failSafeGet(metadata.getDescription(),
-                String.join("/", OPERATIONS, ADD, REQUEST_PROPERTIES));
-        ModelNode vt = ModelNodeHelper.failSafeGet(rp, CONTENT + "/" + VALUE_TYPE);
+        AttributeCollection rp = metadata.getDescription().requestProperties();
         // the "path" attribute requires "archive", but archive may be false, that is a directory deployment
         // but the validation will not let pass, so remove the "requires" and manually set the value if user sets it
-        vt.get(PATH).remove(REQUIRES);
+        rp.get(CONTENT + "." + PATH).remove(REQUIRES);
         ModelNode attributes = new ModelNode();
         attributes.get(RUNTIME_NAME).set(rp.get(RUNTIME_NAME));
-        attributes.get(PATH).set(vt.get(PATH));
-        attributes.get(RELATIVE_TO).set(vt.get(RELATIVE_TO));
-        attributes.get(ARCHIVE).set(vt.get(ARCHIVE));
+        attributes.get(PATH).set(rp.get(CONTENT + "." + PATH));
+        attributes.get(RELATIVE_TO).set(rp.get(CONTENT + "." + RELATIVE_TO));
+        attributes.get(ARCHIVE).set(rp.get(CONTENT + "." + ARCHIVE));
         ModelNode description = new ModelNode();
         description.get(ATTRIBUTES).set(attributes);
 

--- a/app/src/main/java/org/jboss/hal/client/runtime/BootErrorsElement.java
+++ b/app/src/main/java/org/jboss/hal/client/runtime/BootErrorsElement.java
@@ -66,10 +66,10 @@ public class BootErrorsElement implements IsElement<HTMLElement>, Attachable {
 
         // repackage the description and the value-type of the boot errors reply properties
         Metadata managementMetadata = metadataRegistry.lookup(template);
-        ModelNode description = ModelNodeHelper.failSafeGet(managementMetadata.getDescription(),
-                String.join("/", OPERATIONS, READ_BOOT_ERRORS, DESCRIPTION));
-        ModelNode attributes = ModelNodeHelper.failSafeGet(managementMetadata.getDescription(),
-                String.join("/", OPERATIONS, READ_BOOT_ERRORS, REPLY_PROPERTIES, VALUE_TYPE));
+        String description = managementMetadata.getDescription().operations().description(READ_BOOT_ERRORS);
+        ModelNode attributes = ModelNodeHelper.failSafeGet(
+                managementMetadata.getDescription().operations().get(READ_BOOT_ERRORS),
+                String.join("/", REPLY_PROPERTIES, VALUE_TYPE));
         ModelNode modelNode = new ModelNode();
         modelNode.get(DESCRIPTION).set(description);
         modelNode.get(ATTRIBUTES).set(attributes);

--- a/app/src/main/java/org/jboss/hal/client/runtime/subsystem/batch/JobColumn.java
+++ b/app/src/main/java/org/jboss/hal/client/runtime/subsystem/batch/JobColumn.java
@@ -70,7 +70,6 @@ import static org.jboss.hal.client.runtime.subsystem.batch.AddressTemplates.BATC
 import static org.jboss.hal.core.finder.FinderColumn.RefreshMode.RESTORE_SELECTION;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.ACCESS_TYPE;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.ALLOWED;
-import static org.jboss.hal.dmr.ModelDescriptionConstants.ATTRIBUTES;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.BATCH_JBERET;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.DEPLOYMENT;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.JOB;
@@ -235,12 +234,12 @@ public class JobColumn extends FinderColumn<JobNode> {
         Metadata operationMetadata = metadata.forOperation(START_JOB);
         if (xmlNames > 1) {
             operationMetadata.getDescription()
-                    .get(ATTRIBUTES)
+                    .attributes()
                     .get(JOB_XML_NAME)
                     .get(ALLOWED).set(job.get(JOB_XML_NAMES));
         } else {
             operationMetadata.getDescription()
-                    .get(ATTRIBUTES)
+                    .attributes()
                     .get(JOB_XML_NAME)
                     .get(ACCESS_TYPE).set(READ_ONLY);
         }

--- a/app/src/main/java/org/jboss/hal/client/runtime/subsystem/ejb/EjbView.java
+++ b/app/src/main/java/org/jboss/hal/client/runtime/subsystem/ejb/EjbView.java
@@ -47,7 +47,6 @@ import static org.jboss.elemento.Elements.p;
 import static org.jboss.hal.ballroom.LayoutBuilder.column;
 import static org.jboss.hal.ballroom.LayoutBuilder.row;
 import static org.jboss.hal.client.runtime.subsystem.ejb.AddressTemplates.ejbDeploymentTemplate;
-import static org.jboss.hal.dmr.ModelDescriptionConstants.ATTRIBUTES;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.NAME;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.NEXT_TIMEOUT;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.TIMERS;
@@ -86,7 +85,7 @@ public class EjbView extends HalViewImpl implements EjbPresenter.MyView {
         Metadata scheduleMetadata = timersMetadata.forComplexAttribute("schedule");
 
         // methods come in a property list, we need to add an identifier to the table
-        methodsMetadata.getDescription().get(ATTRIBUTES).get(NAME);
+        methodsMetadata.getDescription().attributes().add(new Property(NAME, new ModelNode().set(NAME)));
 
         methodsTable = new ModelNodeTable.Builder<>("ejb-bean-methods-table", methodsMetadata)
                 .columns("name", "execution-time", "invocations", "wait-time")

--- a/app/src/main/java/org/jboss/hal/client/runtime/subsystem/elytron/StoresPresenter.java
+++ b/app/src/main/java/org/jboss/hal/client/runtime/subsystem/elytron/StoresPresenter.java
@@ -98,8 +98,6 @@ import static org.jboss.hal.client.runtime.subsystem.elytron.AddressTemplates.SE
 import static org.jboss.hal.client.runtime.subsystem.elytron.AddressTemplates.SECRET_KEY_CREDENTIAL_STORE_TEMPLATE;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.ADD_ALIAS;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.ALIAS;
-import static org.jboss.hal.dmr.ModelDescriptionConstants.ATTRIBUTES;
-import static org.jboss.hal.dmr.ModelDescriptionConstants.CAPABILITY_REFERENCE;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.CERTIFICATE_AUTHORITY_ACCOUNT;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.CHANGE_ALIAS;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.CHILD_TYPE;
@@ -747,10 +745,8 @@ public class StoresPresenter extends ApplicationFinderPresenter<StoresPresenter.
             // the capability reference the /profile=* resource and the template attached to the metadata
             // points to the {selected.host}/{selected.server}, so we need to register the template to the profile
             String capability = metadata.getDescription()
-                    .get(ATTRIBUTES)
-                    .get(CERTIFICATE_AUTHORITY_ACCOUNT)
-                    .get(CAPABILITY_REFERENCE)
-                    .asString();
+                    .attributes()
+                    .capabilityReference(CERTIFICATE_AUTHORITY_ACCOUNT);
             form.getFormItem(CERTIFICATE_AUTHORITY_ACCOUNT)
                     .registerSuggestHandler(
                             new SuggestCapabilitiesAutoComplete(dispatcher, statementContext, capability,
@@ -792,10 +788,8 @@ public class StoresPresenter extends ApplicationFinderPresenter<StoresPresenter.
             // the capability reference the /profile=* resource and the template attached to the metadata
             // points to the {selected.host}/{selected.server}, so we need to register the template to the profile
             String capability = metadata.getDescription()
-                    .get(ATTRIBUTES)
-                    .get(CERTIFICATE_AUTHORITY_ACCOUNT)
-                    .get(CAPABILITY_REFERENCE)
-                    .asString();
+                    .attributes()
+                    .capabilityReference(CERTIFICATE_AUTHORITY_ACCOUNT);
             form.getFormItem(CERTIFICATE_AUTHORITY_ACCOUNT)
                     .registerSuggestHandler(
                             new SuggestCapabilitiesAutoComplete(dispatcher, statementContext, capability,

--- a/app/src/main/java/org/jboss/hal/client/runtime/subsystem/elytron/wizardpassword/ConfigurePasswordStep.java
+++ b/app/src/main/java/org/jboss/hal/client/runtime/subsystem/elytron/wizardpassword/ConfigurePasswordStep.java
@@ -74,7 +74,7 @@ public class ConfigurePasswordStep extends WizardStep<PasswordContext, PasswordS
         String id = Ids.build(template.lastName(), SET_PASSWORD, FORM);
         ModelNodeForm.Builder<ModelNode> builder = new ModelNodeForm.Builder<>(id, passwordMetadata)
                 .onSave((form1, changedValues) -> this.changedValues = changedValues);
-        passwordMetadata.getDescription().getAttributes(ATTRIBUTES).forEach(attr -> {
+        passwordMetadata.getDescription().attributes().forEach(attr -> {
             if (ModelType.BYTES.equals(attr.getValue().get(TYPE).asType())) {
                 builder.customFormItem(attr.getName(), desc -> {
                     TextBoxItem saltItem = new TextBoxItem(attr.getName(), labelBuilder.label(attr.getName()));

--- a/app/src/main/java/org/jboss/hal/client/runtime/subsystem/elytron/wizardpassword/ReviewPasswordStep.java
+++ b/app/src/main/java/org/jboss/hal/client/runtime/subsystem/elytron/wizardpassword/ReviewPasswordStep.java
@@ -32,7 +32,6 @@ import elemental2.dom.HTMLElement;
 import static org.jboss.elemento.Elements.h;
 import static org.jboss.elemento.Elements.p;
 import static org.jboss.elemento.Elements.section;
-import static org.jboss.hal.dmr.ModelDescriptionConstants.ATTRIBUTES;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.SALT;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.SET_PASSWORD;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.TYPE;
@@ -70,7 +69,7 @@ public class ReviewPasswordStep extends WizardStep<PasswordContext, PasswordStat
         String id = Ids.build(template.lastName(), SET_PASSWORD, "review", FORM);
         ModelNodeForm.Builder<ModelNode> builder = new ModelNodeForm.Builder<>(id, passwordMetadata)
                 .readOnly();
-        passwordMetadata.getDescription().getAttributes(ATTRIBUTES).forEach(attr -> {
+        passwordMetadata.getDescription().attributes().forEach(attr -> {
             if (ModelType.BYTES.equals(attr.getValue().get(TYPE).asType())) {
                 builder.customFormItem(attr.getName(),
                         desc -> new TextBoxItem(attr.getName(), labelBuilder.label(attr.getName())));

--- a/app/src/main/java/org/jboss/hal/client/runtime/subsystem/messaging/ResetServerDialog.java
+++ b/app/src/main/java/org/jboss/hal/client/runtime/subsystem/messaging/ResetServerDialog.java
@@ -23,7 +23,6 @@ import org.jboss.hal.ballroom.form.SwitchItem;
 import org.jboss.hal.core.mbui.form.ModelNodeForm;
 import org.jboss.hal.core.mbui.form.RequireAtLeastOneAttributeValidation;
 import org.jboss.hal.dmr.ModelNode;
-import org.jboss.hal.dmr.Property;
 import org.jboss.hal.meta.Metadata;
 import org.jboss.hal.resources.Ids;
 import org.jboss.hal.resources.Resources;
@@ -36,7 +35,6 @@ import static java.util.Arrays.asList;
 import static org.jboss.elemento.Elements.asHtmlElement;
 import static org.jboss.elemento.Elements.htmlElements;
 import static org.jboss.elemento.Elements.stream;
-import static org.jboss.hal.dmr.ModelDescriptionConstants.DESCRIPTION;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.RESET_ALL_MESSAGE_COUNTERS;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.RESET_ALL_MESSAGE_COUNTER_HISTORIES;
 import static org.jboss.hal.resources.CSS.halFormInput;
@@ -58,17 +56,15 @@ class ResetServerDialog {
         LabelBuilder labelBuilder = new LabelBuilder();
 
         String l1 = labelBuilder.label(RESET_ALL_MESSAGE_COUNTERS);
-        Property p1 = metadata.getDescription().findOperation(RESET_ALL_MESSAGE_COUNTERS);
-        if (p1 != null && p1.getValue().hasDefined(DESCRIPTION)) {
-            l1 = p1.getValue().get(DESCRIPTION).asString();
-            l1 = Strings.sanitize(l1);
+        String d1 = metadata.getDescription().operations().description(RESET_ALL_MESSAGE_COUNTERS);
+        if (!d1.equals("undefined")) {
+            l1 = Strings.sanitize(d1);
         }
 
         String l2 = labelBuilder.label(RESET_ALL_MESSAGE_COUNTER_HISTORIES);
-        Property p2 = metadata.getDescription().findOperation(RESET_ALL_MESSAGE_COUNTER_HISTORIES);
-        if (p2 != null && p2.getValue().hasDefined(DESCRIPTION)) {
-            l2 = p2.getValue().get(DESCRIPTION).asString();
-            l2 = Strings.sanitize(l2);
+        String d2 = metadata.getDescription().operations().description(RESET_ALL_MESSAGE_COUNTER_HISTORIES);
+        if (d2.equals("undefined")) {
+            l2 = Strings.sanitize(d2);
         }
 
         Form<ModelNode> form = new ModelNodeForm.Builder<>(Ids.RESET_MESSAGE_COUNTERS, Metadata.empty())

--- a/app/src/main/java/org/jboss/hal/client/runtime/subsystem/messaging/ServerView.java
+++ b/app/src/main/java/org/jboss/hal/client/runtime/subsystem/messaging/ServerView.java
@@ -333,10 +333,9 @@ public class ServerView extends HalViewImpl implements MyView {
     private Metadata getRolesReplyMetadata(Metadata metadata) {
         ModelNode payload = new ModelNode();
         ResourceDescription description = metadata.getDescription();
-        payload.get(DESCRIPTION).set(failSafeGet(description,
-                String.join("/", OPERATIONS, GET_ROLES, DESCRIPTION)));
-        payload.get(ATTRIBUTES).set(failSafeGet(description,
-                String.join("/", OPERATIONS, GET_ROLES, REPLY_PROPERTIES, VALUE_TYPE)));
+        payload.get(DESCRIPTION).set(description.operations().description(GET_ROLES));
+        payload.get(ATTRIBUTES).set(failSafeGet(description.operations().get(GET_ROLES),
+                String.join("/", REPLY_PROPERTIES, VALUE_TYPE)));
         return new Metadata(metadata.getTemplate(), () -> SecurityContext.READ_ONLY, new ResourceDescription(payload),
                 metadata.getCapabilities());
     }

--- a/app/src/main/java/org/jboss/hal/client/shared/sslwizard/ConfigurationStep.java
+++ b/app/src/main/java/org/jboss/hal/client/shared/sslwizard/ConfigurationStep.java
@@ -168,7 +168,7 @@ public class ConfigurationStep extends AbstractConfiguration {
         boolean valid = form.save();
         if (valid) {
             // set default values, as metadata comes from an artifical resource description (ssl-mgmt-wizard.dmr)
-            description.getAttributes(ATTRIBUTES).forEach(p -> {
+            description.attributes().forEach(p -> {
                 FormItem formItem = getFormItem(p.getName());
                 if (p.getValue().hasDefined(DEFAULT) && formItem != null && formItem.isEmpty()) {
                     model.get(p.getName()).set(p.getValue().get(DEFAULT));

--- a/app/src/main/java/org/jboss/hal/client/skeleton/SettingsDialog.java
+++ b/app/src/main/java/org/jboss/hal/client/skeleton/SettingsDialog.java
@@ -29,7 +29,6 @@ import org.jboss.hal.config.Settings.Key;
 import org.jboss.hal.core.mbui.dialog.ModifyResourceDialog;
 import org.jboss.hal.core.mbui.form.ModelNodeForm;
 import org.jboss.hal.dmr.ModelNode;
-import org.jboss.hal.dmr.Property;
 import org.jboss.hal.meta.Metadata;
 import org.jboss.hal.resources.Ids;
 import org.jboss.hal.resources.Resources;
@@ -42,7 +41,6 @@ import static java.util.Comparator.naturalOrder;
 import static elemental2.dom.DomGlobal.window;
 import static org.jboss.hal.config.Settings.Key.*;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.ALLOWED;
-import static org.jboss.hal.dmr.ModelDescriptionConstants.ATTRIBUTES;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.DEFAULT;
 
 class SettingsDialog {
@@ -65,11 +63,11 @@ class SettingsDialog {
         multipleLocales = locales.size() > 1;
 
         Metadata metadata = Metadata.staticDescription(RESOURCES.settings());
-        defaultPollTime = metadata.getDescription().get(ATTRIBUTES).get(POLL_TIME.key()).get(DEFAULT).asInt();
+        defaultPollTime = metadata.getDescription().attributes().get(POLL_TIME.key()).get(DEFAULT).asInt();
         if (multipleLocales) {
-            Property locale = metadata.getDescription().findAttribute(ATTRIBUTES, LOCALE.key());
-            if (locale != null && locale.getValue().hasDefined(ALLOWED)) {
-                locales.forEach(l -> locale.getValue().get(ALLOWED).add(l));
+            ModelNode locale = metadata.getDescription().attributes().get(LOCALE.key());
+            if (locale != null && locale.hasDefined(ALLOWED)) {
+                locales.forEach(l -> locale.get(ALLOWED).add(l));
             }
         }
         List<String> attributes = new ArrayList<>();

--- a/core/src/main/java/org/jboss/hal/core/ComplexAttributeOperations.java
+++ b/core/src/main/java/org/jboss/hal/core/ComplexAttributeOperations.java
@@ -173,8 +173,7 @@ public class ComplexAttributeOperations {
             @Override
             public void onMetadata(Metadata metadata) {
                 Metadata caMetadata = metadata.forComplexAttribute(complexAttribute);
-                boolean requiredAttributes = !caMetadata.getDescription()
-                        .getRequiredAttributes(ATTRIBUTE_GROUP)
+                boolean requiredAttributes = !caMetadata.getDescription().attributes().required()
                         .isEmpty();
                 ModelNodeForm.Builder<ModelNode> builder = new ModelNodeForm.Builder<>(id, caMetadata)
                         .addOnly();

--- a/core/src/main/java/org/jboss/hal/core/CrudOperations.java
+++ b/core/src/main/java/org/jboss/hal/core/CrudOperations.java
@@ -63,13 +63,11 @@ import static org.jboss.hal.dmr.ModelDescriptionConstants.ADD;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.CHILD_TYPE;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.INCLUDE_ALIASES;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.NAME;
-import static org.jboss.hal.dmr.ModelDescriptionConstants.OPERATIONS;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.READ_CHILDREN_RESOURCES_OPERATION;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.READ_RESOURCE_OPERATION;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.RECURSIVE;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.RECURSIVE_DEPTH;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.REMOVE;
-import static org.jboss.hal.dmr.ModelDescriptionConstants.REQUEST_PROPERTIES;
 
 /**
  * Contains generic CRUD methods to add, read, update and remove (singleton) resources. Some methods just execute the underlying
@@ -264,8 +262,7 @@ public class CrudOperations {
         metadataProcessor.lookup(template, progress.get(), new SuccessfulMetadataCallback(eventBus, resources) {
             @Override
             public void onMetadata(Metadata metadata) {
-                boolean hasRequiredAttributes = !metadata.getDescription()
-                        .getRequiredAttributes(OPERATIONS + "/" + ADD + "/" + REQUEST_PROPERTIES).isEmpty();
+                boolean hasRequiredAttributes = !metadata.getDescription().requestProperties().required().isEmpty();
                 if (hasRequiredAttributes || !Iterables.isEmpty(attributes)) {
                     // no unbound name item!
                     ModelNodeForm.Builder<ModelNode> builder = new ModelNodeForm.Builder<>(id, metadata)
@@ -297,8 +294,7 @@ public class CrudOperations {
      */
     public void addSingleton(String id, String type, Metadata metadata, AddressTemplate template,
             AddSingletonCallback callback) {
-        boolean hasRequiredAttributes = !metadata.getDescription()
-                .getRequiredAttributes(OPERATIONS + "/" + ADD + "/" + REQUEST_PROPERTIES).isEmpty();
+        boolean hasRequiredAttributes = !metadata.getDescription().requestProperties().required().isEmpty();
         if (hasRequiredAttributes) {
             // no unbound name item!
             ModelNodeForm.Builder<ModelNode> builder = new ModelNodeForm.Builder<>(id, metadata)

--- a/core/src/main/java/org/jboss/hal/core/Json.java
+++ b/core/src/main/java/org/jboss/hal/core/Json.java
@@ -36,7 +36,6 @@ import jsinterop.base.JsPropertyMap;
 import static java.util.Collections.emptyList;
 
 import static elemental2.core.Global.JSON;
-import static org.jboss.hal.dmr.ModelDescriptionConstants.ATTRIBUTES;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.TYPE;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.VALUE_TYPE;
 import static org.jboss.hal.dmr.ModelType.BIG_INTEGER;
@@ -89,13 +88,12 @@ public final class Json {
 
     private static ModelNode iterateMap(JsPropertyMap<Object> map, Metadata metadata, Map<String, String> mappping) {
         ModelNode node = new ModelNode();
-        List<Property> attributeDescriptions = metadata.getDescription().getAttributes(ATTRIBUTES);
 
         map.forEach(jsonName -> {
             String dmrName = mappping.get(jsonName);
             if (dmrName != null) {
-                ModelNode attributeDescription = findAttributeDescription(dmrName, attributeDescriptions);
-                if (attributeDescription != null) {
+                ModelNode attributeDescription = metadata.getDescription().attributes().get(dmrName);
+                if (attributeDescription.isDefined()) {
                     if (map.has(jsonName)) {
                         Any any = map.getAsAny(jsonName);
                         ModelNode value = anyValue(jsonName, dmrName, attributeDescription, any);

--- a/core/src/main/java/org/jboss/hal/core/mbui/ResourceElement.java
+++ b/core/src/main/java/org/jboss/hal/core/mbui/ResourceElement.java
@@ -132,7 +132,7 @@ public class ResourceElement implements IsElement<HTMLElement>, Attachable {
         table = builder.tableBuilder.build();
 
         Set<String> excludeComplexAttributes = new HashSet<>();
-        builder.metadata.getDescription().getAttributes(ATTRIBUTES).forEach(prop -> {
+        builder.metadata.getDescription().attributes().forEach(prop -> {
             String name = prop.getName();
             int pos = name.indexOf('.');
             if (pos != -1) {
@@ -166,9 +166,9 @@ public class ResourceElement implements IsElement<HTMLElement>, Attachable {
             for (String complexAttribute : builder.coAttributes.keySet()) {
                 // is the complex attribute *itself* required?
                 boolean requiredComplexAttribute = false;
-                Property attribute = builder.metadata.getDescription().findAttribute(ATTRIBUTES, complexAttribute);
-                if (attribute != null) {
-                    requiredComplexAttribute = failSafeBoolean(attribute.getValue(), REQUIRED);
+                ModelNode attribute = builder.metadata.getDescription().attributes().get(complexAttribute);
+                if (attribute.isDefined()) {
+                    requiredComplexAttribute = failSafeBoolean(attribute, REQUIRED);
                 }
 
                 Callback callback;
@@ -176,7 +176,7 @@ public class ResourceElement implements IsElement<HTMLElement>, Attachable {
                 Metadata metadata = builder.metadata.forComplexAttribute(complexAttribute);
 
                 // does the complex attribute *contain* required attributes?
-                List<Property> requiredAttributes = metadata.getDescription().getRequiredAttributes(ATTRIBUTES);
+                List<Property> requiredAttributes = metadata.getDescription().attributes().required();
                 if (requiredAttributes.isEmpty()) {
                     callback = () -> builder.mbuiContext.ca().add(selectedResource, complexAttribute, type,
                             metadata.getTemplate(), null, builder.crudCallback);

--- a/core/src/main/java/org/jboss/hal/core/mbui/ResourceElement.java
+++ b/core/src/main/java/org/jboss/hal/core/mbui/ResourceElement.java
@@ -18,8 +18,10 @@ package org.jboss.hal.core.mbui;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
@@ -129,8 +131,22 @@ public class ResourceElement implements IsElement<HTMLElement>, Attachable {
         }
         table = builder.tableBuilder.build();
 
+        Set<String> excludeComplexAttributes = new HashSet<>();
+        builder.metadata.getDescription().getAttributes(ATTRIBUTES).forEach(prop -> {
+            String name = prop.getName();
+            int pos = name.indexOf('.');
+            if (pos != -1) {
+                String parentName = name.substring(0, pos);
+                if (builder.coAttributes.containsKey(parentName) ||
+                        builder.coAttributeForms.containsKey(parentName)) {
+                    excludeComplexAttributes.add(name);
+                }
+            }
+        });
+
         ModelNodeForm.Builder formBuilder = new ModelNodeForm.Builder<NamedNode>(Ids.build(builder.baseId, Ids.FORM),
                 builder.metadata)
+                .exclude(excludeComplexAttributes)
                 .prepareReset(f -> builder.mbuiContext.crud()
                         .reset(builder.type, f.getModel().getName(), builder.metadata.getTemplate(), f,
                                 builder.metadata, builder.crudCallback))

--- a/core/src/main/java/org/jboss/hal/core/mbui/form/FormHelper.java
+++ b/core/src/main/java/org/jboss/hal/core/mbui/form/FormHelper.java
@@ -28,8 +28,6 @@ import org.jboss.hal.meta.description.ResourceDescription;
 
 import static org.jboss.hal.dmr.ModelDescriptionConstants.ACCESS_TYPE;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.ALTERNATIVES;
-import static org.jboss.hal.dmr.ModelDescriptionConstants.ATTRIBUTES;
-import static org.jboss.hal.dmr.ModelDescriptionConstants.DEPRECATED;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.NILLABLE;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.READ_ONLY;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.REQUIRES;
@@ -42,19 +40,18 @@ public class FormHelper {
 
         // collect all attributes from the 'requires' list of this attribute
         TreeSet<String> requires = new TreeSet<>();
-        ModelNode attributesDescription = description.get(ATTRIBUTES);
         attributes.forEach(attribute -> {
-            ModelNode attributeDescription = attributesDescription.get(attribute);
+            ModelNode attributeDescription = description.attributes().get(attribute);
             if (attributeDescription != null && attributeDescription.hasDefined(REQUIRES)) {
                 failSafeList(attributeDescription, REQUIRES).forEach(node -> requires.add(node.asString()));
             }
         });
 
-        List<String> deprecated = attributes.stream().filter(attribute -> attributesDescription.get(attribute).has(DEPRECATED))
+        List<String> deprecated = attributes.stream().filter(description.attributes()::isDeprecated)
                 .collect(Collectors.toList());
 
         return attributes.stream()
-                .map(attribute -> description.findAttribute(ATTRIBUTES, attribute))
+                .map(attribute -> description.attributes().property(attribute))
                 .filter(prop -> Objects.nonNull(prop)
                         && !requires.contains(prop.getName())
                         && isNillable(prop.getValue())

--- a/core/src/main/java/org/jboss/hal/core/mbui/form/GroupedForm.java
+++ b/core/src/main/java/org/jboss/hal/core/mbui/form/GroupedForm.java
@@ -45,7 +45,6 @@ import elemental2.dom.HTMLElement;
 import static java.util.stream.Collectors.toList;
 
 import static com.google.common.collect.Lists.asList;
-import static org.jboss.hal.dmr.ModelDescriptionConstants.ATTRIBUTES;
 
 /**
  * A form which groups attributes on different tabs. Each group will include the attributes specified by the {@linkplain Builder
@@ -336,7 +335,7 @@ public class GroupedForm<T extends ModelNode> implements Form<T> {
         public Builder<T> attributeGroup(String id, String name, String title) {
             assertNoCurrentGroup();
             currentGroup = new Group(id, title);
-            List<Property> attributes = metadata.getDescription().getAttributes(ATTRIBUTES, name);
+            List<Property> attributes = metadata.getDescription().attributes().group(name);
             include(attributes.stream().map(Property::getName).sorted().collect(toList()));
             return this;
         }

--- a/core/src/main/java/org/jboss/hal/core/mbui/form/ModelNodeForm.java
+++ b/core/src/main/java/org/jboss/hal/core/mbui/form/ModelNodeForm.java
@@ -137,26 +137,9 @@ public class ModelNodeForm<T extends ModelNode> extends AbstractForm<T> {
             // 1. the ones specified in 'builder.includes'
             // 2. the remaining from 'filteredProperties'
             for (String include : builder.includes) {
-                // nested property like 'file.path'?
-                int dotIndex = include.lastIndexOf('.');
-                if (dotIndex != -1) {
-                    String parents = include.substring(0, dotIndex);
-                    String attribute = include.substring(dotIndex + 1);
-                    Metadata nested = metadata.forComplexAttribute(parents, true);
-                    // nested metadata *always* use ATTRIBUTES
-                    Property property = nested.getDescription().findAttribute(ATTRIBUTES, attribute);
-                    if (property != null) {
-                        Property fixedNameProperty = new Property(include, property.getValue());
-                        if (new PropertyFilter(builder).test(fixedNameProperty)) {
-                            properties.add(fixedNameProperty);
-                            dataMapping.addAttributeDescription(fixedNameProperty.getName(), fixedNameProperty.getValue());
-                        }
-                    }
-                } else {
-                    Property removed = filteredByName.remove(include);
-                    if (removed != null) {
-                        properties.add(removed);
-                    }
+                Property removed = filteredByName.remove(include);
+                if (removed != null) {
+                    properties.add(removed);
                 }
             }
             properties.addAll(filteredByName.values());

--- a/core/src/main/java/org/jboss/hal/core/mbui/form/ModelNodeForm.java
+++ b/core/src/main/java/org/jboss/hal/core/mbui/form/ModelNodeForm.java
@@ -46,6 +46,7 @@ import org.jboss.hal.core.NameI18n;
 import org.jboss.hal.dmr.ModelNode;
 import org.jboss.hal.dmr.ModelType;
 import org.jboss.hal.dmr.Property;
+import org.jboss.hal.meta.AttributeCollection;
 import org.jboss.hal.meta.Metadata;
 import org.jboss.hal.meta.description.ResourceDescription;
 import org.jboss.hal.meta.security.AuthorisationDecision;
@@ -77,12 +78,9 @@ import static org.jboss.hal.ballroom.form.Form.State.EMPTY;
 import static org.jboss.hal.ballroom.form.Form.State.READONLY;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.ACCESS_TYPE;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.ADD;
-import static org.jboss.hal.dmr.ModelDescriptionConstants.ATTRIBUTES;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.DEFAULT;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.DESCRIPTION;
-import static org.jboss.hal.dmr.ModelDescriptionConstants.OPERATIONS;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.READ_WRITE;
-import static org.jboss.hal.dmr.ModelDescriptionConstants.REQUEST_PROPERTIES;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.REQUIRED;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.REQUIRES;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.TYPE;
@@ -102,12 +100,12 @@ public class ModelNodeForm<T extends ModelNode> extends AbstractForm<T> {
     private final Supplier<org.jboss.hal.dmr.Operation> ping;
     private final Map<String, ModelNode> attributeDescriptions;
     private final ResourceDescription resourceDescription;
-    private final String attributePath;
+    private final boolean isFromRequestProperties;
     private final Metadata metadata;
 
     protected ModelNodeForm(Builder<T> builder) {
         super(builder.id, builder.stateMachine(),
-                new ModelNodeMapping<>(builder.metadata.getDescription().getAttributes(builder.attributePath)),
+                new ModelNodeMapping<>(getAttributes(builder.metadata.getDescription(), builder.isFromRequestProperties)),
                 builder.emptyState);
 
         this.addOnly = builder.addOnly;
@@ -119,11 +117,11 @@ public class ModelNodeForm<T extends ModelNode> extends AbstractForm<T> {
         this.prepareReset = builder.prepareReset;
         this.prepareRemove = builder.prepareRemove;
         this.resourceDescription = builder.metadata.getDescription();
-        this.attributePath = builder.attributePath;
+        this.isFromRequestProperties = builder.isFromRequestProperties;
         this.metadata = builder.metadata;
 
         List<Property> properties = new ArrayList<>();
-        List<Property> filteredProperties = resourceDescription.getAttributes(attributePath)
+        List<Property> filteredProperties = getAttributes(resourceDescription, isFromRequestProperties)
                 .stream()
                 .filter(new PropertyFilter(builder))
                 .collect(toList());
@@ -231,7 +229,7 @@ public class ModelNodeForm<T extends ModelNode> extends AbstractForm<T> {
             }
 
             // alternatives
-            List<String> alternatives = resourceDescription.findAlternatives(attributePath, name);
+            List<String> alternatives = getAttributes(resourceDescription, isFromRequestProperties).alternatives(name);
             HashSet<String> uniqueAlternatives = new HashSet<>(alternatives);
             uniqueAlternatives.add(name);
             uniqueAlternatives.removeAll(processedAlternatives);
@@ -375,8 +373,8 @@ public class ModelNodeForm<T extends ModelNode> extends AbstractForm<T> {
             ModelNode attributeDescription = attributeDescriptions.get(name);
             if (attributeDescription != null) {
                 if (attributeDescription.hasDefined(DEFAULT)) {
-                    emptyOrDefault = resourceDescription.isDefaultValue(attributePath, name,
-                            value) || formItem.isEmpty();
+                    emptyOrDefault = getAttributes(resourceDescription, isFromRequestProperties).isDefaultValue(name, value)
+                            || formItem.isEmpty();
                 } else if (attributeDescription.get(TYPE).asType() == ModelType.BOOLEAN) {
                     emptyOrDefault = value == null || !(Boolean) value;
                 } else {
@@ -387,6 +385,11 @@ public class ModelNodeForm<T extends ModelNode> extends AbstractForm<T> {
             }
         }
         return emptyOrDefault;
+    }
+
+    private static AttributeCollection getAttributes(ResourceDescription resourceDescription,
+            boolean isFromRequestProperties) {
+        return isFromRequestProperties ? resourceDescription.requestProperties() : resourceDescription.attributes();
     }
 
     // ------------------------------------------------------ inner classes
@@ -418,7 +421,7 @@ public class ModelNodeForm<T extends ModelNode> extends AbstractForm<T> {
         boolean omitNoAttributesWarning;
         Supplier<org.jboss.hal.dmr.Operation> ping;
         EmptyState emptyState;
-        String attributePath;
+        boolean isFromRequestProperties;
         SaveCallback<T> saveCallback;
         CancelCallback<T> cancelCallback;
         PrepareReset<T> prepareReset;
@@ -443,7 +446,7 @@ public class ModelNodeForm<T extends ModelNode> extends AbstractForm<T> {
             this.hideDeprecated = true;
             this.verifyExcludes = true;
             this.omitNoAttributesWarning = false;
-            this.attributePath = ATTRIBUTES;
+            this.isFromRequestProperties = false;
         }
 
         public Builder<T> include(String[] attributes) {
@@ -483,7 +486,6 @@ public class ModelNodeForm<T extends ModelNode> extends AbstractForm<T> {
         @EsReturn("FormBuilder")
         public Builder<T> addOnly() {
             this.addOnly = true;
-            this.attributePath = ATTRIBUTES;
             return this;
         }
 
@@ -494,7 +496,7 @@ public class ModelNodeForm<T extends ModelNode> extends AbstractForm<T> {
         @EsReturn("FormBuilder")
         public Builder<T> fromRequestProperties() {
             this.addOnly = true;
-            this.attributePath = OPERATIONS + "/" + ADD + "/" + REQUEST_PROPERTIES;
+            this.isFromRequestProperties = true;
             return this;
         }
 
@@ -669,7 +671,8 @@ public class ModelNodeForm<T extends ModelNode> extends AbstractForm<T> {
             }
 
             if (!excludes.isEmpty() && !readOnly && verifyExcludes) {
-                List<Property> requiredAttributes = metadata.getDescription().getRequiredAttributes(attributePath);
+                Iterable<Property> requiredAttributes = (getAttributes(metadata.getDescription(), isFromRequestProperties))
+                        .required();
                 for (Property attribute : requiredAttributes) {
                     if (excludes.contains(attribute.getName())) {
                         throw new IllegalStateException(

--- a/core/src/main/java/org/jboss/hal/core/mbui/form/ModelNodeMapping.java
+++ b/core/src/main/java/org/jboss/hal/core/mbui/form/ModelNodeMapping.java
@@ -28,6 +28,7 @@ import org.jboss.hal.dmr.ModelNode;
 import org.jboss.hal.dmr.ModelNodeHelper;
 import org.jboss.hal.dmr.ModelType;
 import org.jboss.hal.dmr.Property;
+import org.jboss.hal.meta.AttributeCollection;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -44,15 +45,10 @@ import static org.jboss.hal.dmr.ModelType.INT;
 class ModelNodeMapping<T extends ModelNode> extends DefaultMapping<T> {
 
     private static final Logger logger = LoggerFactory.getLogger(ModelNodeMapping.class);
-    private final List<Property> attributeDescriptions;
+    private final AttributeCollection attributeDescriptions;
 
-    ModelNodeMapping(List<Property> attributeDescriptions) {
+    ModelNodeMapping(AttributeCollection attributeDescriptions) {
         this.attributeDescriptions = attributeDescriptions;
-    }
-
-    @Override
-    public void addAttributeDescription(final String name, final ModelNode attributeDescription) {
-        attributeDescriptions.add(new Property(name, attributeDescription));
     }
 
     @Override
@@ -72,8 +68,8 @@ class ModelNodeMapping<T extends ModelNode> extends DefaultMapping<T> {
                 value = model.get(name);
             }
             if (value.isDefined()) {
-                ModelNode attributeDescription = findAttribute(name);
-                if (attributeDescription == null) {
+                ModelNode attributeDescription = attributeDescriptions.get(name);
+                if (!attributeDescription.isDefined()) {
                     logger.error("{}: Unable to populate form item '{}': No attribute description found in\n{}",
                             id, name, attributeDescriptions);
                     continue;
@@ -210,8 +206,8 @@ class ModelNodeMapping<T extends ModelNode> extends DefaultMapping<T> {
             String name = formItem.getName();
 
             if (formItem.isModified()) {
-                ModelNode attributeDescription = findAttribute(name);
-                if (attributeDescription == null) {
+                ModelNode attributeDescription = attributeDescriptions.get(name);
+                if (!attributeDescription.isDefined()) {
                     logger.error("{}: Unable to persist attribute '{}': No attribute description found in\n{}",
                             id, name, attributeDescriptions);
                     continue;
@@ -330,15 +326,6 @@ class ModelNodeMapping<T extends ModelNode> extends DefaultMapping<T> {
         if (model.isDefined()) {
             model.remove(attribute);
         }
-    }
-
-    private ModelNode findAttribute(String name) {
-        for (Property property : attributeDescriptions) {
-            if (name.equals(property.getName())) {
-                return property.getValue();
-            }
-        }
-        return null;
     }
 
     private String id(Form<T> form) {

--- a/core/src/main/java/org/jboss/hal/core/mbui/table/ModelNodeTable.java
+++ b/core/src/main/java/org/jboss/hal/core/mbui/table/ModelNodeTable.java
@@ -38,7 +38,6 @@ import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 
 import static org.jboss.hal.ballroom.table.RefreshMode.RESET;
-import static org.jboss.hal.dmr.ModelDescriptionConstants.ATTRIBUTES;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.NAME;
 import static org.jboss.hal.resources.UIConstants.HASH;
 import static org.jboss.hal.resources.UIConstants.data;
@@ -155,8 +154,8 @@ public class ModelNodeTable<T extends ModelNode> extends DataTable<T> {
 
         /** Adds a column which maps to the specified attribute. */
         public Builder<T> column(String attribute) {
-            Property attributeDescription = metadata.getDescription().findAttribute(ATTRIBUTES, attribute);
-            if (attributeDescription != null) {
+            Property attributeDescription = metadata.getDescription().attributes().property(attribute);
+            if (attributeDescription.getValue().isDefined()) {
                 Column<T> column = columnFactory.createColumn(attributeDescription);
                 return column(column);
             } else {

--- a/core/src/main/java/org/jboss/hal/core/modelbrowser/AttributesTable.java
+++ b/core/src/main/java/org/jboss/hal/core/modelbrowser/AttributesTable.java
@@ -27,11 +27,9 @@ import org.jboss.hal.dmr.ModelNode;
 import org.jboss.hal.dmr.ModelNodeHelper;
 import org.jboss.hal.dmr.Property;
 import org.jboss.hal.resources.CSS;
-import org.jboss.hal.resources.Constants;
 import org.jboss.hal.resources.Resources;
 
 import com.google.common.collect.Ordering;
-import com.google.gwt.core.client.GWT;
 import com.google.gwt.safehtml.shared.SafeHtml;
 import com.google.gwt.safehtml.shared.SafeHtmlBuilder;
 import com.google.gwt.safehtml.shared.SafeHtmlUtils;
@@ -64,8 +62,6 @@ import static org.jboss.hal.resources.CSS.tableStriped;
 import static org.jboss.hal.resources.UIConstants.NBSP;
 
 class AttributesTable implements IsElement {
-
-    private static final Constants CONSTANTS = GWT.create(Constants.class);
 
     private final HTMLElement root;
 
@@ -130,7 +126,7 @@ class AttributesTable implements IsElement {
                         break;
                 }
             } else {
-                builder.innerHtml(SafeHtmlUtils.fromSafeConstant(NBSP));
+                storageTd.innerHTML = SafeHtmlUtils.fromSafeConstant(NBSP).asString();
             }
 
             // access type
@@ -152,7 +148,7 @@ class AttributesTable implements IsElement {
                         break;
                 }
             } else {
-                builder.innerHtml(SafeHtmlUtils.fromSafeConstant(NBSP));
+                accessTypeTd.innerHTML = SafeHtmlUtils.fromSafeConstant(NBSP).asString();
             }
 
             tbody.appendChild(builder.element());

--- a/core/src/main/java/org/jboss/hal/core/modelbrowser/AttributesTable.java
+++ b/core/src/main/java/org/jboss/hal/core/modelbrowser/AttributesTable.java
@@ -15,7 +15,7 @@
  */
 package org.jboss.hal.core.modelbrowser;
 
-import java.util.List;
+import java.util.Collection;
 
 import org.jboss.elemento.HtmlContentBuilder;
 import org.jboss.elemento.IsElement;
@@ -65,7 +65,7 @@ class AttributesTable implements IsElement {
 
     private final HTMLElement root;
 
-    AttributesTable(List<Property> attributes, Environment environment, Resources resources) {
+    AttributesTable(Collection<Property> attributes, Environment environment, Resources resources) {
 
         HTMLElement tbody;
         this.root = table()

--- a/core/src/main/java/org/jboss/hal/core/modelbrowser/ModelBrowser.java
+++ b/core/src/main/java/org/jboss/hal/core/modelbrowser/ModelBrowser.java
@@ -43,7 +43,6 @@ import org.jboss.hal.dmr.ModelDescriptionConstants;
 import org.jboss.hal.dmr.ModelNode;
 import org.jboss.hal.dmr.ModelNodeHelper;
 import org.jboss.hal.dmr.Operation;
-import org.jboss.hal.dmr.Property;
 import org.jboss.hal.dmr.ResourceAddress;
 import org.jboss.hal.dmr.dispatch.Dispatcher;
 import org.jboss.hal.flow.FlowContext;
@@ -90,15 +89,9 @@ import static org.jboss.hal.ballroom.Skeleton.applicationOffset;
 import static org.jboss.hal.core.modelbrowser.SingletonState.CHOOSE;
 import static org.jboss.hal.core.modelbrowser.SingletonState.CREATE;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.ADD;
-import static org.jboss.hal.dmr.ModelDescriptionConstants.OBJECT;
-import static org.jboss.hal.dmr.ModelDescriptionConstants.OPERATIONS;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.PROFILE;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.READ_RESOURCE_OPERATION;
-import static org.jboss.hal.dmr.ModelDescriptionConstants.REQUEST_PROPERTIES;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.SERVER_GROUP;
-import static org.jboss.hal.dmr.ModelDescriptionConstants.STRING;
-import static org.jboss.hal.dmr.ModelDescriptionConstants.TYPE;
-import static org.jboss.hal.dmr.ModelDescriptionConstants.VALUE_TYPE;
 import static org.jboss.hal.flow.Flow.sequential;
 import static org.jboss.hal.meta.StatementContext.Expression.SELECTED_GROUP;
 import static org.jboss.hal.meta.StatementContext.Expression.SELECTED_PROFILE;
@@ -418,7 +411,6 @@ public class ModelBrowser implements IsElement<HTMLElement> {
             metadataProcessor.lookup(template, progress.get(), new SuccessfulMetadataCallback(eventBus, resources) {
                 @Override
                 public void onMetadata(Metadata metadata) {
-                    flattenDescription(metadata.getDescription().get(OPERATIONS).get(ADD).get(REQUEST_PROPERTIES));
                     String title = new LabelBuilder().label(parent.text);
                     ResourceNameItem resourceNameItem = new ResourceNameItem();
                     String id = Ids.build(parent.id, "add");
@@ -430,44 +422,13 @@ public class ModelBrowser implements IsElement<HTMLElement> {
 
                     AddResourceDialog dialog = new AddResourceDialog(
                             resources.messages().addResourceTitle(title),
-                            form, (name1, model) -> {
-                                unflattenModel(model);
-                                crud.add(title, resourceNameItem.getValue(), fqAddress(parent, resourceNameItem.getValue()),
-                                        model, (n, a) -> refresh(parent));
-                            });
+                            form,
+                            (name1, model) -> crud.add(title, resourceNameItem.getValue(),
+                                    fqAddress(parent, resourceNameItem.getValue()),
+                                    model, (n, a) -> refresh(parent)));
                     dialog.show();
                 }
             });
-        }
-    }
-
-    private void flattenDescription(ModelNode model) {
-        for (Property p : model.asPropertyList()) {
-            if (p.getValue().get(TYPE).asString().equalsIgnoreCase(OBJECT)
-                    && !p.getValue().get(VALUE_TYPE).asString().equalsIgnoreCase(STRING)) {
-
-                model.remove(p.getName());
-
-                for (Property nested : p.getValue().get(VALUE_TYPE).asPropertyList()) {
-                    model.get(p.getName() + "." + nested.getName()).set(nested.getValue());
-                }
-            }
-        }
-    }
-
-    private void unflattenModel(ModelNode model) {
-        if (!model.isDefined()) {
-            return;
-        }
-        for (Property p : model.asPropertyList()) {
-            if (p.getName().indexOf('.') < 0) {
-                continue;
-            }
-
-            String[] split = p.getName().split("\\.");
-
-            model.remove(p.getName());
-            model.get(split[0]).get(split[1]).set(p.getValue());
         }
     }
 

--- a/core/src/main/java/org/jboss/hal/core/modelbrowser/OperationsTable.java
+++ b/core/src/main/java/org/jboss/hal/core/modelbrowser/OperationsTable.java
@@ -15,6 +15,7 @@
  */
 package org.jboss.hal.core.modelbrowser;
 
+import java.util.Collection;
 import java.util.List;
 
 import org.jboss.elemento.HtmlContentBuilder;
@@ -60,7 +61,7 @@ class OperationsTable implements IsElement {
     private final HTMLElement root;
     private final Resources resources;
 
-    OperationsTable(List<Property> operations, Environment environment, Resources resources) {
+    OperationsTable(Collection<Property> operations, Environment environment, Resources resources) {
         HTMLElement tbody;
 
         this.resources = resources;

--- a/core/src/main/java/org/jboss/hal/core/modelbrowser/ResourcePanel.java
+++ b/core/src/main/java/org/jboss/hal/core/modelbrowser/ResourcePanel.java
@@ -15,7 +15,6 @@
  */
 package org.jboss.hal.core.modelbrowser;
 
-import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 
@@ -28,7 +27,6 @@ import org.jboss.hal.config.Environment;
 import org.jboss.hal.config.StabilityLevel;
 import org.jboss.hal.core.mbui.form.ModelNodeForm;
 import org.jboss.hal.dmr.ModelNode;
-import org.jboss.hal.dmr.ModelType;
 import org.jboss.hal.dmr.Operation;
 import org.jboss.hal.dmr.Property;
 import org.jboss.hal.dmr.ResourceAddress;
@@ -47,11 +45,7 @@ import static org.jboss.elemento.Elements.p;
 import static org.jboss.hal.core.modelbrowser.ModelBrowser.PLACE_HOLDER_ELEMENT;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.ATTRIBUTES;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.INCLUDE_RUNTIME;
-import static org.jboss.hal.dmr.ModelDescriptionConstants.OBJECT;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.READ_RESOURCE_OPERATION;
-import static org.jboss.hal.dmr.ModelDescriptionConstants.STRING;
-import static org.jboss.hal.dmr.ModelDescriptionConstants.TYPE;
-import static org.jboss.hal.dmr.ModelDescriptionConstants.VALUE_TYPE;
 import static org.jboss.hal.resources.CSS.lead;
 
 /**
@@ -127,9 +121,7 @@ class ResourcePanel implements Iterable<HTMLElement> {
                     .param(INCLUDE_RUNTIME, true)
                     .build();
             dispatcher.execute(operation, result -> {
-                List<String> plainObjects = new ArrayList<>();
-                flattenDescription(metadata.getDescription().get(ATTRIBUTES), plainObjects);
-                flattenModel(result, plainObjects);
+                flattenModel(metadata.getDescription().get(ATTRIBUTES).asPropertyList(), result);
                 ModelNodeForm<ModelNode> form = new ModelNodeForm.Builder<>(
                         Ids.build(Ids.MODEL_BROWSER, node.id, Ids.FORM), metadata)
                         .includeRuntime()
@@ -162,29 +154,15 @@ class ResourcePanel implements Iterable<HTMLElement> {
         }
     }
 
-    private void flattenDescription(ModelNode model, List<String> plainObjects) {
-        for (Property p : model.asPropertyList()) {
-            if (p.getValue().get(TYPE).asString().equalsIgnoreCase(OBJECT)
-                    && !p.getValue().get(VALUE_TYPE).asString().equalsIgnoreCase(STRING)) {
-
-                model.remove(p.getName());
-
-                for (Property nested : p.getValue().get(VALUE_TYPE).asPropertyList()) {
-                    model.get(p.getName() + "." + nested.getName()).set(nested.getValue());
-                }
-            } else if (p.getValue().get(TYPE).asString().equalsIgnoreCase(OBJECT)) {
-                plainObjects.add(p.getName());
-            }
-        }
-    }
-
-    private void flattenModel(ModelNode model, List<String> plainObjects) {
-        for (Property p : model.asPropertyList()) {
-            if (p.getValue().getType() == ModelType.OBJECT && !plainObjects.contains(p.getName())) {
-                model.remove(p.getName());
-
-                for (Property nested : p.getValue().asPropertyList()) {
-                    model.get(p.getName() + "." + nested.getName()).set(nested.getValue());
+    private void flattenModel(List<Property> attributes, ModelNode model) {
+        for (Property attr : attributes) {
+            if (attr.getName().contains(".")) {
+                String parentName = attr.getName().substring(0, attr.getName().indexOf('.'));
+                if (model.hasDefined(parentName)) {
+                    ModelNode value = model.remove(parentName);
+                    for (Property nested : value.asPropertyList()) {
+                        model.get(parentName + "." + nested.getName()).set(nested.getValue());
+                    }
                 }
             }
         }

--- a/core/src/main/java/org/jboss/hal/core/modelbrowser/ResourcePanel.java
+++ b/core/src/main/java/org/jboss/hal/core/modelbrowser/ResourcePanel.java
@@ -136,10 +136,10 @@ class ResourcePanel implements Iterable<HTMLElement> {
             });
 
             tabs.setContent(attributesId,
-                    new AttributesTable(metadata.getDescription().getAttributes(ATTRIBUTES), environment, resources).element());
-            if (!metadata.getDescription().getOperations().isEmpty()) {
+                    new AttributesTable(metadata.getDescription().attributes(), environment, resources).element());
+            if (!metadata.getDescription().operations().isEmpty()) {
                 tabs.setContent(operationsId,
-                        new OperationsTable(metadata.getDescription().getOperations(), environment, resources).element());
+                        new OperationsTable(metadata.getDescription().operations(), environment, resources).element());
             }
         }
     }

--- a/core/src/main/java/org/jboss/hal/core/ui/TuplesListItem.java
+++ b/core/src/main/java/org/jboss/hal/core/ui/TuplesListItem.java
@@ -56,7 +56,6 @@ import static org.jboss.hal.ballroom.form.Decoration.REQUIRED;
 import static org.jboss.hal.ballroom.form.Decoration.RESTRICTED;
 import static org.jboss.hal.ballroom.form.Decoration.STABILITY;
 import static org.jboss.hal.ballroom.form.Decoration.SUGGESTIONS;
-import static org.jboss.hal.dmr.ModelDescriptionConstants.ATTRIBUTES;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.NILLABLE;
 import static org.jboss.hal.resources.CSS.btn;
 import static org.jboss.hal.resources.CSS.btnDefault;
@@ -133,7 +132,7 @@ public class TuplesListItem extends TagsItem<ModelNode> implements ModelNodeItem
     }
 
     public static String[] getAttributeNames(Metadata metadata, boolean markRequired) {
-        return metadata.getDescription().get(ATTRIBUTES).asPropertyList().stream()
+        return metadata.getDescription().attributes().stream()
                 .map(prop -> prop.getName()
                         + (markRequired && prop.getValue().hasDefined(NILLABLE) && !prop.getValue().get(NILLABLE).asBoolean()
                                 ? "*"

--- a/meta/src/main/java/org/jboss/hal/meta/AttributeCollection.java
+++ b/meta/src/main/java/org/jboss/hal/meta/AttributeCollection.java
@@ -1,0 +1,233 @@
+/*
+ *  Copyright 2022 Red Hat
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.jboss.hal.meta;
+
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
+
+import org.jboss.hal.dmr.ModelNode;
+import org.jboss.hal.dmr.ModelType;
+import org.jboss.hal.dmr.Property;
+
+import static java.util.Collections.emptyList;
+import static java.util.stream.Collectors.toList;
+
+import static org.jboss.hal.dmr.ModelDescriptionConstants.ALTERNATIVES;
+import static org.jboss.hal.dmr.ModelDescriptionConstants.ATTRIBUTE_GROUP;
+import static org.jboss.hal.dmr.ModelDescriptionConstants.CAPABILITY_REFERENCE;
+import static org.jboss.hal.dmr.ModelDescriptionConstants.DEFAULT;
+import static org.jboss.hal.dmr.ModelDescriptionConstants.DEPRECATED;
+import static org.jboss.hal.dmr.ModelDescriptionConstants.DESCRIPTION;
+import static org.jboss.hal.dmr.ModelDescriptionConstants.NILLABLE;
+import static org.jboss.hal.dmr.ModelDescriptionConstants.REQUIRED;
+import static org.jboss.hal.dmr.ModelDescriptionConstants.REQUIRES;
+import static org.jboss.hal.dmr.ModelDescriptionConstants.TYPE;
+
+/** Wrapper around a set of attribute descriptions to avoid direct manipulation of the underlying ModelNode */
+public class AttributeCollection implements Collection<Property> {
+    private List<Property> list;
+
+    public AttributeCollection(List<Property> list) {
+        this.list = list;
+    }
+
+    public ModelNode get(String name) {
+        for (Property p : this) {
+            if (p.getName().equals(name)) {
+                return p.getValue();
+            }
+        }
+        return new ModelNode();
+    }
+
+    public Property property(String name) {
+        return new Property(name, get(name));
+    }
+
+    public String description(String name) {
+        return get(name).get(DESCRIPTION).asString();
+    }
+
+    public String capabilityReference(String name) {
+        return get(name).get(CAPABILITY_REFERENCE).asString();
+    }
+
+    public List<Property> group(String group) {
+        return stream()
+                .filter(property -> {
+                    ModelNode attributeDescription = property.getValue();
+                    return attributeDescription.hasDefined(ATTRIBUTE_GROUP) &&
+                            group.equals(attributeDescription.get(ATTRIBUTE_GROUP).asString());
+                })
+                .collect(toList());
+    }
+
+    public List<Property> required() {
+        return stream()
+                .filter(property -> {
+                    ModelNode attributeDescription = property.getValue();
+                    if (attributeDescription.hasDefined(REQUIRED)) {
+                        return attributeDescription.get(REQUIRED).asBoolean();
+                    } else if (attributeDescription.hasDefined(NILLABLE)) {
+                        return !attributeDescription.get(NILLABLE).asBoolean();
+                    }
+                    return false;
+                })
+                .collect(toList());
+    }
+
+    /**
+     * Returns the alternatives for the specified attribute.
+     *
+     * @param name the name of the attribute
+     *
+     * @return the alternatives for {@code name} or an empty list if {@code name} has no alternatives or if there's no attribute
+     *         {@code name}
+     */
+    public List<String> alternatives(String name) {
+        ModelNode attribute = get(name);
+        if (attribute.hasDefined(ALTERNATIVES)) {
+            return attribute.get(ALTERNATIVES).asList().stream()
+                    .map(ModelNode::asString)
+                    .collect(toList());
+        }
+        return emptyList();
+    }
+
+    /**
+     * Returns the attributes which require the specified attribute.
+     *
+     * @param name the name of the attribute which is required by the matching attributes
+     *
+     * @return the attributes which require {@code} or an empty list if no attributes require {@code name} or if there's no
+     *         attribute {@code name}
+     */
+    public List<String> requiredBy(String name) {
+        return stream()
+                .filter(attribute -> {
+                    if (attribute.getValue().hasDefined(REQUIRES)) {
+                        List<String> requires = attribute.getValue().get(REQUIRES).asList().stream()
+                                .map(ModelNode::asString)
+                                .collect(toList());
+                        return requires.contains(name);
+                    }
+                    return false;
+                })
+                .map(Property::getName)
+                .collect(toList());
+    }
+
+    public boolean isDefaultValue(String name, Object value) {
+        ModelNode attribute = get(name);
+        if (attribute.hasDefined(DEFAULT)) {
+            if (value == null) {
+                return true;
+            } else {
+                ModelType type = attribute.get(TYPE).asType();
+                if (type.equals(ModelType.INT)) {
+                    type = ModelType.LONG;
+                }
+                Object defaultValue = attribute.get(DEFAULT).as(type);
+                return value.equals(defaultValue);
+            }
+        }
+        return false;
+    }
+
+    public boolean isDeprecated(String name) {
+        return get(name).has(DEPRECATED);
+    }
+
+    // ------------ collection overrides
+
+    @Override
+    public boolean add(Property property) {
+        return list.add(property);
+    }
+
+    @Override
+    public int size() {
+        return list.size();
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return list.isEmpty();
+    }
+
+    @Override
+    public boolean contains(Object o) {
+        return list.contains(o);
+    }
+
+    @Override
+    public Iterator<Property> iterator() {
+        return list.iterator();
+    }
+
+    @Override
+    public Object[] toArray() {
+        return list.toArray();
+    }
+
+    @Override
+    public <T> T[] toArray(T[] ts) {
+        return list.toArray(ts);
+    }
+
+    @Override
+    public boolean remove(Object o) {
+        return list.remove(o);
+    }
+
+    @Override
+    public boolean containsAll(Collection<?> collection) {
+        return list.containsAll(collection);
+    }
+
+    @Override
+    public boolean addAll(Collection<? extends Property> collection) {
+        return list.addAll(collection);
+    }
+
+    @Override
+    public boolean removeAll(Collection<?> collection) {
+        return list.removeAll(collection);
+    }
+
+    @Override
+    public boolean retainAll(Collection<?> collection) {
+        return list.retainAll(collection);
+    }
+
+    @Override
+    public void clear() {
+        list.clear();
+    }
+
+    @Override
+    public void forEach(Consumer<? super Property> action) {
+        list.forEach(action);
+    }
+
+    @Override
+    public Stream<Property> stream() {
+        return list.stream();
+    }
+}

--- a/meta/src/main/java/org/jboss/hal/meta/description/ResourceDescription.java
+++ b/meta/src/main/java/org/jboss/hal/meta/description/ResourceDescription.java
@@ -15,29 +15,29 @@
  */
 package org.jboss.hal.meta.description;
 
-import java.util.List;
-import java.util.Set;
-import java.util.TreeSet;
+import java.util.Map;
+import java.util.TreeMap;
 
 import org.jboss.hal.config.StabilityLevel;
 import org.jboss.hal.dmr.ModelNode;
 import org.jboss.hal.dmr.ModelNodeHelper;
 import org.jboss.hal.dmr.ModelType;
 import org.jboss.hal.dmr.Property;
+import org.jboss.hal.meta.AttributeCollection;
 
 import static java.util.Collections.emptyList;
-import static java.util.stream.Collectors.toList;
 
 import static org.jboss.hal.dmr.ModelDescriptionConstants.ACCESS_TYPE;
-import static org.jboss.hal.dmr.ModelDescriptionConstants.ALTERNATIVES;
+import static org.jboss.hal.dmr.ModelDescriptionConstants.ADD;
+import static org.jboss.hal.dmr.ModelDescriptionConstants.ATTRIBUTES;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.ATTRIBUTE_GROUP;
-import static org.jboss.hal.dmr.ModelDescriptionConstants.DEFAULT;
+import static org.jboss.hal.dmr.ModelDescriptionConstants.CHILDREN;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.DEPRECATED;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.DESCRIPTION;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.NILLABLE;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.OPERATIONS;
+import static org.jboss.hal.dmr.ModelDescriptionConstants.REQUEST_PROPERTIES;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.REQUIRED;
-import static org.jboss.hal.dmr.ModelDescriptionConstants.REQUIRES;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.STABILITY;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.STORAGE;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.STRING;
@@ -45,21 +45,10 @@ import static org.jboss.hal.dmr.ModelDescriptionConstants.TYPE;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.VALUE_TYPE;
 
 /** Contains the resource and attribute descriptions from the read-resource-description operation. */
-/*
- * TODO Refactor methods which use the 'path' parameter (too error prone). Instead use a fluent API:
- *
- * ResourceDescription description = ...;
- *
- * // attributes from the resource description Property attribute = description.atrributes().get("foo"); List<Property>
- * attributes = description.atrributes().group("bar"); List<Property> attributes = description.atrributes().required();
- *
- * // request properties of the ADD operation Property attribute = description.requestProperties().get("foo"); List<Property>
- * attributes = description.requestProperties().group("bar"); List<Property> attributes =
- * description.requestProperties().required();
- */
+
 public class ResourceDescription extends ModelNode {
 
-    private Set<String> flattened = new TreeSet<>();
+    private Map<String, AttributeCollection> map = new TreeMap<>();
 
     public ResourceDescription(ModelNode payload) {
         set(payload);
@@ -74,167 +63,58 @@ public class ResourceDescription extends ModelNode {
         return ModelNodeHelper.asEnumValue(this, STABILITY, StabilityLevel::valueOf, null);
     }
 
-    public List<Property> getAttributes(String path) {
+    public AttributeCollection attributes() {
+        return getAttributes(ATTRIBUTES);
+    }
+
+    public AttributeCollection requestProperties() {
+        return getAttributes(OPERATIONS + "/" + ADD + "/" + REQUEST_PROPERTIES);
+    }
+
+    public AttributeCollection operations() {
+        return getAttributes(OPERATIONS);
+    }
+
+    public AttributeCollection children() {
+        return getAttributes(CHILDREN);
+    }
+
+    private AttributeCollection getAttributes(String path) {
         ModelNode attributes = ModelNodeHelper.failSafeGet(this, path);
         if (attributes.isDefined()) {
-            List<Property> list = attributes.asPropertyList();
-            if (flattened.contains(path)) {
-                return list;
-            }
-
-            flattened.add(path);
-            for (Property p : list) {
-                ModelNode parentValue = p.getValue();
-                if (parentValue.hasDefined(TYPE) && (parentValue.get(TYPE).asType().equals(ModelType.OBJECT) ||
-                        parentValue.get(TYPE).asType().equals(ModelType.LIST))
-                        && !parentValue.get(VALUE_TYPE).asString().equalsIgnoreCase(STRING)) {
-                    for (Property nested : parentValue.get(VALUE_TYPE).asPropertyList()) {
-                        ModelNode nestedValue = nested.getValue();
-                        // inherit from parent
-                        if (parentValue.hasDefined(DEPRECATED)) {
-                            nestedValue.get(DEPRECATED).set(parentValue.get(DEPRECATED));
+            if (!map.containsKey(path)) {
+                for (Property p : attributes.asPropertyList()) {
+                    ModelNode parentValue = p.getValue();
+                    if (parentValue.hasDefined(TYPE) && (parentValue.get(TYPE).asType().equals(ModelType.OBJECT) ||
+                            parentValue.get(TYPE).asType().equals(ModelType.LIST))
+                            && !parentValue.get(VALUE_TYPE).asString().equalsIgnoreCase(STRING)) {
+                        for (Property nested : parentValue.get(VALUE_TYPE).asPropertyList()) {
+                            ModelNode nestedValue = nested.getValue();
+                            // inherit from parent
+                            if (parentValue.hasDefined(DEPRECATED)) {
+                                nestedValue.get(DEPRECATED).set(parentValue.get(DEPRECATED));
+                            }
+                            if (parentValue.hasDefined(ATTRIBUTE_GROUP)) {
+                                nestedValue.get(ATTRIBUTE_GROUP).set(parentValue.get(ATTRIBUTE_GROUP));
+                            }
+                            nestedValue.get(STORAGE).set(parentValue.get(STORAGE));
+                            nestedValue.get(ACCESS_TYPE).set(parentValue.get(ACCESS_TYPE));
+                            // "required"/"nillable" has to depend on parent value
+                            boolean combined = parentValue.get(NILLABLE).asBoolean()
+                                    || nestedValue.get(NILLABLE).asBoolean();
+                            nestedValue.get(NILLABLE).set(combined);
+                            combined = parentValue.get(REQUIRED).asBoolean()
+                                    && nestedValue.get(REQUIRED).asBoolean();
+                            nestedValue.get(REQUIRED).set(combined);
+                            attributes.get(p.getName() + "." + nested.getName()).set(nestedValue);
                         }
-                        if (parentValue.hasDefined(ATTRIBUTE_GROUP)) {
-                            nestedValue.get(ATTRIBUTE_GROUP).set(parentValue.get(ATTRIBUTE_GROUP));
-                        }
-                        nestedValue.get(STORAGE).set(parentValue.get(STORAGE));
-                        nestedValue.get(ACCESS_TYPE).set(parentValue.get(ACCESS_TYPE));
-                        // "required"/"nillable" has to depend on parent value
-                        boolean combined = parentValue.get(NILLABLE).asBoolean()
-                                || nestedValue.get(NILLABLE).asBoolean();
-                        nestedValue.get(NILLABLE).set(combined);
-                        combined = parentValue.get(REQUIRED).asBoolean()
-                                && nestedValue.get(REQUIRED).asBoolean();
-                        nestedValue.get(REQUIRED).set(combined);
-                        attributes.get(p.getName() + "." + nested.getName()).set(nestedValue);
                     }
                 }
+                map.put(path, new AttributeCollection(attributes.asPropertyList()));
             }
-            return attributes.asPropertyList();
+        } else {
+            map.put(path, new AttributeCollection(emptyList()));
         }
-        return emptyList();
-    }
-
-    public List<Property> getAttributes(String path, String group) {
-        List<Property> attributes = getAttributes(path);
-        return attributes.stream()
-                .filter(property -> {
-                    ModelNode attributeDescription = property.getValue();
-                    return attributeDescription.hasDefined(ATTRIBUTE_GROUP) &&
-                            group.equals(attributeDescription.get(ATTRIBUTE_GROUP).asString());
-                })
-                .collect(toList());
-    }
-
-    public List<Property> getRequiredAttributes(String path) {
-        return getAttributes(path).stream()
-                .filter(property -> {
-                    ModelNode attributeDescription = property.getValue();
-                    if (attributeDescription.hasDefined(REQUIRED)) {
-                        return attributeDescription.get(REQUIRED).asBoolean();
-                    } else if (attributeDescription.hasDefined(NILLABLE)) {
-                        return !attributeDescription.get(NILLABLE).asBoolean();
-                    }
-                    return false;
-                })
-                .collect(toList());
-    }
-
-    public List<Property> getOperations() {
-        return hasDefined(OPERATIONS) ? get(OPERATIONS).asPropertyList() : emptyList();
-    }
-
-    public Property findOperation(String name) {
-        if (hasDefined(OPERATIONS)) {
-            for (Property property : get(OPERATIONS).asPropertyList()) {
-                if (name.equals(property.getName())) {
-                    return property;
-                }
-            }
-        }
-        return null;
-    }
-
-    public Property findAttribute(String path, String name) {
-        for (Property property : getAttributes(path)) {
-            if (name.equals(property.getName())) {
-                return property;
-            }
-        }
-        return null;
-    }
-
-    /**
-     * Returns the alternatives for the specified attribute.
-     *
-     * @param path the path to look for the attribute
-     * @param name the name of the attribute
-     *
-     * @return the alternatives for {@code name} or an empty list if {@code name} has no alternatives or if there's no attribute
-     *         {@code name}
-     */
-    public List<String> findAlternatives(String path, String name) {
-        Property attribute = findAttribute(path, name);
-        if (attribute != null) {
-            if (attribute.getValue().hasDefined(ALTERNATIVES)) {
-                return attribute.getValue().get(ALTERNATIVES).asList().stream()
-                        .map(ModelNode::asString)
-                        .collect(toList());
-            }
-        }
-        return emptyList();
-    }
-
-    /**
-     * Returns the attributes which require the specified attribute.
-     *
-     * @param path the path to look for the attribute
-     * @param name the name of the attribute which is required by the matching attributes
-     *
-     * @return the attributes which require {@code} or an empty list if no attributes require {@code name} or if there's no
-     *         attribute {@code name}
-     */
-    public List<String> findRequires(String path, String name) {
-        return getAttributes(path).stream()
-                .filter(attribute -> {
-                    if (attribute.getValue().hasDefined(REQUIRES)) {
-                        List<String> requires = attribute.getValue().get(REQUIRES).asList().stream()
-                                .map(ModelNode::asString)
-                                .collect(toList());
-                        return requires.contains(name);
-                    }
-                    return false;
-                })
-                .map(Property::getName)
-                .collect(toList());
-    }
-
-    public boolean isDefaultValue(String path, String name, Object value) {
-        Property property = findAttribute(path, name);
-        if (property != null) {
-            ModelNode attribute = property.getValue();
-            if (attribute.hasDefined(DEFAULT)) {
-                if (value == null) {
-                    return true;
-                } else {
-                    ModelType type = attribute.get(TYPE).asType();
-                    if (type.equals(ModelType.INT)) {
-                        type = ModelType.LONG;
-                    }
-                    Object defaultValue = attribute.get(DEFAULT).as(type);
-                    return value.equals(defaultValue);
-                }
-            }
-        }
-        return false;
-    }
-
-    public boolean isDeprecated(String path, String name) {
-        Property property = findAttribute(path, name);
-        if (property != null) {
-            ModelNode attribute = property.getValue();
-            return ModelNodeHelper.failSafeBoolean(attribute, DEPRECATED);
-        }
-        return false;
+        return map.get(path);
     }
 }

--- a/meta/src/main/java/org/jboss/hal/meta/description/ResourceDescription.java
+++ b/meta/src/main/java/org/jboss/hal/meta/description/ResourceDescription.java
@@ -16,6 +16,8 @@
 package org.jboss.hal.meta.description;
 
 import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
 
 import org.jboss.hal.config.StabilityLevel;
 import org.jboss.hal.dmr.ModelNode;
@@ -26,6 +28,7 @@ import org.jboss.hal.dmr.Property;
 import static java.util.Collections.emptyList;
 import static java.util.stream.Collectors.toList;
 
+import static org.jboss.hal.dmr.ModelDescriptionConstants.ACCESS_TYPE;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.ALTERNATIVES;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.ATTRIBUTE_GROUP;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.DEFAULT;
@@ -36,7 +39,10 @@ import static org.jboss.hal.dmr.ModelDescriptionConstants.OPERATIONS;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.REQUIRED;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.REQUIRES;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.STABILITY;
+import static org.jboss.hal.dmr.ModelDescriptionConstants.STORAGE;
+import static org.jboss.hal.dmr.ModelDescriptionConstants.STRING;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.TYPE;
+import static org.jboss.hal.dmr.ModelDescriptionConstants.VALUE_TYPE;
 
 /** Contains the resource and attribute descriptions from the read-resource-description operation. */
 /*
@@ -52,6 +58,8 @@ import static org.jboss.hal.dmr.ModelDescriptionConstants.TYPE;
  * description.requestProperties().required();
  */
 public class ResourceDescription extends ModelNode {
+
+    private Set<String> flattened = new TreeSet<>();
 
     public ResourceDescription(ModelNode payload) {
         set(payload);
@@ -69,6 +77,39 @@ public class ResourceDescription extends ModelNode {
     public List<Property> getAttributes(String path) {
         ModelNode attributes = ModelNodeHelper.failSafeGet(this, path);
         if (attributes.isDefined()) {
+            List<Property> list = attributes.asPropertyList();
+            if (flattened.contains(path)) {
+                return list;
+            }
+
+            flattened.add(path);
+            for (Property p : list) {
+                ModelNode parentValue = p.getValue();
+                if (parentValue.hasDefined(TYPE) && (parentValue.get(TYPE).asType().equals(ModelType.OBJECT) ||
+                        parentValue.get(TYPE).asType().equals(ModelType.LIST))
+                        && !parentValue.get(VALUE_TYPE).asString().equalsIgnoreCase(STRING)) {
+                    for (Property nested : parentValue.get(VALUE_TYPE).asPropertyList()) {
+                        ModelNode nestedValue = nested.getValue();
+                        // inherit from parent
+                        if (parentValue.hasDefined(DEPRECATED)) {
+                            nestedValue.get(DEPRECATED).set(parentValue.get(DEPRECATED));
+                        }
+                        if (parentValue.hasDefined(ATTRIBUTE_GROUP)) {
+                            nestedValue.get(ATTRIBUTE_GROUP).set(parentValue.get(ATTRIBUTE_GROUP));
+                        }
+                        nestedValue.get(STORAGE).set(parentValue.get(STORAGE));
+                        nestedValue.get(ACCESS_TYPE).set(parentValue.get(ACCESS_TYPE));
+                        // "required"/"nillable" has to depend on parent value
+                        boolean combined = parentValue.get(NILLABLE).asBoolean()
+                                || nestedValue.get(NILLABLE).asBoolean();
+                        nestedValue.get(NILLABLE).set(combined);
+                        combined = parentValue.get(REQUIRED).asBoolean()
+                                && nestedValue.get(REQUIRED).asBoolean();
+                        nestedValue.get(REQUIRED).set(combined);
+                        attributes.get(p.getName() + "." + nested.getName()).set(nestedValue);
+                    }
+                }
+            }
             return attributes.asPropertyList();
         }
         return emptyList();


### PR DESCRIPTION
Issue: [HAL-1985](https://issues.redhat.com/browse/HAL-1985)

The fix is to flatten the attribute description by default (and making that display correctly in the Model Browser), with the original complex attributes kept in. I don't think there's a reason not to do it, anything that uses ResourceDescription then doesn't have to deal with it on its own. It does require excluding the attributes in case there is a custom form for the complex attribute but I think that's only the case in the ResourcePanel.

There was a to-do for a refactor on the ResourceDescription so I'm including that in the second commit, if that's still relevant.