### PR TITLE
HAL-2022: sync DMR classes with JBoss

### DIFF
--- a/dmr/src/main/java/org/jboss/hal/dmr/BigIntegerModelValue.java
+++ b/dmr/src/main/java/org/jboss/hal/dmr/BigIntegerModelValue.java
@@ -30,9 +30,18 @@ class BigIntegerModelValue extends ModelValue {
         this.value = value;
     }
 
+    BigIntegerModelValue(DataInput in) {
+        super(ModelType.BIG_INTEGER);
+        byte[] b = new byte[in.readInt()];
+        in.readFully(b);
+        this.value = new BigInteger(b);
+    }
+
     @Override
     void writeExternal(DataOutput out) {
-        out.write(value.toByteArray());
+        byte[] b = value.toByteArray();
+        out.writeInt(b.length);
+        out.write(b);
     }
 
     @Override

--- a/dmr/src/main/java/org/jboss/hal/dmr/BytesModelValue.java
+++ b/dmr/src/main/java/org/jboss/hal/dmr/BytesModelValue.java
@@ -34,6 +34,13 @@ class BytesModelValue extends ModelValue {
         this.bytes = bytes;
     }
 
+    BytesModelValue(DataInput in) {
+        super(ModelType.BYTES);
+        byte[] b = new byte[in.readInt()];
+        in.readFully(b);
+        this.bytes = b;
+    }
+
     @Override
     void writeExternal(DataOutput out) {
         out.writeInt(bytes.length);

--- a/dmr/src/main/java/org/jboss/hal/dmr/ModelNode.java
+++ b/dmr/src/main/java/org/jboss/hal/dmr/ModelNode.java
@@ -1386,7 +1386,6 @@ public class ModelNode implements Cloneable {
      */
     void readExternal(DataInput in) {
         checkProtect();
-        byte[] b; // used by some of these
         try {
             ModelType type = ModelType.forChar((char) (in.readByte() & 0xff));
             switch (type) {
@@ -1397,17 +1396,13 @@ public class ModelNode implements Cloneable {
                     value = new BigDecimalModelValue(in);
                     return;
                 case BIG_INTEGER:
-                    b = new byte[in.readInt()];
-                    in.readFully(b);
-                    value = new BigIntegerModelValue(new BigInteger(b));
+                    value = new BigIntegerModelValue(in);
                     return;
                 case BOOLEAN:
                     value = BooleanModelValue.valueOf(in.readBoolean());
                     return;
                 case BYTES:
-                    b = new byte[in.readInt()];
-                    in.readFully(b);
-                    value = new BytesModelValue(b);
+                    value = new BytesModelValue(in);
                     return;
                 case DOUBLE:
                     value = new DoubleModelValue(in.readDouble());

--- a/dmr/src/main/java/org/jboss/hal/dmr/TypeModelValue.java
+++ b/dmr/src/main/java/org/jboss/hal/dmr/TypeModelValue.java
@@ -22,40 +22,49 @@ class TypeModelValue extends ModelValue {
 
     /** JSON Key used to identify TypeModelValue. */
     private static final String TYPE_KEY = "TYPE_MODEL_VALUE";
+    private static final TypeModelValue BIG_DECIMAL = new TypeModelValue(ModelType.BIG_DECIMAL);
+    private static final TypeModelValue BIG_INTEGER = new TypeModelValue(ModelType.BIG_INTEGER);
     private static final TypeModelValue BOOLEAN = new TypeModelValue(ModelType.BOOLEAN);
     private static final TypeModelValue BYTES = new TypeModelValue(ModelType.BYTES);
-    private static final TypeModelValue DECIMAL = new TypeModelValue(ModelType.BIG_DECIMAL);
     private static final TypeModelValue DOUBLE = new TypeModelValue(ModelType.DOUBLE);
+    private static final TypeModelValue EXPRESSION = new TypeModelValue(ModelType.EXPRESSION);
     private static final TypeModelValue INT = new TypeModelValue(ModelType.INT);
     private static final TypeModelValue LONG = new TypeModelValue(ModelType.LONG);
     private static final TypeModelValue LIST = new TypeModelValue(ModelType.LIST);
     private static final TypeModelValue OBJECT = new TypeModelValue(ModelType.OBJECT);
+    private static final TypeModelValue PROPERTY = new TypeModelValue(ModelType.PROPERTY);
     private static final TypeModelValue STRING = new TypeModelValue(ModelType.STRING);
     private static final TypeModelValue TYPE = new TypeModelValue(ModelType.TYPE);
     private static final TypeModelValue UNDEFINED = new TypeModelValue(ModelType.UNDEFINED);
 
-    static TypeModelValue of(ModelType type) {
+    static TypeModelValue of(final ModelType type) {
         switch (type) {
-            case LONG:
-                return LONG;
-            case INT:
-                return INT;
+            case BIG_DECIMAL:
+                return BIG_DECIMAL;
+            case BIG_INTEGER:
+                return BIG_INTEGER;
             case BOOLEAN:
                 return BOOLEAN;
-            case STRING:
-                return STRING;
-            case DOUBLE:
-                return DOUBLE;
-            case BIG_DECIMAL:
-                return DECIMAL;
             case BYTES:
                 return BYTES;
+            case DOUBLE:
+                return DOUBLE;
+            case EXPRESSION:
+                return EXPRESSION;
+            case INT:
+                return INT;
             case LIST:
                 return LIST;
-            case TYPE:
-                return TYPE;
+            case LONG:
+                return LONG;
             case OBJECT:
                 return OBJECT;
+            case PROPERTY:
+                return PROPERTY;
+            case STRING:
+                return STRING;
+            case TYPE:
+                return TYPE;
             default:
                 return UNDEFINED;
         }


### PR DESCRIPTION
Issue: [HAL-2022](https://issues.redhat.com/browse/HAL-2022)

For some reason there are discrepancies between the DMR classes in HAL and in jboss-dmr. The major issue was the BIG_INTEGER not writing out the length before the array.