### PR TITLE
[JBEAP-26190] Domain mode has server-group missing Resume operation in Web Console

### DIFF
--- a/app/src/main/java/org/jboss/hal/client/runtime/group/ServerGroupColumn.java
+++ b/app/src/main/java/org/jboss/hal/client/runtime/group/ServerGroupColumn.java
@@ -162,23 +162,16 @@ public class ServerGroupColumn extends FinderColumn<ServerGroup>
                             .handler(serverGroupActions::restart)
                             .constraints(constraints(item, RESTART_SERVERS))
                             .build());
-                }
-                if (item.getServers(Server::isStarted).size() - item.getServers(Server::isSuspended)
-                        .size() > 0) {
                     actions.add(new ItemAction.Builder<ServerGroup>()
                             .title(resources.constants().suspend())
                             .handler(serverGroupActions::suspend)
                             .constraints(constraints(item, SUSPEND_SERVERS))
                             .build());
-                }
-                if (item.hasServers(Server::isSuspended)) {
                     actions.add(new ItemAction.Builder<ServerGroup>()
                             .title(resources.constants().resume())
                             .handler(serverGroupActions::resume)
                             .constraints(constraints(item, RESUME_SERVERS))
                             .build());
-                }
-                if (item.hasServers(Server::isStarted)) {
                     actions.add(new ItemAction.Builder<ServerGroup>()
                             .title(resources.constants().stop())
                             .handler(serverGroupActions::stop)

--- a/core/src/main/java/org/jboss/hal/core/runtime/group/ServerGroupActions.java
+++ b/core/src/main/java/org/jboss/hal/core/runtime/group/ServerGroupActions.java
@@ -237,7 +237,9 @@ public class ServerGroupActions {
     }
 
     public void resume(ServerGroup serverGroup) {
-        List<Server> suspendedServers = serverGroup.getServers(Server::isSuspended);
+        // Suspended state is not available (only data from server-config is),
+        // So let's use the started state from server-config, which is good enough here.
+        List<Server> suspendedServers = serverGroup.getServers(Server::isStarted);
         if (!suspendedServers.isEmpty()) {
             prepare(serverGroup, suspendedServers, RESUME);
             Operation operation = new Operation.Builder(serverGroup.getAddress(), RESUME_SERVERS).build();


### PR DESCRIPTION
Upstream Issue: https://issues.redhat.com/browse/HAL-1955
Upstream PR: https://github.com/hal/console/pull/1363
Issue: https://issues.redhat.com/browse/JBEAP-26190

> The problem was that the `isSuspended()` method was not working correctly for the server groups due to missing runtime data.
> 
> The server group column uses: `/host=primary/server-config=...`  (missing runtime data, except for `server-status-config` => `isStopped()` works)
> The server column uses: `/host=primary/server=...` (contains runtime data)
> 
> The fix was to allow all the actions to be present (depending on the `isStarted()`) within the server group column.