### PR TITLE
[HAL-2025] Webconsole page for EJB3 remoting profile contains duplicate ID

### DIFF
--- a/app/src/main/java/org/jboss/hal/client/configuration/subsystem/ejb/EjbView.java
+++ b/app/src/main/java/org/jboss/hal/client/configuration/subsystem/ejb/EjbView.java
@@ -265,7 +265,7 @@ public abstract class EjbView extends MbuiViewImpl<EjbPresenter> implements EjbP
                 .columns(TYPE, VALUE)
                 .build();
 
-        channelCreationOptionsForm = new ModelNodeForm.Builder<NamedNode>(Ids.build(rpId, Ids.FORM),
+        channelCreationOptionsForm = new ModelNodeForm.Builder<NamedNode>(Ids.build(ccoId, Ids.FORM),
                 channelCreationOptionsMetadata)
                 .onSave((form, changedValues) -> {
                     String name = form.getModel().getName();


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/HAL-2025
I believe the problem was due to the unnoticed use of the wrong variable when copying the code.

Before:
<img width="1510" height="542" alt="image" src="https://github.com/user-attachments/assets/d5e34f83-36fe-4704-a66d-9c4d73639b9b" />
After the fix:
<img width="1652" height="534" alt="image" src="https://github.com/user-attachments/assets/7bf285d4-ba50-42f0-9ff0-b29788f83a86" />
