### PR TITLE
[HAL-1991] Fix AddUnmanagedDialog

### DIFF
--- a/meta/src/main/java/org/jboss/hal/meta/description/ResourceDescription.java
+++ b/meta/src/main/java/org/jboss/hal/meta/description/ResourceDescription.java
@@ -85,7 +85,9 @@ public class ResourceDescription extends ModelNode {
             if (!map.containsKey(path)) {
                 for (Property p : attributes.asPropertyList()) {
                     ModelNode parentValue = p.getValue();
-                    if (parentValue.hasDefined(TYPE) && parentValue.get(TYPE).asType().equals(ModelType.OBJECT)
+                    // process also on LIST type if we're in request attributes.
+                    boolean isRequestProperties = path.endsWith(REQUEST_PROPERTIES);
+                    if (parentValue.hasDefined(TYPE) && (parentValue.get(TYPE).asType().equals(ModelType.OBJECT) || (isRequestProperties && parentValue.get(TYPE).asType().equals(ModelType.LIST)))
                             && !parentValue.get(VALUE_TYPE).asString().equalsIgnoreCase(STRING)) {
                         for (Property nested : parentValue.get(VALUE_TYPE).asPropertyList()) {
                             ModelNode nestedValue = nested.getValue();


### PR DESCRIPTION
[HAL-1991] Fix AddUnmanagedDialog

Issue: https://issues.redhat.com/browse/HAL-1991

Fix AttributeCollection in `AddUnmanagedDialog`, it should be `attributes()` instead of `requestProperties()`.

Also fix `getAttributes` method in ResourceDescription.java.
The parentValue value type could be LIST for `content` 
Also it's incorrect to assume the `nestedValue` always inherit ACCESS_TYPE value from parent. For example, the `content`'s Access Type is [`read-only`](https://docs.wildfly.org/33/wildscribe/deployment/index.html#attr-content). `content.path` can't be read-only if you want user input in this dialog.

@michpetrov I think you know more about the recent change around this area for #1187, could you review this ? 