### PR TITLE
HAL-1990: remove unnecessary copying of complex attributes

### DIFF
--- a/app/src/main/java/org/jboss/hal/client/configuration/subsystem/elytron/OtherSettingsPresenter.java
+++ b/app/src/main/java/org/jboss/hal/client/configuration/subsystem/elytron/OtherSettingsPresenter.java
@@ -30,11 +30,11 @@ import org.jboss.hal.ballroom.form.Form;
 import org.jboss.hal.ballroom.form.Form.FinishRemove;
 import org.jboss.hal.ballroom.form.Form.FinishReset;
 import org.jboss.hal.ballroom.form.FormItem;
-import org.jboss.hal.ballroom.form.TextBoxItem;
 import org.jboss.hal.ballroom.form.ValidationResult;
 import org.jboss.hal.core.ComplexAttributeOperations;
 import org.jboss.hal.core.CrudOperations;
 import org.jboss.hal.core.configuration.PathsAutoComplete;
+import org.jboss.hal.core.elytron.CredentialReference;
 import org.jboss.hal.core.finder.Finder;
 import org.jboss.hal.core.finder.FinderPath;
 import org.jboss.hal.core.finder.FinderPathFactory;
@@ -67,7 +67,6 @@ import org.jboss.hal.spi.MessageEvent;
 import org.jboss.hal.spi.Requires;
 
 import com.google.gwt.safehtml.shared.SafeHtml;
-import com.google.gwt.safehtml.shared.SafeHtmlUtils;
 import com.google.web.bindery.event.shared.EventBus;
 import com.gwtplatform.mvp.client.annotations.NameToken;
 import com.gwtplatform.mvp.client.annotations.ProxyCodeSplit;
@@ -112,7 +111,6 @@ import static org.jboss.hal.client.configuration.subsystem.elytron.AddressTempla
 import static org.jboss.hal.client.configuration.subsystem.elytron.AddressTemplates.SYSLOG_AUDIT_LOG_ADDRESS;
 import static org.jboss.hal.client.configuration.subsystem.elytron.AddressTemplates.TRUST_MANAGER_ADDRESS;
 import static org.jboss.hal.client.configuration.subsystem.elytron.ElytronResource.SYSLOG_AUDIT_LOG;
-import static org.jboss.hal.dmr.ModelDescriptionConstants.ALIAS;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.CAPABILITY_REFERENCE;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.CHILD_TYPE;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.CLASS_NAME;
@@ -156,7 +154,6 @@ import static org.jboss.hal.dmr.ModelDescriptionConstants.VALUE;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.VALUE_TYPE;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.WRITE_ATTRIBUTE_OPERATION;
 import static org.jboss.hal.dmr.ModelNodeHelper.asNamedNodes;
-import static org.jboss.hal.dmr.ModelNodeHelper.move;
 import static org.jboss.hal.flow.Flow.sequential;
 
 public class OtherSettingsPresenter extends MbuiPresenter<OtherSettingsPresenter.MyView, OtherSettingsPresenter.MyProxy>
@@ -316,29 +313,25 @@ public class OtherSettingsPresenter extends MbuiPresenter<OtherSettingsPresenter
 
     void addCredentialStore() {
         Metadata metadata = metadataRegistry.lookup(CREDENTIAL_STORE_TEMPLATE);
-        SafeHtml typeHelp = SafeHtmlUtils.fromString(
-                metadata.getDescription().attributes().description(TYPE));
-        Metadata crMetadata = metadata.forComplexAttribute(CREDENTIAL_REFERENCE, true);
-        crMetadata.copyComplexAttributeAttributes(asList(STORE, ALIAS, TYPE, CLEAR_TEXT), metadata);
-        TextBoxItem typeItem = new TextBoxItem("type-", resources.constants().type());
 
         String id = Ids.build(Ids.ELYTRON_CREDENTIAL_STORE, Ids.ADD);
         NameItem nameItem = new NameItem();
         ModelNodeForm<ModelNode> form = new ModelNodeForm.Builder<>(id, metadata)
                 .addOnly()
                 .unboundFormItem(nameItem, 0)
-                .include(CREATE, PATH, RELATIVE_TO, STORE, ALIAS, TYPE, CLEAR_TEXT)
-                .unboundFormItem(typeItem, 3, typeHelp)
+                .include(CREATE, TYPE, PATH, RELATIVE_TO)
+                .include(CredentialReference.ATTRIBUTES_PREFIXED)
                 .unsorted()
                 .build();
         form.getFormItem(RELATIVE_TO).registerSuggestHandler(new PathsAutoComplete());
-        form.addFormValidation(new RequireAtLeastOneAttributeValidation<>(asList(STORE, CLEAR_TEXT), resources));
+        form.addFormValidation(new RequireAtLeastOneAttributeValidation<>(
+                asList(CREDENTIAL_REFERENCE + "." + STORE, CREDENTIAL_REFERENCE + "." + CLEAR_TEXT), resources));
         form.addFormValidation(form1 -> {
             ValidationResult result = ValidationResult.OK;
-            String typeValue = typeItem.getValue();
+            String typeValue = form1.<String> getFormItem(TYPE).getValue();
             FormItem<String> locationAttr = form1.getFormItem(PATH);
             boolean invalidLocation = locationAttr.isEmpty() &&
-                    (typeItem.isEmpty() || Collections.binarySearch(FILE_BASED_CS, typeValue) > -1);
+                    (form1.getFormItem(TYPE).isEmpty() || Collections.binarySearch(FILE_BASED_CS, typeValue) > -1);
             if (invalidLocation) {
                 form1.getFormItem(PATH).showError(resources.constants().requiredField());
                 result = ValidationResult.invalid(resources.messages().pathRequired());
@@ -347,15 +340,6 @@ public class OtherSettingsPresenter extends MbuiPresenter<OtherSettingsPresenter
         });
 
         new AddResourceDialog(resources.messages().addResourceTitle(Names.CREDENTIAL_STORE), form, (name, model) -> {
-            if (model != null) {
-                move(model, STORE, CREDENTIAL_REFERENCE + "/" + STORE);
-                move(model, ALIAS, CREDENTIAL_REFERENCE + "/" + ALIAS);
-                move(model, TYPE, CREDENTIAL_REFERENCE + "/" + TYPE);
-                move(model, CLEAR_TEXT, CREDENTIAL_REFERENCE + "/" + CLEAR_TEXT);
-            }
-            if (!typeItem.isEmpty()) {
-                model.get(TYPE).set(typeItem.getValue());
-            }
             ResourceAddress address = CREDENTIAL_STORE_TEMPLATE.resolve(statementContext, nameItem.getValue());
             crud.add(Names.CREDENTIAL_STORE, name, address, model,
                     (n, a) -> reload(CREDENTIAL_STORE, nodes -> getView().updateResourceElement(CREDENTIAL_STORE, nodes)));
@@ -425,39 +409,22 @@ public class OtherSettingsPresenter extends MbuiPresenter<OtherSettingsPresenter
 
     void addKeyStore() {
         Metadata metadata = metadataRegistry.lookup(KEY_STORE_TEMPLATE);
-        Metadata crMetadata = metadata.forComplexAttribute(CREDENTIAL_REFERENCE, true);
-        crMetadata.copyComplexAttributeAttributes(asList(STORE, ALIAS, CLEAR_TEXT), metadata);
 
         String id = Ids.build(Ids.ELYTRON_KEY_STORE, Ids.ADD);
         NameItem nameItem = new NameItem();
 
-        // there is a special handling for "type" attribute, as this attribute name exists in key-store and
-        // credential-reference complex attribute. We must create an unbound form item for credential-reference-type
-        String crType = "credential-reference-type";
-        String crTypeLabel = new LabelBuilder().label(crType);
-        TextBoxItem crTypeItem = new TextBoxItem(crType, crTypeLabel);
-        SafeHtml crTypeItemHelp = SafeHtmlUtils.fromString(metadata.getDescription()
-                .attributes().description(CREDENTIAL_REFERENCE + "." + TYPE));
-
         ModelNodeForm<ModelNode> form = new ModelNodeForm.Builder<>(id, metadata)
                 .addOnly()
                 .unboundFormItem(nameItem, 0)
-                .include(TYPE, PATH, RELATIVE_TO, STORE, ALIAS, CLEAR_TEXT)
-                .unboundFormItem(crTypeItem, 7, crTypeItemHelp)
+                .include(TYPE, PATH, RELATIVE_TO)
+                .include(CredentialReference.ATTRIBUTES_PREFIXED)
                 .unsorted()
                 .build();
         form.getFormItem(RELATIVE_TO).registerSuggestHandler(new PathsAutoComplete());
-        form.addFormValidation(new RequireAtLeastOneAttributeValidation<>(asList(STORE, CLEAR_TEXT), resources));
+        form.addFormValidation(new RequireAtLeastOneAttributeValidation<>(
+                asList(CREDENTIAL_REFERENCE + "." + STORE, CREDENTIAL_REFERENCE + "." + CLEAR_TEXT), resources));
 
         new AddResourceDialog(resources.messages().addResourceTitle(Names.KEY_STORE), form, (name, model) -> {
-            if (model != null) {
-                move(model, STORE, CREDENTIAL_REFERENCE + "/" + STORE);
-                move(model, ALIAS, CREDENTIAL_REFERENCE + "/" + ALIAS);
-                move(model, CLEAR_TEXT, CREDENTIAL_REFERENCE + "/" + CLEAR_TEXT);
-                if (!crTypeItem.isEmpty()) {
-                    model.get(CREDENTIAL_REFERENCE).get(TYPE).set(crTypeItem.getValue());
-                }
-            }
             ResourceAddress address = KEY_STORE_TEMPLATE.resolve(statementContext, nameItem.getValue());
             crud.add(Names.KEY_STORE, name, address, model,
                     (n, a) -> reload(KEY_STORE, nodes -> getView().updateResourceElement(KEY_STORE, nodes)));
@@ -468,26 +435,19 @@ public class OtherSettingsPresenter extends MbuiPresenter<OtherSettingsPresenter
 
     void addKeyManager() {
         Metadata metadata = metadataRegistry.lookup(KEY_MANAGER_TEMPLATE);
-        Metadata crMetadata = metadata.forComplexAttribute(CREDENTIAL_REFERENCE, true);
-        crMetadata.copyComplexAttributeAttributes(asList(STORE, ALIAS, TYPE, CLEAR_TEXT), metadata);
 
         String id = Ids.build(Ids.ELYTRON_KEY_MANAGER, Ids.ADD);
         NameItem nameItem = new NameItem();
         ModelNodeForm<ModelNode> form = new ModelNodeForm.Builder<>(id, metadata)
                 .addOnly()
                 .unboundFormItem(nameItem, 0)
-                .include(STORE, ALIAS, TYPE, CLEAR_TEXT)
+                .include(CredentialReference.ATTRIBUTES_PREFIXED)
                 .unsorted()
                 .build();
-        form.addFormValidation(new RequireAtLeastOneAttributeValidation<>(asList(STORE, CLEAR_TEXT), resources));
+        form.addFormValidation(new RequireAtLeastOneAttributeValidation<>(
+                asList(CREDENTIAL_REFERENCE + "." + STORE, CREDENTIAL_REFERENCE + "." + CLEAR_TEXT), resources));
 
         new AddResourceDialog(resources.messages().addResourceTitle(Names.KEY_MANAGER), form, (name, model) -> {
-            if (model != null) {
-                move(model, STORE, CREDENTIAL_REFERENCE + "/" + STORE);
-                move(model, ALIAS, CREDENTIAL_REFERENCE + "/" + ALIAS);
-                move(model, TYPE, CREDENTIAL_REFERENCE + "/" + TYPE);
-                move(model, CLEAR_TEXT, CREDENTIAL_REFERENCE + "/" + CLEAR_TEXT);
-            }
             ResourceAddress address = KEY_MANAGER_TEMPLATE.resolve(statementContext, nameItem.getValue());
             crud.add(Names.KEY_MANAGER, name, address, model,
                     (n, a) -> reload(KEY_MANAGER, nodes -> getView().updateResourceElement(KEY_MANAGER, nodes)));
@@ -642,6 +602,7 @@ public class OtherSettingsPresenter extends MbuiPresenter<OtherSettingsPresenter
 
     void addJaspiConfiguration() {
         Metadata metadata = metadataRegistry.lookup(AddressTemplates.JASPI_CONFIGURATION_TEMPLATE);
+        // server-auth-modules is a LIST, needs to be copied
         Metadata metaServerAuth = metadata.forComplexAttribute(SERVER_AUTH_MODULES, true);
         metaServerAuth.copyComplexAttributeAttributes(asList(CLASS_NAME, MODULE, FLAG), metadata);
         String id = Ids.build(Ids.ELYTRON_JASPI, Ids.ADD);

--- a/app/src/main/java/org/jboss/hal/client/configuration/subsystem/elytron/RealmsPresenter.java
+++ b/app/src/main/java/org/jboss/hal/client/configuration/subsystem/elytron/RealmsPresenter.java
@@ -101,7 +101,6 @@ import static org.jboss.hal.dmr.ModelDescriptionConstants.USE_RECURSIVE_SEARCH;
 import static org.jboss.hal.dmr.ModelNodeHelper.asNamedNodes;
 import static org.jboss.hal.dmr.ModelNodeHelper.failSafeBoolean;
 import static org.jboss.hal.dmr.ModelNodeHelper.failSafeGet;
-import static org.jboss.hal.dmr.ModelNodeHelper.move;
 
 public class RealmsPresenter extends MbuiPresenter<RealmsPresenter.MyView, RealmsPresenter.MyProxy>
         implements SupportsExpertMode {
@@ -383,8 +382,8 @@ public class RealmsPresenter extends MbuiPresenter<RealmsPresenter.MyView, Realm
         Form<ModelNode> form = new ModelNodeForm.Builder<>(id, metadata)
                 .addOnly()
                 .unboundFormItem(nameItem, 0)
-                .include(DIR_CONTEXT, DIRECT_VERIFICATION, ALLOW_BLANK_PASSWORD, IDENTITY_MAPPING + "." + SEARCH_BASE_DN,
-                        IDENTITY_MAPPING + "." + USE_RECURSIVE_SEARCH)
+                .include(DIR_CONTEXT, DIRECT_VERIFICATION, ALLOW_BLANK_PASSWORD, IDENTITY_MAPPING + DOT + SEARCH_BASE_DN,
+                        IDENTITY_MAPPING + DOT + USE_RECURSIVE_SEARCH)
                 .build();
 
         new AddResourceDialog(resources.messages().addResourceTitle(Names.LDAP_REALM), form,
@@ -517,23 +516,17 @@ public class RealmsPresenter extends MbuiPresenter<RealmsPresenter.MyView, Realm
 
     void addPropertiesRealm() {
         Metadata metadata = metadataRegistry.lookup(PROPERTIES_REALM_TEMPLATE);
-        Metadata upMetadata = metadata.forComplexAttribute(USERS_PROPERTIES, true);
-        upMetadata.copyComplexAttributeAttributes(asList(PATH, RELATIVE_TO), metadata);
 
         String id = Ids.build(Ids.ELYTRON_PROPERTIES_REALM, Ids.ADD);
         NameItem nameItem = new NameItem();
         Form<ModelNode> form = new ModelNodeForm.Builder<>(id, metadata)
                 .addOnly()
                 .unboundFormItem(nameItem, 0)
-                .include(PATH, RELATIVE_TO, GROUPS_ATTRIBUTE)
+                .include(USERS_PROPERTIES + DOT + PATH, USERS_PROPERTIES + DOT + RELATIVE_TO, GROUPS_ATTRIBUTE)
                 .build();
-        form.getFormItem(RELATIVE_TO).registerSuggestHandler(new PathsAutoComplete());
+        form.getFormItem(USERS_PROPERTIES + DOT + RELATIVE_TO).registerSuggestHandler(new PathsAutoComplete());
 
         new AddResourceDialog(resources.messages().addResourceTitle(Names.PROPERTIES_REALM), form, (name, model) -> {
-            if (model != null) {
-                move(model, PATH, USERS_PROPERTIES + "/" + PATH);
-                move(model, RELATIVE_TO, USERS_PROPERTIES + "/" + RELATIVE_TO);
-            }
             ResourceAddress address = PROPERTIES_REALM_TEMPLATE.resolve(statementContext, nameItem.getValue());
             crud.add(Names.PROPERTIES_REALM, name, address, model,
                     (n, a) -> reload(PROPERTIES_REALM, nodes -> getView().updateResourceElement(PROPERTIES_REALM, nodes)));

--- a/app/src/main/java/org/jboss/hal/client/configuration/subsystem/undertow/ApplicationSecurityDomainView.java
+++ b/app/src/main/java/org/jboss/hal/client/configuration/subsystem/undertow/ApplicationSecurityDomainView.java
@@ -66,6 +66,7 @@ public class ApplicationSecurityDomainView extends HalViewImpl implements Applic
                 .singleton(() -> presenter.checkSingleSignOn(),
                         () -> presenter.addSingleSignOn())
                 .onSave((f, changedValues) -> presenter.saveSingleSignOn(changedValues))
+                .exclude(CREDENTIAL_REFERENCE + ".*")
                 .prepareReset(f -> presenter.resetSingleSignOn(f))
                 .prepareRemove(f -> presenter.removeSingleSignOn(f))
                 .build();

--- a/core/src/main/java/org/jboss/hal/core/elytron/CredentialReference.java
+++ b/core/src/main/java/org/jboss/hal/core/elytron/CredentialReference.java
@@ -62,6 +62,20 @@ public class CredentialReference {
     private final ComplexAttributeOperations ca;
     private final Resources resources;
 
+    public static final String[] ATTRIBUTES = new String[] {
+            STORE,
+            ALIAS,
+            TYPE,
+            CLEAR_TEXT
+    };
+
+    public static final String[] ATTRIBUTES_PREFIXED = new String[] {
+            CREDENTIAL_REFERENCE + "." + STORE,
+            CREDENTIAL_REFERENCE + "." + ALIAS,
+            CREDENTIAL_REFERENCE + "." + TYPE,
+            CREDENTIAL_REFERENCE + "." + CLEAR_TEXT
+    };
+
     @Inject
     public CredentialReference(EventBus eventBus, Dispatcher dispatcher, ComplexAttributeOperations ca,
             Resources resources) {


### PR DESCRIPTION
One usage of the `copyComplexAttributeAttributes` remains for a list type attribute but I think it might be removed if we made the form use request properties, I haven't tried changing it so I don't break something else.

I will try to improve the credential reference handling, e.g. the validator used in the Elytron presenters doesn't look like it works the same way as the `CredentialReference.CrFormValuesValidation` and requires/alternatives validation doesn't work out of the box on the flattened attributes either, but that's out of the scope for this issue.